### PR TITLE
feat(mvp3): add non-operative approval intent UI

### DIFF
--- a/src/domain/approvalIntent.ts
+++ b/src/domain/approvalIntent.ts
@@ -1,0 +1,85 @@
+import type { HumanActionStatus } from "./humanAction";
+
+export type ApprovalIntent = "APPROVE" | "REJECT" | "DEFER";
+
+export interface ApprovalIntentDraft {
+  intent: ApprovalIntent;
+  fingerprint: string;
+}
+
+export interface ApprovalIntentContext {
+  actionStatus: HumanActionStatus;
+  evidenceState: string | null | undefined;
+  sourceRefs: string[];
+  observedAt: string;
+  evidence: unknown;
+}
+
+/**
+ * Approval Intent UI is presentation-only and may appear only for ACTION_REQUIRED
+ * with confirmed evidence. All other statuses and fail-closed evidence states hide it.
+ */
+export function isApprovalIntentUiAllowed(
+  actionStatus: HumanActionStatus,
+  evidenceState: string | null | undefined,
+): boolean {
+  if (actionStatus !== "ACTION_REQUIRED") return false;
+  if (
+    evidenceState === "ERROR" ||
+    evidenceState === "MISSING" ||
+    evidenceState === "CONTRADICTORY" ||
+    evidenceState == null
+  ) {
+    return false;
+  }
+  return evidenceState === "CONFIRMED";
+}
+
+/**
+ * Fingerprint of the actionable observation. Any change clears local draft intent.
+ */
+export function buildApprovalIntentFingerprint(context: ApprovalIntentContext): string {
+  return JSON.stringify({
+    actionStatus: context.actionStatus,
+    evidenceState: context.evidenceState ?? null,
+    sourceRefs: context.sourceRefs,
+    observedAt: context.observedAt,
+    evidence: context.evidence ?? null,
+  });
+}
+
+/**
+ * Drop stale local drafts when the observation fingerprint changes or UI is no longer allowed.
+ */
+export function reconcileApprovalIntentDraft(
+  draft: ApprovalIntentDraft | null,
+  fingerprint: string,
+  allowed: boolean,
+): ApprovalIntentDraft | null {
+  if (!allowed || draft == null) return null;
+  if (draft.fingerprint !== fingerprint) return null;
+  return draft;
+}
+
+/**
+ * Create a local-only, ephemeral draft. Never implies external submission.
+ */
+export function selectApprovalIntent(
+  allowed: boolean,
+  intent: ApprovalIntent,
+  fingerprint: string,
+): { draft: ApprovalIntentDraft | null; externalEffect: false } {
+  if (!allowed) {
+    return { draft: null, externalEffect: false };
+  }
+  return {
+    draft: { intent, fingerprint },
+    externalEffect: false,
+  };
+}
+
+export function approvalIntentLabel(intent: ApprovalIntent): string {
+  if (intent === "APPROVE") return "承認案";
+  if (intent === "REJECT") return "却下案";
+  return "保留";
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState } from "react";
+import {
+  buildApprovalIntentFingerprint,
+  isApprovalIntentUiAllowed,
+  reconcileApprovalIntentDraft,
+  selectApprovalIntent,
+  type ApprovalIntent,
+  type ApprovalIntentDraft,
+} from "../domain/approvalIntent";
 import type { HumanAction } from "../domain/humanAction";
