### PR TITLE
feat(mvp3): add fail-closed Access identity verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ Approval Intent は実承認・永続化・実行ゲートではありません�
 MVP-3 Approval Intent UI V1 = COMPLETE
 MVP-3 Approval Ledger CONTRACT-V1 = DESIGN ONLY
 MVP-3 Approval Ledger IDENTITY-V1 = DESIGN ONLY
+MVP-3 Approval Ledger AUTH-VERIFY-V1 = CODE PRESENT (not production-activated)
 ```
 
 Ledger 契約ドラフト:
@@ -559,7 +560,7 @@ docs/mvp-3-approval-ledger-contract-v1.md
 docs/mvp-3-approval-ledger-identity-v1.md
 ```
 
-契約上の追加 invariant（design-only）:
+契約上の追加 invariant:
 
 ```text
 stable decision fingerprint（observedAt は audit metadata。canonical から分離）
@@ -570,15 +571,18 @@ principal identity = issuer + subjectId（subjectId alone is not globally stable
 browser-supplied approverId/email/displayName must not establish identity
 JWT fail-closed validation required before any future privileged Ledger write
 displayName/email persistence NOT REQUIRED until PII retention is resolved
-fingerprint canonicalization / idempotency / auth implementation = NOT AUTHORIZED
+authenticated ≠ authorized to write Ledger
+fingerprint canonicalization / idempotency / authorization allowlist = NOT AUTHORIZED
 ```
 
 ただし:
 
 ```text
 Ledger persistence Implementation Start = NOT AUTHORIZED
-authentication / authorization implementation = NOT AUTHORIZED
-backend mutation API = NOT AUTHORIZED
+Cloudflare Access configuration = NOT AUTHORIZED
+production auth boundary activation = NOT AUTHORIZED
+authorization allowlist implementation = NOT AUTHORIZED
+backend approval mutation API = NOT AUTHORIZED
 real persistence / write = NOT AUTHORIZED
 Action Gateway / Agent execution = NOT AUTHORIZED
 ```

--- a/docs/mvp-3-approval-ledger-identity-v1.md
+++ b/docs/mvp-3-approval-ledger-identity-v1.md
@@ -237,9 +237,9 @@ MUST NOT be included in `decisionFingerprint`.
 
 ---
 
-## 7. JWT validation contract (fail-closed; not implemented)
+## 7. JWT validation contract (fail-closed)
 
-For any future privileged Ledger request, the trusted server boundary MUST verify at least:
+For any privileged Ledger request, the trusted server boundary MUST verify at least:
 
 ```text
 JWT signature is valid
@@ -275,11 +275,20 @@ missing / empty subject
 => Ledger write forbidden
 ```
 
+Implementation status:
+
 ```text
-JWT validation implementation = NOT AUTHORIZED in this slice
+MVP-3-APPROVAL-LEDGER-AUTH-VERIFY-V1
+  = server-side Access JWT verifier + optional GET /api/auth/status
+  = IMPLEMENTED IN CODE (repository)
+
+Cloudflare Access configuration = NOT AUTHORIZED
+production authentication boundary activation = NOT AUTHORIZED
+authorization allowlist = NOT AUTHORIZED
+Approval Ledger persistence = NOT AUTHORIZED
 ```
 
-This section defines the contract only. It does not add runtime validation code.
+Authentication verification ≠ authorization to write the Ledger.
 
 ---
 
