### PR TITLE
feat(mvp2): add fail-closed PR evidence trace

### DIFF
--- a/src/domain/humanActionResolver.ts
+++ b/src/domain/humanActionResolver.ts
@@ -38,7 +38,8 @@ export function resolveHumanAction(facts: ObservedFacts): HumanAction {
     };
   }
 
-  // Prefer UNKNOWN over WAIT: insufficient evidence must not be reported as waiting.
+  // Prefer UNKNOWN over WAIT: insufficient or inconsistent evidence must not be
+  // reported as waiting or actionable.
   const unresolved = facts.openPullRequests.find(hasUnknownEvidence);
   if (unresolved) {
     return unknown(`PR #${unresolved.number} の判定規則に必要な情報を確定できません。`, unresolved.sourceRefs);
@@ -56,7 +57,11 @@ export function resolveHumanAction(facts: ObservedFacts): HumanAction {
   }
 
   const actionable = facts.openPullRequests.find(
-    (pr) => pr.humanDecisionRequired === true && pr.ci === "PASS" && pr.review === "PASS",
+    (pr) =>
+      pr.humanDecisionEvidence.state === "REQUIRED" &&
+      pr.humanDecisionRequired === true &&
+      pr.ci === "PASS" &&
+      pr.review === "PASS",
   );
 
   if (actionable) {
@@ -69,7 +74,11 @@ export function resolveHumanAction(facts: ObservedFacts): HumanAction {
     };
   }
 
-  if (facts.openPullRequests.every((pr) => pr.humanDecisionRequired === false)) {
+  if (
+    facts.openPullRequests.every(
+      (pr) => pr.humanDecisionEvidence.state === "NONE" && pr.humanDecisionRequired === false,
+    )
+  ) {
     return {
       status: "NO_ACTION",
       title: "ありません",
@@ -83,10 +92,17 @@ export function resolveHumanAction(facts: ObservedFacts): HumanAction {
 }
 
 function hasUnknownEvidence(pr: ObservedPullRequest): boolean {
+  const decisionState = pr.humanDecisionEvidence.state;
+  const decisionProjectionMismatch =
+    (decisionState === "REQUIRED" && pr.humanDecisionRequired !== true) ||
+    (decisionState === "NONE" && pr.humanDecisionRequired !== false);
+
   return (
     pr.ci === "UNKNOWN" ||
     pr.review === "UNKNOWN" ||
     pr.mergeState === "UNKNOWN" ||
-    pr.humanDecisionRequired === null
+    decisionState === "UNRESOLVED" ||
+    decisionState === "CONTRADICTORY" ||
+    decisionProjectionMismatch
   );
 }

--- a/src/domain/humanDecisionEvidence.ts
+++ b/src/domain/humanDecisionEvidence.ts
@@ -1,0 +1,61 @@
+export type HumanDecisionEvidenceState =
+  | "REQUIRED"
+  | "NONE"
+  | "UNRESOLVED"
+  | "CONTRADICTORY";
+
+export type HumanDecisionEvidenceSource =
+  | "PR_BODY_MARKER"
+  | "NO_RECOGNIZED_MARKER";
+
+export interface HumanDecisionEvidence {
+  state: HumanDecisionEvidenceState;
+  source: HumanDecisionEvidenceSource;
+  matchedMarkers: Array<"Human-Decision: REQUIRED" | "Human-Decision: NONE">;
+}
+
+const REQUIRED_MARKER = /^[ \t]*Human-Decision:[ \t]*REQUIRED[ \t]*$/im;
+const NONE_MARKER = /^[ \t]*Human-Decision:[ \t]*NONE[ \t]*$/im;
+
+export function collectHumanDecisionEvidence(
+  body: string | null | undefined,
+): HumanDecisionEvidence {
+  const required = Boolean(body && REQUIRED_MARKER.test(body));
+  const none = Boolean(body && NONE_MARKER.test(body));
+
+  if (required && none) {
+    return {
+      state: "CONTRADICTORY",
+      source: "PR_BODY_MARKER",
+      matchedMarkers: ["Human-Decision: REQUIRED", "Human-Decision: NONE"],
+    };
+  }
+
+  if (required) {
+    return {
+      state: "REQUIRED",
+      source: "PR_BODY_MARKER",
+      matchedMarkers: ["Human-Decision: REQUIRED"],
+    };
+  }
+
+  if (none) {
+    return {
+      state: "NONE",
+      source: "PR_BODY_MARKER",
+      matchedMarkers: ["Human-Decision: NONE"],
+    };
+  }
+
+  return {
+    state: "UNRESOLVED",
+    source: "NO_RECOGNIZED_MARKER",
+    matchedMarkers: [],
+  };
+}
+
+export function toHumanDecisionRequired(evidence: HumanDecisionEvidence): boolean | null {
+  if (evidence.state === "REQUIRED") return true;
+  if (evidence.state === "NONE") return false;
+  return null;
+}

--- a/src/domain/observedFacts.ts
+++ b/src/domain/observedFacts.ts
@@ -1,3 +1,5 @@
+import type { HumanDecisionEvidence } from "./humanDecisionEvidence";
+
 export type EvidenceState = "CONFIRMED" | "MISSING" | "CONTRADICTORY" | "ERROR";
 
 export type CiState = "PASS" | "PENDING" | "FAIL" | "UNKNOWN";
@@ -12,6 +14,7 @@ export interface ObservedPullRequest {
   review: ReviewState;
   mergeState: MergeState;
   humanDecisionRequired: boolean | null;
+  humanDecisionEvidence: HumanDecisionEvidence;
   sourceRefs: string[];
 }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useState } from "react";
 import type { HumanAction } from "../domain/humanAction";
 
+type PrEvidence = {
+  pr: number;
+  draft: boolean;
+  ci: string;
+  review: string;
+  mergeState: string;
+  humanDecision: string;
+  humanDecisionSource: string;
+  sourceRefs: string[];
+};
+
 type StatusResponse = {
   action: HumanAction;
   developmentStatus: {
@@ -9,6 +20,7 @@ type StatusResponse = {
     openPrCount: number | null;
     evidenceState: string;
   };
+  evidence: PrEvidence[] | null;
   observedAt: string;
 };
 
@@ -40,6 +52,7 @@ export function App() {
             openPrCount: null,
             evidenceState: "ERROR",
           },
+          evidence: null,
           observedAt: new Date().toISOString(),
         }),
       )
@@ -72,6 +85,21 @@ export function App() {
         <p>{action.reason}</p>
         {action.sourceRefs.length > 0 && (
           <ul>{action.sourceRefs.map((ref) => <li key={ref}>{ref}</li>)}</ul>
+        )}
+
+        {data?.evidence && data.evidence.length > 0 && (
+          <>
+            <h3>Observed PR evidence</h3>
+            <ul>
+              {data.evidence.map((item) => (
+                <li key={item.pr}>
+                  <strong>PR #{item.pr}</strong>{" — "}
+                  Draft={item.draft ? "YES" : "NO"}, CI={item.ci}, Review={item.review}, Merge={item.mergeState},{" "}
+                  HumanDecision={item.humanDecision} ({item.humanDecisionSource})
+                </li>
+              ))}
+            </ul>
+          </>
         )}
       </details>
     </main>

--- a/src/worker/github/readOnlyAdapter.ts
+++ b/src/worker/github/readOnlyAdapter.ts
@@ -1,3 +1,7 @@
+import {
+  collectHumanDecisionEvidence,
+  toHumanDecisionRequired,
+} from "../../domain/humanDecisionEvidence";
 import type {
   CiState,
   MergeState,
@@ -84,6 +88,7 @@ async function observePull(
   const pull = await githubGet<PullResponse>(`/repos/${repository}/pulls/${summary.number}`, env);
   const sha = pull.head?.sha;
   const sourceRefs = [pull.html_url ?? `github:pr:${summary.number}`];
+  const humanDecisionEvidence = collectHumanDecisionEvidence(pull.body ?? summary.body);
 
   if (!sha) {
     return {
@@ -93,7 +98,8 @@ async function observePull(
       ci: "UNKNOWN",
       review: "UNKNOWN",
       mergeState: "UNKNOWN",
-      humanDecisionRequired: parseHumanDecision(summary.body),
+      humanDecisionRequired: toHumanDecisionRequired(humanDecisionEvidence),
+      humanDecisionEvidence,
       sourceRefs,
     };
   }
@@ -116,7 +122,8 @@ async function observePull(
     ci: normalizeCi(checks, status),
     review: normalizeReview(reviews),
     mergeState: normalizeMergeState(pull),
-    humanDecisionRequired: parseHumanDecision(pull.body),
+    humanDecisionRequired: toHumanDecisionRequired(humanDecisionEvidence),
+    humanDecisionEvidence,
     sourceRefs,
   };
 }
@@ -167,13 +174,6 @@ function normalizeMergeState(pull: PullResponse): MergeState {
   }
   if (pull.mergeable === false) return "BLOCKED";
   return "UNKNOWN";
-}
-
-function parseHumanDecision(body: string | null | undefined): boolean | null {
-  if (!body) return null;
-  if (/Human-Decision:\s*REQUIRED/i.test(body)) return true;
-  if (/Human-Decision:\s*NONE/i.test(body)) return false;
-  return null;
 }
 
 async function githubGet<T>(path: string, env: GitHubEnv): Promise<T> {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -25,6 +25,17 @@ export default {
             openPrCount: facts.openPullRequests?.length ?? null,
             evidenceState: facts.evidenceState,
           },
+          evidence:
+            facts.openPullRequests?.map((pr) => ({
+              pr: pr.number,
+              draft: pr.draft,
+              ci: pr.ci,
+              review: pr.review,
+              mergeState: pr.mergeState,
+              humanDecision: pr.humanDecisionEvidence.state,
+              humanDecisionSource: pr.humanDecisionEvidence.source,
+              sourceRefs: pr.sourceRefs,
+            })) ?? null,
           observedAt: facts.observedAt,
         },
         { headers: { "Cache-Control": "no-store" } },

--- a/test/humanActionResolver.test.ts
+++ b/test/humanActionResolver.test.ts
@@ -11,6 +11,11 @@ function pr(overrides: Partial<ObservedPullRequest> = {}): ObservedPullRequest {
     review: "PASS",
     mergeState: "CLEAN",
     humanDecisionRequired: false,
+    humanDecisionEvidence: {
+      state: "NONE",
+      source: "PR_BODY_MARKER",
+      matchedMarkers: ["Human-Decision: NONE"],
+    },
     sourceRefs: ["github:pr:1"],
     ...overrides,
   };

--- a/test/humanActionResolver.test.ts
+++ b/test/humanActionResolver.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from "vitest";
 import { resolveHumanAction } from "../src/domain/humanActionResolver";
 import type { ObservedFacts, ObservedPullRequest } from "../src/domain/observedFacts";
 
+const requiredEvidence = {
+  state: "REQUIRED" as const,
+  source: "PR_BODY_MARKER" as const,
+  matchedMarkers: ["Human-Decision: REQUIRED" as const],
+};
+
+const noneEvidence = {
+  state: "NONE" as const,
+  source: "PR_BODY_MARKER" as const,
+  matchedMarkers: ["Human-Decision: NONE" as const],
+};
+
+const unresolvedEvidence = {
+  state: "UNRESOLVED" as const,
+  source: "NO_RECOGNIZED_MARKER" as const,
+  matchedMarkers: [],
+};
+
 function pr(overrides: Partial<ObservedPullRequest> = {}): ObservedPullRequest {
   return {
     number: 1,
@@ -11,11 +29,7 @@ function pr(overrides: Partial<ObservedPullRequest> = {}): ObservedPullRequest {
     review: "PASS",
     mergeState: "CLEAN",
     humanDecisionRequired: false,
-    humanDecisionEvidence: {
-      state: "NONE",
-      source: "PR_BODY_MARKER",
-      matchedMarkers: ["Human-Decision: NONE"],
-    },
+    humanDecisionEvidence: noneEvidence,
     sourceRefs: ["github:pr:1"],
     ...overrides,
   };
@@ -37,7 +51,13 @@ function facts(overrides: Partial<ObservedFacts> = {}): ObservedFacts {
 
 describe("resolveHumanAction", () => {
   it("returns ACTION_REQUIRED only with explicit human decision evidence", () => {
-    const result = resolveHumanAction(facts({ openPullRequests: [pr({ humanDecisionRequired: true })] }));
+    const result = resolveHumanAction(
+      facts({
+        openPullRequests: [
+          pr({ humanDecisionRequired: true, humanDecisionEvidence: requiredEvidence }),
+        ],
+      }),
+    );
     expect(result.status).toBe("ACTION_REQUIRED");
   });
 
@@ -50,6 +70,7 @@ describe("resolveHumanAction", () => {
             review: "PASS",
             mergeState: "CLEAN",
             humanDecisionRequired: true,
+            humanDecisionEvidence: requiredEvidence,
           }),
         ],
       }),
@@ -67,6 +88,7 @@ describe("resolveHumanAction", () => {
             review: "PASS",
             mergeState: "CLEAN",
             humanDecisionRequired: true,
+            humanDecisionEvidence: requiredEvidence,
             sourceRefs: ["github:pr:1"],
           }),
           pr({
@@ -75,6 +97,7 @@ describe("resolveHumanAction", () => {
             review: "PASS",
             mergeState: "CLEAN",
             humanDecisionRequired: false,
+            humanDecisionEvidence: noneEvidence,
             sourceRefs: ["github:pr:2"],
           }),
         ],
@@ -97,18 +120,56 @@ describe("resolveHumanAction", () => {
     expect(resolveHumanAction(facts({ evidenceState: "ERROR" })).status).toBe("UNKNOWN");
   });
 
-  it("returns UNKNOWN for contradictory evidence", () => {
+  it("returns UNKNOWN for contradictory repository evidence", () => {
     expect(resolveHumanAction(facts({ evidenceState: "CONTRADICTORY" })).status).toBe("UNKNOWN");
   });
 
-  it("returns UNKNOWN when no known rule applies", () => {
-    const result = resolveHumanAction(facts({ openPullRequests: [pr({ humanDecisionRequired: null })] }));
+  it("returns UNKNOWN when human decision evidence is unresolved", () => {
+    const result = resolveHumanAction(
+      facts({
+        openPullRequests: [
+          pr({ humanDecisionRequired: null, humanDecisionEvidence: unresolvedEvidence }),
+        ],
+      }),
+    );
+    expect(result.status).toBe("UNKNOWN");
+  });
+
+  it("returns UNKNOWN when structured decision markers contradict", () => {
+    const result = resolveHumanAction(
+      facts({
+        openPullRequests: [
+          pr({
+            humanDecisionRequired: null,
+            humanDecisionEvidence: {
+              state: "CONTRADICTORY",
+              source: "PR_BODY_MARKER",
+              matchedMarkers: ["Human-Decision: REQUIRED", "Human-Decision: NONE"],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(result.status).toBe("UNKNOWN");
+  });
+
+  it("returns UNKNOWN when boolean projection conflicts with decision evidence", () => {
+    const result = resolveHumanAction(
+      facts({
+        openPullRequests: [pr({ humanDecisionRequired: true, humanDecisionEvidence: noneEvidence })],
+      }),
+    );
     expect(result.status).toBe("UNKNOWN");
   });
 
   it("never upgrades insufficient evidence to ACTION_REQUIRED", () => {
     const result = resolveHumanAction(
-      facts({ evidenceState: "MISSING", openPullRequests: [pr({ humanDecisionRequired: true })] }),
+      facts({
+        evidenceState: "MISSING",
+        openPullRequests: [
+          pr({ humanDecisionRequired: true, humanDecisionEvidence: requiredEvidence }),
+        ],
+      }),
     );
     expect(result.status).toBe("UNKNOWN");
   });

--- a/test/humanDecisionEvidence.test.ts
+++ b/test/humanDecisionEvidence.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectHumanDecisionEvidence,
+  toHumanDecisionRequired,
+} from "../src/domain/humanDecisionEvidence";
+
+describe("collectHumanDecisionEvidence", () => {
+  it("confirms REQUIRED only from the exact structured marker", () => {
+    const evidence = collectHumanDecisionEvidence("Human-Decision: REQUIRED");
+    expect(evidence).toEqual({
+      state: "REQUIRED",
+      source: "PR_BODY_MARKER",
+      matchedMarkers: ["Human-Decision: REQUIRED"],
+    });
+    expect(toHumanDecisionRequired(evidence)).toBe(true);
+  });
+
+  it("confirms NONE only from the exact structured marker", () => {
+    const evidence = collectHumanDecisionEvidence("Human-Decision: NONE");
+    expect(evidence.state).toBe("NONE");
+    expect(toHumanDecisionRequired(evidence)).toBe(false);
+  });
+
+  it("does not infer a decision from free-form HUMAN-ONLY text", () => {
+    const evidence = collectHumanDecisionEvidence("Ready / Merge — HUMAN-ONLY");
+    expect(evidence.state).toBe("UNRESOLVED");
+    expect(evidence.source).toBe("NO_RECOGNIZED_MARKER");
+    expect(toHumanDecisionRequired(evidence)).toBeNull();
+  });
+
+  it("fails closed when REQUIRED and NONE markers conflict", () => {
+    const evidence = collectHumanDecisionEvidence(
+      "Human-Decision: REQUIRED\nHuman-Decision: NONE",
+    );
+    expect(evidence.state).toBe("CONTRADICTORY");
+    expect(evidence.matchedMarkers).toEqual([
+      "Human-Decision: REQUIRED",
+      "Human-Decision: NONE",
+    ]);
+    expect(toHumanDecisionRequired(evidence)).toBeNull();
+  });
+
+  it("ignores marker-like prose that is not an exact marker line", () => {
+    const evidence = collectHumanDecisionEvidence(
+      "Example: Human-Decision: REQUIRED should not authorize anything.",
+    );
+    expect(evidence.state).toBe("UNRESOLVED");
+  });
+});


### PR DESCRIPTION
## MVP-2 slice

`EVIDENCE-TRACE-V1`

MVP-1 の fail-closed Human Action Resolver を維持したまま、Open PR ごとの一次情報を Evidence として収集・API/UIへ露出します。

## Baseline

```text
main = 603a154bdeb917fdc32137b51d430b7d4fc412f5
MVP-1 = COMPLETE
```

## IN

- strict `Human-Decision: REQUIRED|NONE` marker collection
- conflicting REQUIRED + NONE => `CONTRADICTORY` / no action escalation
- free-form `HUMAN-ONLY` text => `UNRESOLVED`（推測しない）
- `humanDecisionRequired` と structured evidence の不一致 => `UNKNOWN`
- per-PR CI / Review / Merge / HumanDecision evidence を `/api/status` へ追加
- UI details に Observed PR evidence を表示
- unit tests for strict marker / free-form non-inference / contradiction / projection mismatch

## OUT

- `severe-behavior-support-spfx` mutation
- GitHub write capability in the app
- Issue / comment / review write
- free-form NLP inference
- automatic approval / Ready / Merge
- SharePoint mutation
- structured marker 以外からの Human Action 自動昇格

## Expected production semantics after deploy

PR #245 等に structured `Human-Decision:` marker がない場合:

```text
evidenceState = CONFIRMED
humanDecision = UNRESOLVED
HumanAction = UNKNOWN
```

`UNKNOWN` は fail-closed の正常結果です。

## Verification

Human-run official repository verification on HEAD `8a6fed9e70986167a77387c60c43e1f23daa5413`:

```text
npm ci: PASS
npm run verify: PASS
  tsc --noEmit: PASS
  vitest run: 24 / 24 PASS (3 files)
  vite build: PASS (worker + client)
```

Test breakdown:

```text
humanDecisionEvidence.test.ts  5 PASS
humanActionResolver.test.ts   11 PASS
normalizeCi.test.ts            8 PASS
```

Additional static/pure-logic checks performed before official verify:

```text
Domain + Worker strict TypeScript check: PASS
UI TSX syntax/type shape check: PASS
Manual domain assertions: PASS
```

## Merge

```text
Ready: YES
Merge: SQUASH MERGED
Merge commit: 566da5dd94c55f8cc9b6640da2f92328a89970fd
Production deploy: NOT RUN YET
```

## Security boundary

```text
Observed repo request = GET only
severe-behavior-support-spfx mutation = 0
GitHub write capability in runtime = 0
Secret change = 0
Production deploy = NOT RUN YET
```
