### PR TITLE
fix(mvp2): post-merge P2 — stale marker + sourceRefs UI

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -96,6 +96,13 @@ export function App() {
                   <strong>PR #{item.pr}</strong>{" — "}
                   Draft={item.draft ? "YES" : "NO"}, CI={item.ci}, Review={item.review}, Merge={item.mergeState},{" "}
                   HumanDecision={item.humanDecision} ({item.humanDecisionSource})
+                  {item.sourceRefs.length > 0 && (
+                    <ul>
+                      {item.sourceRefs.map((ref) => (
+                        <li key={ref}>{ref}</li>
+                      ))}
+                    </ul>
+                  )}
                 </li>
               ))}
             </ul>

--- a/src/worker/github/readOnlyAdapter.ts
+++ b/src/worker/github/readOnlyAdapter.ts
@@ -80,6 +80,19 @@ export async function observeRepository(
   }
 }
 
+/**
+ * Prefer the authoritative PR detail body.
+ * Explicit `null` means the body is empty — do not resurrect a stale list-response marker.
+ * Fall back to summary.body only when the detail body property is missing (`undefined`).
+ */
+export function selectAuthoritativePullBody(
+  detailBody: string | null | undefined,
+  summaryBody: string | null | undefined,
+): string | null | undefined {
+  if (detailBody !== undefined) return detailBody;
+  return summaryBody;
+}
+
 async function observePull(
   repository: string,
   summary: PullResponse,
@@ -88,7 +101,9 @@ async function observePull(
   const pull = await githubGet<PullResponse>(`/repos/${repository}/pulls/${summary.number}`, env);
   const sha = pull.head?.sha;
   const sourceRefs = [pull.html_url ?? `github:pr:${summary.number}`];
-  const humanDecisionEvidence = collectHumanDecisionEvidence(pull.body ?? summary.body);
+  const humanDecisionEvidence = collectHumanDecisionEvidence(
+    selectAuthoritativePullBody(pull.body, summary.body),
+  );
 
   if (!sha) {
     return {

--- a/test/selectAuthoritativePullBody.test.ts
+++ b/test/selectAuthoritativePullBody.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectHumanDecisionEvidence,
+  toHumanDecisionRequired,
+} from "../src/domain/humanDecisionEvidence";
+import { resolveHumanAction } from "../src/domain/humanActionResolver";
+import type { ObservedFacts, ObservedPullRequest } from "../src/domain/observedFacts";
+import { selectAuthoritativePullBody } from "../src/worker/github/readOnlyAdapter";
+
+function factsFromBodies(
+  detailBody: string | null | undefined,
+  summaryBody: string | null | undefined,
+): ObservedFacts {
+  const body = selectAuthoritativePullBody(detailBody, summaryBody);
+  const humanDecisionEvidence = collectHumanDecisionEvidence(body);
+  const humanDecisionRequired = toHumanDecisionRequired(humanDecisionEvidence);
+
+  const openPullRequest: ObservedPullRequest = {
+    number: 245,
+    title: "Example",
+    draft: false,
+    ci: "PASS",
+    review: "PASS",
+    mergeState: "CLEAN",
+    humanDecisionRequired,
+    humanDecisionEvidence,
+    sourceRefs: ["github:pr:245"],
+  };
+
+  return {
+    repository: "yasutakesougo/severe-behavior-support-spfx",
+    observedAt: "2026-08-11T00:00:00.000Z",
+    evidenceState: "CONFIRMED",
+    currentMain: "abc123",
+    openPullRequests: [openPullRequest],
+    relevantIssueStates: {},
+    errors: [],
+    sourceRefs: ["github:repo:yasutakesougo/severe-behavior-support-spfx"],
+  };
+}
+
+describe("selectAuthoritativePullBody", () => {
+  it("does not resurrect a stale REQUIRED marker when detail body is explicit null", () => {
+    const body = selectAuthoritativePullBody(null, "Human-Decision: REQUIRED");
+    const evidence = collectHumanDecisionEvidence(body);
+    const action = resolveHumanAction(factsFromBodies(null, "Human-Decision: REQUIRED"));
+
+    expect(body).toBeNull();
+    expect(evidence.state).toBe("UNRESOLVED");
+    expect(toHumanDecisionRequired(evidence)).toBeNull();
+    expect(action.status).not.toBe("ACTION_REQUIRED");
+    expect(action.status).toBe("UNKNOWN");
+  });
+
+  it("recognizes REQUIRED from the authoritative detail body", () => {
+    const body = selectAuthoritativePullBody("Human-Decision: REQUIRED", "stale");
+    const evidence = collectHumanDecisionEvidence(body);
+    const action = resolveHumanAction(
+      factsFromBodies("Human-Decision: REQUIRED", "stale"),
+    );
+
+    expect(evidence.state).toBe("REQUIRED");
+    expect(toHumanDecisionRequired(evidence)).toBe(true);
+    expect(action.status).toBe("ACTION_REQUIRED");
+  });
+
+  it("recognizes NONE from the authoritative detail body", () => {
+    const body = selectAuthoritativePullBody("Human-Decision: NONE", "Human-Decision: REQUIRED");
+    const evidence = collectHumanDecisionEvidence(body);
+    const action = resolveHumanAction(
+      factsFromBodies("Human-Decision: NONE", "Human-Decision: REQUIRED"),
+    );
+
+    expect(evidence.state).toBe("NONE");
+    expect(toHumanDecisionRequired(evidence)).toBe(false);
+    expect(action.status).toBe("NO_ACTION");
+  });
+
+  it("falls back to summary body only when detail body is missing", () => {
+    const body = selectAuthoritativePullBody(undefined, "Human-Decision: REQUIRED");
+    const evidence = collectHumanDecisionEvidence(body);
+
+    expect(body).toBe("Human-Decision: REQUIRED");
+    expect(evidence.state).toBe("REQUIRED");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Slice

`MVP-2-POSTMERGE-P2-FIX`

PR #7（MVP-2 closeout）は **HOLD / Draft維持**。本 PR は merged PR #6 の post-merge Codex P2 2件のみを潰します。

## Baseline

```text
main = 566da5dd94c55f8cc9b6640da2f92328a89970fd
```

## Findings mapping

| ID | Finding | Severity | Fix |
| --- | --- | --- | --- |
| F-001 | stale Human-Decision marker resurrection via `pull.body ?? summary.body` | **BLOCKER** | `selectAuthoritativePullBody`: detail `body === null` は bodyなし。stale list marker を復活させない |
| F-002 | Observed PR evidence UI が per-PR `sourceRefs` を表示しない | 修正推奨 | 各 PR 行の下に `item.sourceRefs` を表示 |

## F-001 contract

```text
authoritative PR detail body が明示的 null
  → 「bodyなし」
  → stale summary.body の Human-Decision: REQUIRED を復活させない
  → false ACTION_REQUIRED 禁止
  → fail-closed 維持
```

Before:

```ts
collectHumanDecisionEvidence(pull.body ?? summary.body)
```

After:

```ts
collectHumanDecisionEvidence(
  selectAuthoritativePullBody(pull.body, summary.body),
)
```

## Regression tests

`test/selectAuthoritativePullBody.test.ts`（+4）:

1. `summary.body = Human-Decision: REQUIRED` + `detail.body = null` → `UNRESOLVED` / `ACTION_REQUIRED` に昇格しない
2. `detail.body = Human-Decision: REQUIRED` → REQUIRED 認識 / `ACTION_REQUIRED`
3. `detail.body = Human-Decision: NONE` → NONE 認識 / `NO_ACTION`
4. detail body missing (`undefined`) のときのみ summary へ fallback

## F-002

`src/ui/App.tsx` — Observed PR evidence の各 PR 行に `item.sourceRefs` をネスト表示し、一次 source へ追跡可能にする。

## Verification

```text
npm run verify: PASS
  tsc --noEmit: PASS
  vitest run: 28 / 28 PASS (4 files)
  vite build: PASS
```

## OUT / STOP

- PR #7 Ready / Merge しない
- 本 fix PR も Ready / Merge しない（Draft）
- production deploy しない
- MVP-3 開始しない
- Human Approval UI / GitHub write / SharePoint / Action Gateway / Agent execution / secret / Cloudflare permission / severe-behavior-support-spfx mutation = 0

## Next Human gate

本 Draft PR の review 後の Ready 判断。

その後に PR #7 closeout 再開。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-544de248-85b7-488e-b4de-0e9dc091d8ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-544de248-85b7-488e-b4de-0e9dc091d8ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