@@ -583,13 +592,14 @@ src/** / test/** mutation
 ```text
 A. CONTRACT-V1     = MERGED (design)
 B. IDENTITY-V1     = this document (design-only)
+B2. AUTH-VERIFY-V1 = Access JWT verifier in code — Access config / prod activation NOT AUTHORIZED
 C. PERSIST-V1      = durable write/read — NOT AUTHORIZED
-   (+ auth enforcement implementation GO required before/with C)
+   (+ authorization allowlist GO required before/with C)
 D. Action Gateway  = NOT AUTHORIZED
 E. GitHub write    = NOT AUTHORIZED
 ```
 
-IDENTITY-V1 design acceptance does **not** authorize PERSIST-V1 or auth implementation.
+IDENTITY-V1 / AUTH-VERIFY-V1 do **not** authorize PERSIST-V1, Access configuration, or ledger.write.
 
 ---
 
@@ -614,11 +624,12 @@ IDENTITY-V1 design acceptance does **not** authorize PERSIST-V1 or auth implemen
 ```text
 Approval Intent UI             = IMPLEMENTED (local ephemeral)
 Approval Ledger CONTRACT-V1    = DESIGN (merged)
-Approval Ledger IDENTITY-V1    = DESIGN ONLY (this doc)
-Authentication implementation  = 0 / NOT AUTHORIZED
-Authorization implementation   = 0 / NOT AUTHORIZED
+Approval Ledger IDENTITY-V1    = DESIGN (merged)
+Access JWT verifier (code)     = AUTH-VERIFY-V1 (repo code; not production-activated)
+Cloudflare Access configuration = 0 / NOT AUTHORIZED
+Authorization allowlist        = 0 / NOT AUTHORIZED
 Approval Ledger persist        = 0 / NOT AUTHORIZED
-Backend approval API           = 0
+Backend approval mutation API  = 0
 GitHub write                   = 0
 SharePoint mutation            = 0
 Action Gateway                 = 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@cloudflare/vite-plugin": "latest",
+        "jose": "^6.2.8",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2360,6 +2361,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "latest",
+    "jose": "^6.2.8",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/worker/auth/accessJwtVerifier.ts
+++ b/src/worker/auth/accessJwtVerifier.ts
@@ -1,0 +1,184 @@
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+} from "jose";
+
+/**
+ * Scoped Human principal after fail-closed Access JWT verification.
+ * displayName / email are intentionally omitted from the trusted principal.
+ */
+export type AuthenticatedHumanPrincipal = {
+  issuer: string;
+  subjectId: string;
+};
+
+export type AccessVerifierConfig = {
+  /** Exact expected JWT `iss` (e.g. https://<team>.cloudflareaccess.com). */
+  expectedIssuer: string;
+  /** Expected Access application audience (`aud`). */
+  expectedAudience: string;
+};
+
+export type AccessVerifyFailureReason =
+  | "MISSING_CONFIGURATION"
+  | "MISSING_TOKEN"
+  | "INVALID_SIGNATURE"
+  | "UNEXPECTED_ISSUER"
+  | "UNEXPECTED_AUDIENCE"
+  | "EXPIRED"
+  | "NOT_YET_VALID"
+  | "MISSING_SUBJECT"
+  | "NON_HUMAN_PRINCIPAL"
+  | "INVALID_TOKEN";
+
+export type AccessVerifyResult =
+  | { ok: true; principal: AuthenticatedHumanPrincipal }
+  | { ok: false; reason: AccessVerifyFailureReason };
+
+export type AccessKeyResolver = JWTVerifyGetKey | CryptoKey | Uint8Array;
+
+const ACCESS_JWT_HEADER = "cf-access-jwt-assertion";
+
+/**
+ * Extract Cloudflare Access JWT from the request.
+ * Browser query/body identity fields are never consulted.
+ */
+export function extractAccessJwt(request: Request): string | null {
+  const header = request.headers.get(ACCESS_JWT_HEADER);
+  if (!header) return null;
+  const token = header.trim();
+  return token.length > 0 ? token : null;
+}
+
+export function isAccessVerifierConfigured(config: Partial<AccessVerifierConfig> | null | undefined): boolean {
+  return Boolean(
+    config?.expectedIssuer &&
+      config.expectedIssuer.trim() &&
+      config.expectedAudience &&
+      config.expectedAudience.trim(),
+  );
+}
+
+/**
+ * Cloudflare Access service tokens commonly carry `common_name`.
+ * Those are non-Human principals and must not approve.
+ */
+export function isNonHumanAccessPrincipal(payload: JWTPayload): boolean {
+  if (typeof payload.common_name === "string" && payload.common_name.length > 0) {
+    return true;
+  }
+  if (payload.type === "app") {
+    return true;
+  }
+  return false;
+}
+
+function normalizeConfig(config: AccessVerifierConfig): AccessVerifierConfig | null {
+  const expectedIssuer = config.expectedIssuer?.trim();
+  const expectedAudience = config.expectedAudience?.trim();
+  if (!expectedIssuer || !expectedAudience) return null;
+  return { expectedIssuer, expectedAudience };
+}
+
+function mapVerifyError(error: unknown): AccessVerifyFailureReason {
+  const code = typeof error === "object" && error && "code" in error ? String((error as { code?: string }).code) : "";
+  const message = error instanceof Error ? error.message : String(error);
+  const claim =
+    typeof error === "object" && error && "claim" in error
+      ? String((error as { claim?: string }).claim)
+      : "";
+
+  if (code === "ERR_JWT_EXPIRED") return "EXPIRED";
+  if (code === "ERR_JWT_CLAIM_VALIDATION_FAILED") {
+    if (claim === "iss" || /"iss"|iss claim/i.test(message)) return "UNEXPECTED_ISSUER";
+    if (claim === "aud" || /"aud"|aud claim/i.test(message)) return "UNEXPECTED_AUDIENCE";
+    if (claim === "nbf" || /"nbf"|nbf claim|not[\s-]?yet/i.test(message)) return "NOT_YET_VALID";
+    if (claim === "exp" || /"exp"|exp claim|timestamp check failed/i.test(message)) return "EXPIRED";
+    if (claim === "sub" || /"sub"|sub claim/i.test(message)) return "MISSING_SUBJECT";
+  }
+  if (code === "ERR_JWS_SIGNATURE_VERIFICATION_FAILED" || /signature verification failed/i.test(message)) {
+    return "INVALID_SIGNATURE";
+  }
+  if (/"iss"|unexpected.*"iss"/i.test(message)) return "UNEXPECTED_ISSUER";
+  if (/"aud"|unexpected.*"aud"/i.test(message)) return "UNEXPECTED_AUDIENCE";
+  if (/"nbf"|not yet valid/i.test(message)) return "NOT_YET_VALID";
+  if (/"exp"|jwt expired/i.test(message)) return "EXPIRED";
+  return "INVALID_TOKEN";
+}
+
+/**
+ * Fail-closed Cloudflare Access JWT verifier.
+ *
+ * Authentication only: a successful result means a Human principal was verified.
+ * It does NOT grant ledger.write authorization.
+ */
+export async function verifyAccessHumanJwt(
+  token: string | null | undefined,
+  config: AccessVerifierConfig,
+  keyResolver: AccessKeyResolver,
+): Promise<AccessVerifyResult> {
+  const normalized = normalizeConfig(config);
+  if (!normalized) {
+    return { ok: false, reason: "MISSING_CONFIGURATION" };
+  }
+
+  if (!token || !token.trim()) {
+    return { ok: false, reason: "MISSING_TOKEN" };
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, keyResolver, {
+      issuer: normalized.expectedIssuer,
+      audience: normalized.expectedAudience,
+      clockTolerance: 0,
+    });
+
+    const issuer = typeof payload.iss === "string" ? payload.iss.trim() : "";
+    if (!issuer || issuer !== normalized.expectedIssuer) {
+      return { ok: false, reason: "UNEXPECTED_ISSUER" };
+    }
+
+    const subjectId = typeof payload.sub === "string" ? payload.sub.trim() : "";
+    if (!subjectId) {
+      return { ok: false, reason: "MISSING_SUBJECT" };
+    }
+
+    if (isNonHumanAccessPrincipal(payload)) {
+      return { ok: false, reason: "NON_HUMAN_PRINCIPAL" };
+    }
+
+    return {
+      ok: true,
+      principal: {
+        issuer,
+        subjectId,
+      },
+    };
+  } catch (error) {
+    return { ok: false, reason: mapVerifyError(error) };
+  }
+}
+
+/**
+ * Build a JWKS resolver for a configured Access team issuer.
+ * Used at runtime when Access env is present; tests inject local keys instead.
+ */
+export function createAccessJwksResolver(expectedIssuer: string): JWTVerifyGetKey {
+  const issuer = expectedIssuer.trim().replace(/\/$/, "");
+  return createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`));
+}
+
+export function accessVerifierConfigFromEnv(env: {
+  ACCESS_TEAM_DOMAIN?: string;
+  ACCESS_AUD?: string;
+}): AccessVerifierConfig | null {
+  const expectedIssuer = env.ACCESS_TEAM_DOMAIN?.trim();
+  const expectedAudience = env.ACCESS_AUD?.trim();
+  if (!expectedIssuer || !expectedAudience) return null;
+  return {
+    expectedIssuer: expectedIssuer.replace(/\/$/, ""),
+    expectedAudience,
+  };
+}

--- a/src/worker/auth/accessJwtVerifier.ts
+++ b/src/worker/auth/accessJwtVerifier.ts
@@ -40,6 +40,10 @@ export type AccessVerifyResult =
 export type AccessKeyResolver = JWTVerifyGetKey | CryptoKey | Uint8Array;
 
 const ACCESS_JWT_HEADER = "cf-access-jwt-assertion";
+const ACCESS_SIGNING_ALGORITHMS = ["RS256"] as const;
+
+/** Issuer-keyed cache so the same trusted issuer reuses one remote JWKS resolver. */
+const jwksResolverByIssuer = new Map<string, JWTVerifyGetKey>();
 
 /**
  * Extract Cloudflare Access JWT from the request.
@@ -62,22 +66,20 @@ export function isAccessVerifierConfigured(config: Partial<AccessVerifierConfig>
 }
 
 /**
- * Cloudflare Access service tokens commonly carry `common_name`.
- * Those are non-Human principals and must not approve.
+ * Cloudflare Access service tokens carry a non-empty `common_name`.
+ * `type: "app"` is NOT a discriminator — Human application JWTs also use it.
  */
 export function isNonHumanAccessPrincipal(payload: JWTPayload): boolean {
-  if (typeof payload.common_name === "string" && payload.common_name.length > 0) {
-    return true;
-  }
-  if (payload.type === "app") {
-    return true;
-  }
-  return false;
+  return typeof payload.common_name === "string" && payload.common_name.trim().length > 0;
+}
+
+function normalizeIssuer(issuer: string): string {
+  return issuer.trim().replace(/\/$/, "");
 }
 
 function normalizeConfig(config: AccessVerifierConfig): AccessVerifierConfig | null {
-  const expectedIssuer = config.expectedIssuer?.trim();
-  const expectedAudience = config.expectedAudience?.trim();
+  const expectedIssuer = config.expectedIssuer ? normalizeIssuer(config.expectedIssuer) : "";
+  const expectedAudience = config.expectedAudience?.trim() ?? "";
   if (!expectedIssuer || !expectedAudience) return null;
   return { expectedIssuer, expectedAudience };
 }
@@ -132,10 +134,11 @@ export async function verifyAccessHumanJwt(
     const { payload } = await jwtVerify(token, keyResolver, {
       issuer: normalized.expectedIssuer,
       audience: normalized.expectedAudience,
+      algorithms: [...ACCESS_SIGNING_ALGORITHMS],
       clockTolerance: 0,
     });
 
-    const issuer = typeof payload.iss === "string" ? payload.iss.trim() : "";
+    const issuer = typeof payload.iss === "string" ? normalizeIssuer(payload.iss) : "";
     if (!issuer || issuer !== normalized.expectedIssuer) {
       return { ok: false, reason: "UNEXPECTED_ISSUER" };
     }
@@ -162,12 +165,27 @@ export async function verifyAccessHumanJwt(
 }
 
 /**
- * Build a JWKS resolver for a configured Access team issuer.
- * Used at runtime when Access env is present; tests inject local keys instead.
+ * Return a cached remote JWKS resolver for the configured trusted issuer.
+ * JWKS URL is derived only from configured issuer — never from untrusted JWT claims.
  */
-export function createAccessJwksResolver(expectedIssuer: string): JWTVerifyGetKey {
-  const issuer = expectedIssuer.trim().replace(/\/$/, "");
-  return createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`));
+export function getAccessJwksResolver(expectedIssuer: string): JWTVerifyGetKey {
+  const issuer = normalizeIssuer(expectedIssuer);
+  const cached = jwksResolverByIssuer.get(issuer);
+  if (cached) return cached;
+
+  const resolver = createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`));
+  jwksResolverByIssuer.set(issuer, resolver);
+  return resolver;
+}
+
+/** Test helper: clear issuer-keyed JWKS cache. */
+export function clearAccessJwksResolverCache(): void {
+  jwksResolverByIssuer.clear();
+}
+
+/** Test helper: inspect whether an issuer already has a cached resolver. */
+export function hasCachedAccessJwksResolver(expectedIssuer: string): boolean {
+  return jwksResolverByIssuer.has(normalizeIssuer(expectedIssuer));
 }
 
 export function accessVerifierConfigFromEnv(env: {
@@ -178,7 +196,7 @@ export function accessVerifierConfigFromEnv(env: {
   const expectedAudience = env.ACCESS_AUD?.trim();
   if (!expectedIssuer || !expectedAudience) return null;
   return {
-    expectedIssuer: expectedIssuer.replace(/\/$/, ""),
+    expectedIssuer: normalizeIssuer(expectedIssuer),
     expectedAudience,
   };
 }

--- a/src/worker/auth/authStatus.ts
+++ b/src/worker/auth/authStatus.ts
@@ -1,0 +1,49 @@
+import {
+  accessVerifierConfigFromEnv,
+  extractAccessJwt,
+  getAccessJwksResolver,
+  verifyAccessHumanJwt,
+  type AccessKeyResolver,
+} from "./accessJwtVerifier";
+
+export type AuthStatusEnv = {
+  ACCESS_TEAM_DOMAIN?: string;
+  ACCESS_AUD?: string;
+};
+
+function unauthorizedAuthStatus(): Response {
+  return Response.json(
+    { authenticated: false },
+    {
+      status: 401,
+      headers: { "Cache-Control": "no-store" },
+    },
+  );
+}
+
+/**
+ * READ-ONLY auth probe.
+ * Authentication verification only — never grants ledger.write authorization.
+ *
+ * `keyResolver` is injectable for tests; production uses cached Access JWKS.
+ */
+export async function handleAuthStatus(
+  request: Request,
+  env: AuthStatusEnv,
+  keyResolver?: AccessKeyResolver,
+): Promise<Response> {
+  const config = accessVerifierConfigFromEnv(env);
+  if (!config) return unauthorizedAuthStatus();
+
+  const token = extractAccessJwt(request);
+  const resolver = keyResolver ?? getAccessJwksResolver(config.expectedIssuer);
+  const result = await verifyAccessHumanJwt(token, config, resolver);
+
+  if (!result.ok) return unauthorizedAuthStatus();
+
+  // Do not expose issuer/subjectId/email/displayName on this probe.
+  return Response.json(
+    { authenticated: true },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,16 +1,64 @@
 import { resolveHumanAction } from "../domain/humanActionResolver";
+import {
+  accessVerifierConfigFromEnv,
+  createAccessJwksResolver,
+  extractAccessJwt,
+  verifyAccessHumanJwt,
+} from "./auth/accessJwtVerifier";
 import { observeRepository } from "./github/readOnlyAdapter";
 
 interface Env {
   ASSETS: { fetch(request: Request): Promise<Response> };
   GITHUB_TOKEN?: string;
+  /** Cloudflare Access team domain / JWT issuer. Optional until Access is configured. */
+  ACCESS_TEAM_DOMAIN?: string;
+  /** Cloudflare Access application audience tag. Optional until Access is configured. */
+  ACCESS_AUD?: string;
 }
 
 const TARGET_REPOSITORY = "yasutakesougo/severe-behavior-support-spfx";
 
+function unauthorizedAuthStatus(): Response {
+  return Response.json(
+    { authenticated: false },
+    {
+      status: 401,
+      headers: { "Cache-Control": "no-store" },
+    },
+  );
+}
+
+/**
+ * READ-ONLY auth probe.
+ * Authentication verification only — never grants ledger.write authorization.
+ */
+async function handleAuthStatus(request: Request, env: Env): Promise<Response> {
+  const config = accessVerifierConfigFromEnv(env);
+  if (!config) return unauthorizedAuthStatus();
+
+  const token = extractAccessJwt(request);
+  const result = await verifyAccessHumanJwt(
+    token,
+    config,
+    createAccessJwksResolver(config.expectedIssuer),
+  );
+
+  if (!result.ok) return unauthorizedAuthStatus();
+
+  // Do not expose issuer/subjectId/email/displayName on this probe.
+  return Response.json(
+    { authenticated: true },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/api/auth/status") {
+      return handleAuthStatus(request, env);
+    }
 
     if (request.method === "GET" && url.pathname === "/api/status") {
       const facts = await observeRepository(TARGET_REPOSITORY, env);

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,10 +1,5 @@
 import { resolveHumanAction } from "../domain/humanActionResolver";
-import {
-  accessVerifierConfigFromEnv,
-  createAccessJwksResolver,
-  extractAccessJwt,
-  verifyAccessHumanJwt,
-} from "./auth/accessJwtVerifier";
+import { handleAuthStatus } from "./auth/authStatus";
 import { observeRepository } from "./github/readOnlyAdapter";
 
 interface Env {
@@ -17,40 +12,6 @@ interface Env {
 }
 
 const TARGET_REPOSITORY = "yasutakesougo/severe-behavior-support-spfx";
-
-function unauthorizedAuthStatus(): Response {
-  return Response.json(
-    { authenticated: false },
-    {
-      status: 401,
-      headers: { "Cache-Control": "no-store" },
-    },
-  );
-}
-
-/**
- * READ-ONLY auth probe.
- * Authentication verification only — never grants ledger.write authorization.
- */
-async function handleAuthStatus(request: Request, env: Env): Promise<Response> {
-  const config = accessVerifierConfigFromEnv(env);
-  if (!config) return unauthorizedAuthStatus();
-
-  const token = extractAccessJwt(request);
-  const result = await verifyAccessHumanJwt(
-    token,
-    config,
-    createAccessJwksResolver(config.expectedIssuer),
-  );
-
-  if (!result.ok) return unauthorizedAuthStatus();
-
-  // Do not expose issuer/subjectId/email/displayName on this probe.
-  return Response.json(
-    { authenticated: true },
-    { headers: { "Cache-Control": "no-store" } },
-  );
-}
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {

--- a/test/accessJwtVerifier.test.ts
+++ b/test/accessJwtVerifier.test.ts
@@ -2,11 +2,15 @@ import { generateKeyPair, SignJWT, type JWTPayload } from "jose";
 import { describe, expect, it } from "vitest";
 import {
   accessVerifierConfigFromEnv,
+  clearAccessJwksResolverCache,
+  getAccessJwksResolver,
+  hasCachedAccessJwksResolver,
   isAccessVerifierConfigured,
   isNonHumanAccessPrincipal,
   verifyAccessHumanJwt,
   type AccessVerifierConfig,
 } from "../src/worker/auth/accessJwtVerifier";
+import { handleAuthStatus } from "../src/worker/auth/authStatus";
 
 const ISSUER = "https://example.cloudflareaccess.com";
 const AUDIENCE = "test-access-aud-tag";
@@ -18,21 +22,33 @@ const config: AccessVerifierConfig = {
 
 type SyntheticKeyPair = Awaited<ReturnType<typeof generateKeyPair>>;
 
-async function makeKeys(): Promise<SyntheticKeyPair> {
-  return generateKeyPair("RS256");
+async function makeKeys(alg: "RS256" | "ES256" = "RS256"): Promise<SyntheticKeyPair> {
+  return generateKeyPair(alg);
 }
 
 async function signToken(
   privateKey: SyntheticKeyPair["privateKey"],
   claims: JWTPayload,
-  options?: { exp?: string | number | Date; nbf?: string | number | Date; audience?: string | string[] },
+  options?: {
+    alg?: "RS256" | "ES256";
+    exp?: string | number | Date;
+    nbf?: string | number | Date;
+    audience?: string | string[];
+    issuer?: string;
+    includeSubjectClaim?: boolean;
+  },
 ): Promise<string> {
+  const alg = options?.alg ?? "RS256";
+  const includeSubject = options?.includeSubjectClaim !== false;
   let builder = new SignJWT(claims)
-    .setProtectedHeader({ alg: "RS256" })
-    .setIssuer(ISSUER)
+    .setProtectedHeader({ alg })
+    .setIssuer(options?.issuer ?? ISSUER)
     .setAudience(options?.audience ?? AUDIENCE)
-    .setSubject(typeof claims.sub === "string" ? claims.sub : "human-subject-1")
     .setIssuedAt();
+
+  if (includeSubject) {
+    builder = builder.setSubject(typeof claims.sub === "string" ? claims.sub : "human-subject-1");
+  }
 
   if (options?.exp !== undefined) builder = builder.setExpirationTime(options.exp);
   else builder = builder.setExpirationTime("5m");
@@ -43,9 +59,13 @@ async function signToken(
 }
 
 describe("verifyAccessHumanJwt", () => {
-  it("accepts a valid Human JWT and returns issuer + subjectId", async () => {
+  it("accepts a valid Human application JWT with type=app", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await signToken(privateKey, { sub: "human-subject-1", email: "human@example.com" });
+    const token = await signToken(privateKey, {
+      type: "app",
+      sub: "human-subject-1",
+      email: "human@example.com",
+    });
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
 
@@ -53,6 +73,7 @@ describe("verifyAccessHumanJwt", () => {
       ok: true,
       principal: { issuer: ISSUER, subjectId: "human-subject-1" },
     });
+    expect(isNonHumanAccessPrincipal({ type: "app", sub: "human-subject-1" })).toBe(false);
   });
 
   it("denies a missing token", async () => {
@@ -64,7 +85,7 @@ describe("verifyAccessHumanJwt", () => {
   it("denies an invalid signature", async () => {
     const { privateKey } = await makeKeys();
     const other = await makeKeys();
-    const token = await signToken(privateKey, { sub: "human-subject-1" });
+    const token = await signToken(privateKey, { type: "app", sub: "human-subject-1" });
 
     const result = await verifyAccessHumanJwt(token, config, other.publicKey);
     expect(result.ok).toBe(false);
@@ -73,14 +94,11 @@ describe("verifyAccessHumanJwt", () => {
 
   it("denies an unexpected issuer", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await new SignJWT({ sub: "human-subject-1" })
-      .setProtectedHeader({ alg: "RS256" })
-      .setIssuer("https://other.cloudflareaccess.com")
-      .setAudience(AUDIENCE)
-      .setSubject("human-subject-1")
-      .setIssuedAt()
-      .setExpirationTime("5m")
-      .sign(privateKey);
+    const token = await signToken(
+      privateKey,
+      { type: "app", sub: "human-subject-1" },
+      { issuer: "https://other.cloudflareaccess.com" },
+    );
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
     expect(result.ok).toBe(false);
@@ -89,7 +107,11 @@ describe("verifyAccessHumanJwt", () => {
 
   it("denies an unexpected audience", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await signToken(privateKey, { sub: "human-subject-1" }, { audience: "wrong-aud" });
+    const token = await signToken(
+      privateKey,
+      { type: "app", sub: "human-subject-1" },
+      { audience: "wrong-aud" },
+    );
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
     expect(result.ok).toBe(false);
@@ -98,7 +120,11 @@ describe("verifyAccessHumanJwt", () => {
 
   it("denies an expired token", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await signToken(privateKey, { sub: "human-subject-1" }, { exp: "-1s" });
+    const token = await signToken(
+      privateKey,
+      { type: "app", sub: "human-subject-1" },
+      { exp: "-1s" },
+    );
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
     expect(result.ok).toBe(false);
@@ -107,7 +133,11 @@ describe("verifyAccessHumanJwt", () => {
 
   it("denies a not-yet-valid token", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await signToken(privateKey, { sub: "human-subject-1" }, { nbf: "1h" });
+    const token = await signToken(
+      privateKey,
+      { type: "app", sub: "human-subject-1" },
+      { nbf: "1h" },
+    );
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
     expect(result.ok).toBe(false);
@@ -116,13 +146,7 @@ describe("verifyAccessHumanJwt", () => {
 
   it("denies a missing subject", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await new SignJWT({})
-      .setProtectedHeader({ alg: "RS256" })
-      .setIssuer(ISSUER)
-      .setAudience(AUDIENCE)
-      .setIssuedAt()
-      .setExpirationTime("5m")
-      .sign(privateKey);
+    const token = await signToken(privateKey, { type: "app" }, { includeSubjectClaim: false });
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
     expect(result.ok).toBe(false);
@@ -131,43 +155,138 @@ describe("verifyAccessHumanJwt", () => {
 
   it("denies an empty subject", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await new SignJWT({ sub: "   " })
-      .setProtectedHeader({ alg: "RS256" })
-      .setIssuer(ISSUER)
-      .setAudience(AUDIENCE)
-      .setSubject("   ")
-      .setIssuedAt()
-      .setExpirationTime("5m")
-      .sign(privateKey);
+    const token = await signToken(privateKey, { type: "app", sub: "" });
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("MISSING_SUBJECT");
   });
 
-  it("denies a service-token / non-Human principal", async () => {
+  it("denies a documented service-token shape even when type=app", async () => {
     const { privateKey, publicKey } = await makeKeys();
     const token = await signToken(privateKey, {
+      type: "app",
+      common_name: "service-client-id.access",
+      sub: "",
+    });
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(["MISSING_SUBJECT", "NON_HUMAN_PRINCIPAL"]).toContain(result.reason);
+    }
+    expect(isNonHumanAccessPrincipal({ type: "app", common_name: "service-client-id.access", sub: "" })).toBe(
+      true,
+    );
+    expect(isNonHumanAccessPrincipal({ type: "app", sub: "human-subject-1" })).toBe(false);
+  });
+
+  it("denies a service-token with common_name even if sub is present", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, {
+      type: "app",
+      common_name: "service-client-id.access",
       sub: "service-client-id",
-      common_name: "ci-service-token",
     });
 
     const result = await verifyAccessHumanJwt(token, config, publicKey);
     expect(result).toEqual({ ok: false, reason: "NON_HUMAN_PRINCIPAL" });
-    expect(isNonHumanAccessPrincipal({ common_name: "ci-service-token" })).toBe(true);
+  });
+
+  it("denies a non-RS256 algorithm even when otherwise well-formed", async () => {
+    const { privateKey, publicKey } = await makeKeys("ES256");
+    const token = await signToken(
+      privateKey,
+      { type: "app", sub: "human-subject-1", email: "human@example.com" },
+      { alg: "ES256" },
+    );
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
   });
 
   it("denies missing verifier configuration", async () => {
     const { privateKey, publicKey } = await makeKeys();
-    const token = await signToken(privateKey, { sub: "human-subject-1" });
+    const token = await signToken(privateKey, { type: "app", sub: "human-subject-1" });
 
-    const result = await verifyAccessHumanJwt(token, {
-      expectedIssuer: "",
-      expectedAudience: AUDIENCE,
-    }, publicKey);
+    const result = await verifyAccessHumanJwt(
+      token,
+      {
+        expectedIssuer: "",
+        expectedAudience: AUDIENCE,
+      },
+      publicKey,
+    );
 
     expect(result).toEqual({ ok: false, reason: "MISSING_CONFIGURATION" });
     expect(isAccessVerifierConfigured({ expectedIssuer: "", expectedAudience: AUDIENCE })).toBe(false);
     expect(accessVerifierConfigFromEnv({})).toBeNull();
+  });
+
+  it("reuses the remote JWKS resolver for the same trusted issuer", () => {
+    clearAccessJwksResolverCache();
+    const first = getAccessJwksResolver(ISSUER);
+    const second = getAccessJwksResolver(`${ISSUER}/`);
+    const other = getAccessJwksResolver("https://other.cloudflareaccess.com");
+
+    expect(first).toBe(second);
+    expect(other).not.toBe(first);
+    expect(hasCachedAccessJwksResolver(ISSUER)).toBe(true);
+    expect(hasCachedAccessJwksResolver("https://other.cloudflareaccess.com")).toBe(true);
+    clearAccessJwksResolverCache();
+  });
+});
+
+describe("GET /api/auth/status probe", () => {
+  it("returns 401 when configuration is missing", async () => {
+    const response = await handleAuthStatus(new Request("https://example.test/api/auth/status"), {});
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toEqual({ authenticated: false });
+    expect(body).not.toHaveProperty("issuer");
+    expect(body).not.toHaveProperty("subjectId");
+    expect(body).not.toHaveProperty("email");
+    expect(body).not.toHaveProperty("displayName");
+  });
+
+  it("returns 401 for an invalid token", async () => {
+    const { publicKey } = await makeKeys();
+    const response = await handleAuthStatus(
+      new Request("https://example.test/api/auth/status", {
+        headers: { "Cf-Access-Jwt-Assertion": "not-a-jwt" },
+      }),
+      { ACCESS_TEAM_DOMAIN: ISSUER, ACCESS_AUD: AUDIENCE },
+      publicKey,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toEqual({ authenticated: false });
+  });
+
+  it("returns 200 for a valid Human token without identity fields", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, {
+      type: "app",
+      sub: "human-subject-1",
+      email: "human@example.com",
+    });
+
+    const response = await handleAuthStatus(
+      new Request("https://example.test/api/auth/status", {
+        headers: { "Cf-Access-Jwt-Assertion": token },
+      }),
+      { ACCESS_TEAM_DOMAIN: ISSUER, ACCESS_AUD: AUDIENCE },
+      publicKey,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toEqual({ authenticated: true });
+    expect(Object.keys(body as object).sort()).toEqual(["authenticated"]);
   });
 });

--- a/test/accessJwtVerifier.test.ts
+++ b/test/accessJwtVerifier.test.ts
@@ -1,0 +1,173 @@
+import { generateKeyPair, SignJWT, type JWTPayload } from "jose";
+import { describe, expect, it } from "vitest";
+import {
+  accessVerifierConfigFromEnv,
+  isAccessVerifierConfigured,
+  isNonHumanAccessPrincipal,
+  verifyAccessHumanJwt,
+  type AccessVerifierConfig,
+} from "../src/worker/auth/accessJwtVerifier";
+
+const ISSUER = "https://example.cloudflareaccess.com";
+const AUDIENCE = "test-access-aud-tag";
+
+const config: AccessVerifierConfig = {
+  expectedIssuer: ISSUER,
+  expectedAudience: AUDIENCE,
+};
+
+type SyntheticKeyPair = Awaited<ReturnType<typeof generateKeyPair>>;
+
+async function makeKeys(): Promise<SyntheticKeyPair> {
+  return generateKeyPair("RS256");
+}
+
+async function signToken(
+  privateKey: SyntheticKeyPair["privateKey"],
+  claims: JWTPayload,
+  options?: { exp?: string | number | Date; nbf?: string | number | Date; audience?: string | string[] },
+): Promise<string> {
+  let builder = new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuer(ISSUER)
+    .setAudience(options?.audience ?? AUDIENCE)
+    .setSubject(typeof claims.sub === "string" ? claims.sub : "human-subject-1")
+    .setIssuedAt();
+
+  if (options?.exp !== undefined) builder = builder.setExpirationTime(options.exp);
+  else builder = builder.setExpirationTime("5m");
+
+  if (options?.nbf !== undefined) builder = builder.setNotBefore(options.nbf);
+
+  return builder.sign(privateKey);
+}
+
+describe("verifyAccessHumanJwt", () => {
+  it("accepts a valid Human JWT and returns issuer + subjectId", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { sub: "human-subject-1", email: "human@example.com" });
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+
+    expect(result).toEqual({
+      ok: true,
+      principal: { issuer: ISSUER, subjectId: "human-subject-1" },
+    });
+  });
+
+  it("denies a missing token", async () => {
+    const { publicKey } = await makeKeys();
+    const result = await verifyAccessHumanJwt(null, config, publicKey);
+    expect(result).toEqual({ ok: false, reason: "MISSING_TOKEN" });
+  });
+
+  it("denies an invalid signature", async () => {
+    const { privateKey } = await makeKeys();
+    const other = await makeKeys();
+    const token = await signToken(privateKey, { sub: "human-subject-1" });
+
+    const result = await verifyAccessHumanJwt(token, config, other.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("INVALID_SIGNATURE");
+  });
+
+  it("denies an unexpected issuer", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await new SignJWT({ sub: "human-subject-1" })
+      .setProtectedHeader({ alg: "RS256" })
+      .setIssuer("https://other.cloudflareaccess.com")
+      .setAudience(AUDIENCE)
+      .setSubject("human-subject-1")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(privateKey);
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("UNEXPECTED_ISSUER");
+  });
+
+  it("denies an unexpected audience", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { sub: "human-subject-1" }, { audience: "wrong-aud" });
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("UNEXPECTED_AUDIENCE");
+  });
+
+  it("denies an expired token", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { sub: "human-subject-1" }, { exp: "-1s" });
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("EXPIRED");
+  });
+
+  it("denies a not-yet-valid token", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { sub: "human-subject-1" }, { nbf: "1h" });
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("NOT_YET_VALID");
+  });
+
+  it("denies a missing subject", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: "RS256" })
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(privateKey);
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("MISSING_SUBJECT");
+  });
+
+  it("denies an empty subject", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await new SignJWT({ sub: "   " })
+      .setProtectedHeader({ alg: "RS256" })
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setSubject("   ")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(privateKey);
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("MISSING_SUBJECT");
+  });
+
+  it("denies a service-token / non-Human principal", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, {
+      sub: "service-client-id",
+      common_name: "ci-service-token",
+    });
+
+    const result = await verifyAccessHumanJwt(token, config, publicKey);
+    expect(result).toEqual({ ok: false, reason: "NON_HUMAN_PRINCIPAL" });
+    expect(isNonHumanAccessPrincipal({ common_name: "ci-service-token" })).toBe(true);
+  });
+
+  it("denies missing verifier configuration", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { sub: "human-subject-1" });
+
+    const result = await verifyAccessHumanJwt(token, {
+      expectedIssuer: "",
+      expectedAudience: AUDIENCE,
+    }, publicKey);
+
+    expect(result).toEqual({ ok: false, reason: "MISSING_CONFIGURATION" });
+    expect(isAccessVerifierConfigured({ expectedIssuer: "", expectedAudience: AUDIENCE })).toBe(false);
+    expect(accessVerifierConfigFromEnv({})).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Slice

`MVP-3-APPROVAL-LEDGER-AUTH-VERIFY-V1`

```text
AUTH VERIFICATION ONLY

authentication verification = IMPLEMENTED IN CODE

authorization = NOT IMPLEMENTED
Approval Ledger persistence = NOT AUTHORIZED
Cloudflare Access configuration = NOT AUTHORIZED
production deploy = NOT AUTHORIZED

Action Gateway = 0
GitHub write = 0
```

## Baseline

```text
main / base = 8dec92469c777223d9c038cf70715826d7b202e7
```

## Follow-up corrections

1. **Human/service classification**
   - Removed `type === "app"` rejection (`type=app` is shared by Human + service tokens)
   - Service denial via non-empty `common_name` (+ blank/missing `sub`)
   - Human fixture includes `{ type: "app", sub, email }` => PASS

2. **RS256 only**
   - `jwtVerify({ algorithms: ["RS256"] })`
   - non-RS256 signed token => DENY

3. **JWKS resolver reuse**
   - issuer-keyed cache via `getAccessJwksResolver`
   - JWKS URL derived only from configured trusted issuer

4. **Probe regressions**
   - missing config / invalid token => `401 { authenticated: false }`
   - valid Human => `200 { authenticated: true }`
   - `Cache-Control: no-store`
   - no issuer/subjectId/email/displayName in body
   - `/api/status` remains ungated

## Verification

```text
npm run verify: PASS
  vitest run: 56 / 56 PASS
```

```text
Human JWT with type=app => PASS
service JWT with type=app + common_name/blank sub => DENY
non-RS256 => DENY
JWKS resolver reuse => PRESENT
GET /api/auth/status valid Human => 200
GET /api/auth/status invalid/missing => 401
/api/status semantics unchanged
persistence capability = 0
external write capability = 0
Cloudflare config mutation = 0
production deploy = 0
```

## STOP

- Draft 維持
- Ready / Merge しない
- Access config / PERSIST / authorization を開始しない

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-544de248-85b7-488e-b4de-0e9dc091d8ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-544de248-85b7-488e-b4de-0e9dc091d8ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

