### PR TITLE
fix: Checks API soft-fail with Commit Status CI fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,20 @@ npm run preview
 
 ## Environment variables / Secrets
 
-public repository の read-only API は認証なしでも取得できますが、GitHub API rate limit を避けるため Worker 側に token を設定できます。
+private repository の観測には、Worker 側の `GITHUB_TOKEN`（fine-grained PAT）が必要です。
 
 ブラウザへ token は渡しません。
+
+対象 repository 向けの最小権限は次です。
+
+```text
+Contents          Read-only
+Pull requests     Read-only
+Commit statuses   Read-only
+Metadata          Read-only（GitHub 側の基本権限）
+```
+
+Checks 権限は必須ではありません。Check Runs API が取得できない場合、adapter は Commit Status だけで CI を判定し、確定不能なら `CI = UNKNOWN` とします。repository 全体を `ERROR` にはしません。
 
 ローカル開発では `.dev.vars` を使用できます。
 

--- a/src/worker/github/readOnlyAdapter.ts
+++ b/src/worker/github/readOnlyAdapter.ts
@@ -98,8 +98,13 @@ async function observePull(
     };
   }
 
+  // Checks API may be unavailable for fine-grained PATs (no Checks permission UI).
+  // Soft-fail check-runs so observation can continue with Commit Status only.
   const [checks, status, reviews] = await Promise.all([
-    githubGet<CheckRunsResponse>(`/repos/${repository}/commits/${sha}/check-runs?per_page=100`, env),
+    githubGetOptional<CheckRunsResponse>(
+      `/repos/${repository}/commits/${sha}/check-runs?per_page=100`,
+      env,
+    ),
     githubGet<StatusResponse>(`/repos/${repository}/commits/${sha}/status`, env),
     githubGet<ReviewResponse[]>(`/repos/${repository}/pulls/${summary.number}/reviews?per_page=100`, env),
   ]);
@@ -116,13 +121,21 @@ async function observePull(
   };
 }
 
-function normalizeCi(checks: CheckRunsResponse, status: StatusResponse): CiState {
-  const runs = checks.check_runs ?? [];
-  if (runs.some((run) => run.status !== "completed")) return "PENDING";
-  if (runs.some((run) => run.conclusion && !["success", "neutral", "skipped"].includes(run.conclusion))) {
-    return "FAIL";
+/**
+ * Prefer Check Runs when available.
+ * If Checks API is unavailable or returns no runs, fall back to Commit Status.
+ * If neither can determine CI, return UNKNOWN (do not escalate repository evidenceState).
+ */
+export function normalizeCi(checks: CheckRunsResponse | null, status: StatusResponse): CiState {
+  const runs = checks?.check_runs ?? [];
+  if (runs.length > 0) {
+    if (runs.some((run) => run.status !== "completed")) return "PENDING";
+    if (runs.some((run) => run.conclusion && !["success", "neutral", "skipped"].includes(run.conclusion))) {
+      return "FAIL";
+    }
+    return "PASS";
   }
-  if (runs.length > 0) return "PASS";
+
   if (status.state === "pending") return "PENDING";
   if (status.state === "failure" || status.state === "error") return "FAIL";
   if (status.state === "success") return "PASS";
@@ -159,16 +172,26 @@ function parseHumanDecision(body: string | null | undefined): boolean | null {
 }
 
 async function githubGet<T>(path: string, env: GitHubEnv): Promise<T> {
+  const response = await githubFetch(path, env);
+  if (!response.ok) throw new Error("GitHub API request failed");
+  return (await response.json()) as T;
+}
+
+/** Soft-fail GET for optional endpoints (e.g. check-runs without Checks permission). */
+async function githubGetOptional<T>(path: string, env: GitHubEnv): Promise<T | null> {
+  const response = await githubFetch(path, env);
+  if (!response.ok) return null;
+  return (await response.json()) as T;
+}
+
+async function githubFetch(path: string, env: GitHubEnv): Promise<Response> {
   const headers = new Headers({
     Accept: "application/vnd.github+json",
     "User-Agent": "ai-development-control-center",
     "X-GitHub-Api-Version": "2022-11-28",
   });
   if (env.GITHUB_TOKEN) headers.set("Authorization", `Bearer ${env.GITHUB_TOKEN}`);
-
-  const response = await fetch(`${API}${path}`, { method: "GET", headers });
-  if (!response.ok) throw new Error("GitHub API request failed");
-  return (await response.json()) as T;
+  return fetch(`${API}${path}`, { method: "GET", headers });
 }
 
 function missing(repository: string, sourceRefs: string[], message: string): ObservedFacts {

--- a/test/normalizeCi.test.ts
+++ b/test/normalizeCi.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCi } from "../src/worker/github/readOnlyAdapter";
+
+describe("normalizeCi", () => {
+  it("uses check runs when Checks API succeeds", () => {
+    expect(
+      normalizeCi(
+        {
+          check_runs: [
+            { status: "completed", conclusion: "success" },
+            { status: "completed", conclusion: "skipped" },
+          ],
+        },
+        { state: "failure" },
+      ),
+    ).toBe("PASS");
+  });
+
+  it("returns PENDING when any check run is incomplete", () => {
+    expect(
+      normalizeCi(
+        { check_runs: [{ status: "in_progress", conclusion: null }] },
+        { state: "success" },
+      ),
+    ).toBe("PENDING");
+  });
+
+  it("returns FAIL when a check run conclusion is failure", () => {
+    expect(
+      normalizeCi(
+        { check_runs: [{ status: "completed", conclusion: "failure" }] },
+        { state: "success" },
+      ),
+    ).toBe("FAIL");
+  });
+
+  it("falls back to commit status when Checks API is unavailable", () => {
+    expect(normalizeCi(null, { state: "success" })).toBe("PASS");
+    expect(normalizeCi(null, { state: "pending" })).toBe("PENDING");
+    expect(normalizeCi(null, { state: "failure" })).toBe("FAIL");
+    expect(normalizeCi(null, { state: "error" })).toBe("FAIL");
+  });
+
+  it("falls back to commit status when check runs are empty", () => {
+    expect(normalizeCi({ total_count: 0, check_runs: [] }, { state: "success" })).toBe("PASS");
+  });
+
+  it("returns UNKNOWN when neither checks nor commit status can determine CI", () => {
+    expect(normalizeCi(null, {})).toBe("UNKNOWN");
+    expect(normalizeCi(null, { state: "unknown" })).toBe("UNKNOWN");
+    expect(normalizeCi({ check_runs: [] }, { state: undefined })).toBe("UNKNOWN");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

fine-grained PAT で Checks 権限 UI が使えない問題に対応するため、GitHub adapter を修正しました。

## Behavior

```text
Checks API 成功 → Check Runs で CI 判定
Checks API 取得不能 / 空 → Commit Status で判定
どちらでも確定不能 → CI = UNKNOWN
repository 全体は ERROR にしない
```

fail-closed は維持します。推測で CI を補完しません。

## PAT scopes (after this change)

```text
Contents          Read-only
Pull requests     Read-only
Commit statuses   Read-only
Metadata          Read-only
```

Checks / Issues / classic `repo` は不要です。

## Verification

- `npm run verify` PASS
- 14 tests passed（既存 8 + `normalizeCi` 6）

## Out of scope

- PAT 作成 / `wrangler secret put` は未実行
- Cloudflare 再 deploy は未実行（明示 GO 待ち）
- `severe-behavior-support-spfx` mutation = 0

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fef39-200d-74f0-a177-bc0b8409076a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fef39-200d-74f0-a177-bc0b8409076a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