+import { ApprovalIntentPanel } from "./ApprovalIntentPanel";
 
 type PrEvidence = {
   pr: number;
@@ -35,6 +44,7 @@ const fallback: HumanAction = {
 export function App() {
   const [data, setData] = useState<StatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [intentDraft, setIntentDraft] = useState<ApprovalIntentDraft | null>(null);
 
   useEffect(() => {
     fetch("/api/status", { cache: "no-store" })
@@ -60,6 +70,26 @@ export function App() {
   }, []);
 
   const action = data?.action ?? fallback;
+  const evidenceState = data?.developmentStatus.evidenceState;
+  const approvalAllowed = isApprovalIntentUiAllowed(action.status, evidenceState);
+  const fingerprint = data
+    ? buildApprovalIntentFingerprint({
+        actionStatus: action.status,
+        evidenceState,
+        sourceRefs: action.sourceRefs,
+        observedAt: data.observedAt,
+        evidence: data.evidence,
+      })
+    : "";
+
+  useEffect(() => {
+    setIntentDraft((current) => reconcileApprovalIntentDraft(current, fingerprint, approvalAllowed));
+  }, [fingerprint, approvalAllowed]);
+
+  function handleSelectIntent(intent: ApprovalIntent) {
+    const result = selectApprovalIntent(approvalAllowed, intent, fingerprint);
+    setIntentDraft(result.draft);
+  }
 
   return (
     <main className="shell">
@@ -77,8 +107,19 @@ export function App() {
           <div><dt>Main</dt><dd>{data?.developmentStatus.main ?? "確認中"}</dd></div>
           <div><dt>Open PR</dt><dd>{data?.developmentStatus.openPrCount ?? "—"}</dd></div>
           <div><dt>Evidence</dt><dd>{data?.developmentStatus.evidenceState ?? "確認中"}</dd></div>
+          <div><dt>observedAt</dt><dd>{data?.observedAt ?? "確認中"}</dd></div>
         </dl>
       </section>
+
+      {!loading && approvalAllowed && data && (
+        <ApprovalIntentPanel
+          action={action}
+          observedAt={data.observedAt}
+          evidence={data.evidence}
+          draft={intentDraft}
+          onSelect={handleSelectIntent}
+        />
+      )}
 
       <details className="details-card">
         <summary>理由と参照元を見る</summary>

--- a/src/ui/ApprovalIntentPanel.tsx
+++ b/src/ui/ApprovalIntentPanel.tsx
@@ -1,0 +1,129 @@
+import {
+  approvalIntentLabel,
+  type ApprovalIntent,
+  type ApprovalIntentDraft,
+} from "../domain/approvalIntent";
+import type { HumanAction } from "../domain/humanAction";
+
+type PrEvidence = {
+  pr: number;
+  draft: boolean;
+  ci: string;
+  review: string;
+  mergeState: string;
+  humanDecision: string;
+  humanDecisionSource: string;
+  sourceRefs: string[];
+};
+
+type Props = {
+  action: HumanAction;
+  observedAt: string;
+  evidence: PrEvidence[] | null;
+  draft: ApprovalIntentDraft | null;
+  onSelect: (intent: ApprovalIntent) => void;
+};
+
+const CHOICES: ApprovalIntent[] = ["APPROVE", "REJECT", "DEFER"];
+
+/**
+ * Presentation-only Approval Intent controls.
+ * Selection stays in React memory and never submits externally.
+ */
+export function ApprovalIntentPanel({
+  action,
+  observedAt,
+  evidence,
+  draft,
+  onSelect,
+}: Props) {
+  return (
+    <section className="approval-intent-card" aria-label="Approval Intent local draft">
+      <h2>Approval Intent（案）</h2>
+      <p className="approval-intent-note">
+        これは実際の承認ではありません。選択は端末上の一時案のみで、外部へ送信・保存されません。
+      </p>
+
+      <dl className="approval-intent-evidence">
+        <div>
+          <dt>Human Action</dt>
+          <dd>{action.status}</dd>
+        </div>
+        <div>
+          <dt>Title</dt>
+          <dd>{action.title}</dd>
+        </div>
+        <div>
+          <dt>Instruction</dt>
+          <dd>{action.instruction}</dd>
+        </div>
+        <div>
+          <dt>Reason</dt>
+          <dd>{action.reason}</dd>
+        </div>
+        <div>
+          <dt>observedAt</dt>
+          <dd>{observedAt}</dd>
+        </div>
+      </dl>
+
+      {action.sourceRefs.length > 0 && (
+        <>
+          <h3>sourceRefs</h3>
+          <ul>
+            {action.sourceRefs.map((ref) => (
+              <li key={ref}>{ref}</li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      <h3>Observed evidence trace</h3>
+      {evidence && evidence.length > 0 ? (
+        <ul>
+          {evidence.map((item) => (
+            <li key={item.pr}>
+              <strong>PR #{item.pr}</strong>
+              {" — "}
+              Draft={item.draft ? "YES" : "NO"}, CI={item.ci}, Review={item.review}, Merge={item.mergeState},{" "}
+              HumanDecision={item.humanDecision} ({item.humanDecisionSource})
+              {item.sourceRefs.length > 0 && (
+                <ul>
+                  {item.sourceRefs.map((ref) => (
+                    <li key={ref}>{ref}</li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>evidence trace はありません。</p>
+      )}
+
+      <div className="approval-intent-choices" role="group" aria-label="Approval Intent choices">
+        {CHOICES.map((intent) => (
+          <button
+            key={intent}
+            type="button"
+            className={draft?.intent === intent ? "selected" : undefined}
+            onClick={() => onSelect(intent)}
+          >
+            {approvalIntentLabel(intent)}
+          </button>
+        ))}
+      </div>
+
+      {draft && (
+        <div className="approval-intent-draft" role="status">
+          <p>
+            選択中の案: <strong>{approvalIntentLabel(draft.intent)}</strong>
+          </p>
+          <p>LOCAL DRAFT</p>
+          <p>NOT SUBMITTED</p>
+          <p>外部システムには反映されていません</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -7,7 +7,7 @@
 body { margin: 0; min-width: 320px; min-height: 100vh; }
 button, input, textarea, select { font: inherit; }
 .shell { width: min(100%, 720px); margin: 0 auto; padding: 20px 16px 48px; }
-.action-card, .status-card, .details-card {
+.action-card, .status-card, .details-card, .approval-intent-card {
   background: #fff;
   border: 1px solid #dfe5dc;
   border-radius: 20px;
@@ -32,6 +32,39 @@ dd { margin: 0; font-weight: 650; overflow-wrap: anywhere; }
 .details-card { margin-top: 16px; padding: 16px 18px; }
 summary { cursor: pointer; font-weight: 700; }
 .details-card p, .details-card li { line-height: 1.6; color: #59645b; overflow-wrap: anywhere; }
+.approval-intent-card { margin-top: 16px; padding: 20px; }
+.approval-intent-card h2 { margin: 0 0 8px; font-size: 1.05rem; }
+.approval-intent-card h3 { margin: 18px 0 8px; font-size: 0.95rem; }
+.approval-intent-note { margin: 0 0 16px; color: #5f675f; line-height: 1.6; }
+.approval-intent-evidence { margin: 0; }
+.approval-intent-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+.approval-intent-choices button {
+  border: 1px solid #c9d2c6;
+  background: #f8faf6;
+  color: #182018;
+  border-radius: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+.approval-intent-choices button.selected {
+  border-color: #355d3a;
+  background: #e7efe6;
+  font-weight: 700;
+}
+.approval-intent-draft {
+  margin-top: 16px;
+  padding: 14px 16px;
+  border: 1px dashed #8a722a;
+  border-radius: 12px;
+  background: #fff9eb;
+}
+.approval-intent-draft p { margin: 0 0 6px; color: #5f675f; line-height: 1.5; }
+.approval-intent-draft p:last-child { margin-bottom: 0; }
 @media (min-width: 640px) {
   .shell { padding-top: 40px; }
   .action-card { padding: 32px; }

--- a/test/approvalIntent.test.ts
+++ b/test/approvalIntent.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildApprovalIntentFingerprint,
+  isApprovalIntentUiAllowed,
+  reconcileApprovalIntentDraft,
+  selectApprovalIntent,
+  type ApprovalIntentContext,
+} from "../src/domain/approvalIntent";
+
+function context(overrides: Partial<ApprovalIntentContext> = {}): ApprovalIntentContext {
+  return {
+    actionStatus: "ACTION_REQUIRED",
+    evidenceState: "CONFIRMED",
+    sourceRefs: ["github:pr:10"],
+    observedAt: "2026-08-11T07:00:00.000Z",
+    evidence: [{ pr: 10, humanDecision: "REQUIRED" }],
+    ...overrides,
+  };
+}
+
+describe("approval intent UI visibility", () => {
+  it("allows Approval Intent UI only for ACTION_REQUIRED with confirmed evidence", () => {
+    expect(isApprovalIntentUiAllowed("ACTION_REQUIRED", "CONFIRMED")).toBe(true);
+  });
+
+  it("forbids Approval Intent UI for WAIT", () => {
+    expect(isApprovalIntentUiAllowed("WAIT", "CONFIRMED")).toBe(false);
+  });
+
+  it("forbids Approval Intent UI for NO_ACTION", () => {
+    expect(isApprovalIntentUiAllowed("NO_ACTION", "CONFIRMED")).toBe(false);
+  });
+
+  it("forbids Approval Intent UI for UNKNOWN", () => {
+    expect(isApprovalIntentUiAllowed("UNKNOWN", "CONFIRMED")).toBe(false);
+  });
+
+  it("forbids Approval Intent creation for insufficient or contradictory evidence", () => {
+    expect(isApprovalIntentUiAllowed("ACTION_REQUIRED", "MISSING")).toBe(false);
+    expect(isApprovalIntentUiAllowed("ACTION_REQUIRED", "CONTRADICTORY")).toBe(false);
+    expect(isApprovalIntentUiAllowed("ACTION_REQUIRED", "ERROR")).toBe(false);
+    expect(isApprovalIntentUiAllowed("ACTION_REQUIRED", null)).toBe(false);
+  });
+});
+
+describe("approval intent local draft selection", () => {
+  it("stores APPROVE as a local draft with no external effect", () => {
+    const fingerprint = buildApprovalIntentFingerprint(context());
+    const result = selectApprovalIntent(true, "APPROVE", fingerprint);
+    expect(result.draft).toEqual({ intent: "APPROVE", fingerprint });
+    expect(result.externalEffect).toBe(false);
+  });
+
+  it("stores REJECT as a local draft with no external effect", () => {
+    const fingerprint = buildApprovalIntentFingerprint(context());
+    const result = selectApprovalIntent(true, "REJECT", fingerprint);
+    expect(result.draft).toEqual({ intent: "REJECT", fingerprint });
+    expect(result.externalEffect).toBe(false);
+  });
+
+  it("stores DEFER as a local draft with no external effect", () => {
+    const fingerprint = buildApprovalIntentFingerprint(context());
+    const result = selectApprovalIntent(true, "DEFER", fingerprint);
+    expect(result.draft).toEqual({ intent: "DEFER", fingerprint });
+    expect(result.externalEffect).toBe(false);
+  });
+
+  it("does not create a draft when Approval Intent UI is forbidden", () => {
+    const fingerprint = buildApprovalIntentFingerprint(context({ actionStatus: "WAIT" }));
+    const result = selectApprovalIntent(false, "APPROVE", fingerprint);
+    expect(result.draft).toBeNull();
+    expect(result.externalEffect).toBe(false);
+  });
+});
+
+describe("approval intent stale protection", () => {
+  it("clears old local intent when action or evidence fingerprint changes", () => {
+    const initial = context();
+    const fingerprint = buildApprovalIntentFingerprint(initial);
+    const draft = selectApprovalIntent(true, "APPROVE", fingerprint).draft;
+
+    const changedStatus = buildApprovalIntentFingerprint(
+      context({ actionStatus: "NO_ACTION" }),
+    );
+    expect(
+      reconcileApprovalIntentDraft(draft, changedStatus, isApprovalIntentUiAllowed("NO_ACTION", "CONFIRMED")),
+    ).toBeNull();
+
+    const changedSourceRefs = buildApprovalIntentFingerprint(
+      context({ sourceRefs: ["github:pr:99"] }),
+    );
+    expect(reconcileApprovalIntentDraft(draft, changedSourceRefs, true)).toBeNull();
+
+    const changedEvidence = buildApprovalIntentFingerprint(
+      context({ evidence: [{ pr: 10, humanDecision: "NONE" }] }),
+    );
+    expect(reconcileApprovalIntentDraft(draft, changedEvidence, true)).toBeNull();
+  });
+
+  it("keeps local intent only while fingerprint and visibility remain valid", () => {
+    const fingerprint = buildApprovalIntentFingerprint(context());
+    const draft = selectApprovalIntent(true, "REJECT", fingerprint).draft;
+    expect(reconcileApprovalIntentDraft(draft, fingerprint, true)).toEqual(draft);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Slice

`MVP-3-APPROVAL-INTENT-UI-V1`

Presentation-only / non-operative Approval Intent UI.
`HumanAction = ACTION_REQUIRED` のときだけ、Human が evidence を確認し「承認案 / 却下案 / 保留」をローカル UI で選べます。

**これは実際の承認ではありません。**

## Baseline

```text
main = 07e88ac1ac874fea3b0ed52cbf567bcecb90be52
```

## Security contract

```text
Approval Intent =
  LOCAL ONLY
  EPHEMERAL
  NOT SUBMITTED
  NOT PERSISTED
  NO EXTERNAL EFFECT
```

Human が「承認案」を選んでも:

- GitHub Ready / Merge / Comment = 0
- SharePoint write = 0
- Action Gateway = 0
- Cursor / Codex Agent = 0
- Worker mutation request = 0

## IN

1. Approval Intent domain (`APPROVE` / `REJECT` / `DEFER`) — pure/client-side only
2. Visibility: `ACTION_REQUIRED` + `evidenceState=CONFIRMED` のみ
3. Evidence-first UI（Human Action / instruction / reason / sourceRefs / observedAt / evidence trace）
4. Intent choices with non-operative wording（承認案 / 却下案 / 保留）
5. Confirmation: `LOCAL DRAFT` / `NOT SUBMITTED` / 外部システムには反映されていません
6. Stale protection: action / sourceRefs / evidence / observedAt fingerprint 変化で local draft 破棄。reload 復元なし

## OUT

- Approval persistence / Ledger / auth / identity
- backend approval API
- Action Gateway / GitHub write / SharePoint write / Agent execution
- real Ready / Merge / Close
- KV / D1 / DO / R2 / localStorage / sessionStorage / IndexedDB / cookie

## FORBIDDEN (maintained)

- POST / PUT / PATCH / DELETE endpoint 追加なし
- `/api/approval` なし
- GITHUB_TOKEN / Cloudflare secret / permission 変更なし
- Human Action Resolver semantics 変更なし
- Human-Decision marker 拡張なし
- free-form NLP inference なし

## Files changed

```text
src/domain/approvalIntent.ts          (new)
src/ui/ApprovalIntentPanel.tsx        (new)
src/ui/App.tsx
src/ui/styles.css
test/approvalIntent.test.ts           (new)
```

Worker / GitHub adapter は未変更（GET only 維持）。

## Verification

```text
npm ci: PASS
npm run verify: PASS
  tsc --noEmit: PASS
  vitest run: 39 / 39 PASS (5 files)
  vite build: PASS
```

Test breakdown:

```text
approvalIntent.test.ts             11 PASS  (new)
humanActionResolver.test.ts        11 PASS  (existing fail-closed retained)
selectAuthoritativePullBody.test.ts 4 PASS
normalizeCi.test.ts                 8 PASS
humanDecisionEvidence.test.ts       5 PASS
```

Exact new test count: **39** (previous 28 + 11).

## External mutation capability remains 0

```text
GitHub write capability = 0
SharePoint mutation = 0
target repository mutation = 0
new backend mutation endpoint = 0
persistent approval storage = 0
Agent execution capability = 0
Worker GitHub calls = GET only
```

Diff scan: no `localStorage` / `sessionStorage` / `IndexedDB` / `/api/approval` / mutation methods.

## STOP

- Ready にしない
- Merge しない
- production deploy しない
- next MVP-3 slice（Approval Ledger / Action Gateway 等）を開始しない

## Next Human gate

MVP-3-APPROVAL-INTENT-UI-V1 Draft PR review → Human Ready decision.

Real approval execution remains NOT AUTHORIZED.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-544de248-85b7-488e-b4de-0e9dc091d8ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-544de248-85b7-488e-b4de-0e9dc091d8ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

