### PR TITLE
fix: FALSE_WAIT — empty commit status is UNKNOWN, prefer UNKNOWN over WAIT

### DIFF
--- a/src/domain/humanActionResolver.ts
+++ b/src/domain/humanActionResolver.ts
@@ -38,6 +38,12 @@ export function resolveHumanAction(facts: ObservedFacts): HumanAction {
     };
   }
 
+  // Prefer UNKNOWN over WAIT: insufficient evidence must not be reported as waiting.
+  const unresolved = facts.openPullRequests.find(hasUnknownEvidence);
+  if (unresolved) {
+    return unknown(`PR #${unresolved.number} の判定規則に必要な情報を確定できません。`, unresolved.sourceRefs);
+  }
+
   const pending = facts.openPullRequests.find((pr) => pr.ci === "PENDING" || pr.review === "PENDING");
   if (pending) {
     return {
@@ -47,11 +53,6 @@ export function resolveHumanAction(facts: ObservedFacts): HumanAction {
       reason: "Human判断の前提となる確認が完了していません。",
       sourceRefs: pending.sourceRefs,
     };
-  }
-
-  const unresolved = facts.openPullRequests.find(hasUnknownEvidence);
-  if (unresolved) {
-    return unknown(`PR #${unresolved.number} の判定規則に必要な情報を確定できません。`, unresolved.sourceRefs);
   }
 
   const actionable = facts.openPullRequests.find(

--- a/src/worker/github/readOnlyAdapter.ts
+++ b/src/worker/github/readOnlyAdapter.ts
@@ -123,8 +123,9 @@ async function observePull(
 
 /**
  * Prefer Check Runs when available.
- * If Checks API is unavailable or returns no runs, fall back to Commit Status.
- * If neither can determine CI, return UNKNOWN (do not escalate repository evidenceState).
+ * If Checks API is unavailable or returns no runs, fall back to Commit Status
+ * only when total_count > 0. GitHub returns state=pending even with zero statuses,
+ * so empty combined status must be UNKNOWN (fail-closed), not PENDING.
  */
 export function normalizeCi(checks: CheckRunsResponse | null, status: StatusResponse): CiState {
   const runs = checks?.check_runs ?? [];
@@ -134,6 +135,10 @@ export function normalizeCi(checks: CheckRunsResponse | null, status: StatusResp
       return "FAIL";
     }
     return "PASS";
+  }
+
+  if (typeof status.total_count !== "number" || status.total_count <= 0) {
+    return "UNKNOWN";
   }
 
   if (status.state === "pending") return "PENDING";

--- a/test/humanActionResolver.test.ts
+++ b/test/humanActionResolver.test.ts
@@ -36,9 +36,47 @@ describe("resolveHumanAction", () => {
     expect(result.status).toBe("ACTION_REQUIRED");
   });
 
-  it("returns WAIT while CI is pending", () => {
-    const result = resolveHumanAction(facts({ openPullRequests: [pr({ ci: "PENDING", humanDecisionRequired: true })] }));
+  it("returns WAIT while CI is pending when all other PR evidence is known", () => {
+    const result = resolveHumanAction(
+      facts({
+        openPullRequests: [
+          pr({
+            ci: "PENDING",
+            review: "PASS",
+            mergeState: "CLEAN",
+            humanDecisionRequired: true,
+          }),
+        ],
+      }),
+    );
     expect(result.status).toBe("WAIT");
+  });
+
+  it("prefers UNKNOWN over WAIT when another PR has insufficient evidence", () => {
+    const result = resolveHumanAction(
+      facts({
+        openPullRequests: [
+          pr({
+            number: 1,
+            ci: "PENDING",
+            review: "PASS",
+            mergeState: "CLEAN",
+            humanDecisionRequired: true,
+            sourceRefs: ["github:pr:1"],
+          }),
+          pr({
+            number: 2,
+            ci: "UNKNOWN",
+            review: "PASS",
+            mergeState: "CLEAN",
+            humanDecisionRequired: false,
+            sourceRefs: ["github:pr:2"],
+          }),
+        ],
+      }),
+    );
+    expect(result.status).toBe("UNKNOWN");
+    expect(result.sourceRefs).toEqual(["github:pr:2"]);
   });
 
   it("returns NO_ACTION when no human action exists", () => {

--- a/test/normalizeCi.test.ts
+++ b/test/normalizeCi.test.ts
@@ -11,7 +11,7 @@ describe("normalizeCi", () => {
             { status: "completed", conclusion: "skipped" },
           ],
         },
-        { state: "failure" },
+        { state: "failure", total_count: 1 },
       ),
     ).toBe("PASS");
   });
@@ -20,7 +20,7 @@ describe("normalizeCi", () => {
     expect(
       normalizeCi(
         { check_runs: [{ status: "in_progress", conclusion: null }] },
-        { state: "success" },
+        { state: "success", total_count: 1 },
       ),
     ).toBe("PENDING");
   });
@@ -29,25 +29,35 @@ describe("normalizeCi", () => {
     expect(
       normalizeCi(
         { check_runs: [{ status: "completed", conclusion: "failure" }] },
-        { state: "success" },
+        { state: "success", total_count: 1 },
       ),
     ).toBe("FAIL");
   });
 
-  it("falls back to commit status when Checks API is unavailable", () => {
-    expect(normalizeCi(null, { state: "success" })).toBe("PASS");
-    expect(normalizeCi(null, { state: "pending" })).toBe("PENDING");
-    expect(normalizeCi(null, { state: "failure" })).toBe("FAIL");
-    expect(normalizeCi(null, { state: "error" })).toBe("FAIL");
+  it("uses commit status only when total_count > 0", () => {
+    expect(normalizeCi(null, { state: "success", total_count: 1 })).toBe("PASS");
+    expect(normalizeCi(null, { state: "pending", total_count: 1 })).toBe("PENDING");
+    expect(normalizeCi(null, { state: "failure", total_count: 1 })).toBe("FAIL");
+    expect(normalizeCi(null, { state: "error", total_count: 1 })).toBe("FAIL");
   });
 
-  it("falls back to commit status when check runs are empty", () => {
-    expect(normalizeCi({ total_count: 0, check_runs: [] }, { state: "success" })).toBe("PASS");
+  it("returns UNKNOWN when checks unavailable and commit status total_count is 0", () => {
+    expect(normalizeCi(null, { state: "pending", total_count: 0 })).toBe("UNKNOWN");
   });
 
-  it("returns UNKNOWN when neither checks nor commit status can determine CI", () => {
-    expect(normalizeCi(null, {})).toBe("UNKNOWN");
-    expect(normalizeCi(null, { state: "unknown" })).toBe("UNKNOWN");
+  it("returns UNKNOWN when checks empty and commit status total_count is 0", () => {
+    expect(normalizeCi({ total_count: 0, check_runs: [] }, { state: "pending", total_count: 0 })).toBe(
+      "UNKNOWN",
+    );
+  });
+
+  it("returns PENDING when checks unavailable and one commit status is pending", () => {
+    expect(normalizeCi(null, { state: "pending", total_count: 1 })).toBe("PENDING");
+  });
+
+  it("returns UNKNOWN when total_count cannot be confirmed", () => {
+    expect(normalizeCi(null, { state: "pending" })).toBe("UNKNOWN");
+    expect(normalizeCi(null, { state: "success" })).toBe("UNKNOWN");
     expect(normalizeCi({ check_runs: [] }, { state: undefined })).toBe("UNKNOWN");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**FALSE_WAIT fail-closed fix.** Empty Combined Commit Status (`state=pending`, `total_count=0`) must not become `CI=PENDING` / `HumanAction=WAIT`.

## Changes

1. **`normalizeCi`**
   - Check Runs あり → 従来どおり
   - Check Runs なし + `total_count > 0` → commit status `state` を使用
   - `total_count = 0` または確認不能 → `CI = UNKNOWN`

2. **`resolveHumanAction`**
   - PR 内 UNKNOWN evidence を PENDING/`WAIT` より先に評価

## Tests

`npm run verify` PASS（17 tests）

- checks unavailable + status pending + total_count=0 → UNKNOWN
- checks empty + status pending + total_count=0 → UNKNOWN
- checks unavailable + status pending + total_count=1 → PENDING
- PR A=PENDING + PR B=UNKNOWN → UNKNOWN
- PR A=PENDING（他証拠確定）→ WAIT

## Expected after deploy

`/api/status` が `WAIT` → `UNKNOWN` に変わる場合、今回の情報条件では **正しい安全側判定** です。

## Out of scope

- production deploy は未実行（明示 GO 待ち）
- `severe-behavior-support-spfx` mutation = 0

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fef39-200d-74f0-a177-bc0b8409076a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fef39-200d-74f0-a177-bc0b8409076a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

