### PR TITLE
feat(mvp3): MVP-3-APPROVAL-LEDGER-AUTHZ-V1 — deny-by-default Ledger authorization boundary

### DIFF
--- a/src/worker/auth/ledgerAuthorizer.ts
+++ b/src/worker/auth/ledgerAuthorizer.ts
@@ -1,0 +1,92 @@
+import type { AuthenticatedHumanPrincipal } from "./accessJwtVerifier";
+
+/**
+ * Explicit authorization boundary for the Approval Ledger.
+ *
+ * Authentication (verified Access JWT → issuer + subjectId) answers "who is this Human?".
+ * Authorization answers "may this Human use this Ledger capability?".
+ * The two are evaluated separately and both fail closed.
+ */
+export type LedgerCapability = "ledger.record" | "ledger.read";
+
+export type LedgerAuthzDenyReason =
+  /** No authorization policy is configured/available. Deny-by-default. */
+  | "AUTHZ_UNAVAILABLE"
+  /** A policy is available but does not grant this principal the capability. */
+  | "PRINCIPAL_NOT_AUTHORIZED";
+
+export type LedgerAuthzDecision =
+  | { allowed: true; capability: LedgerCapability; policy: string }
+  | { allowed: false; reason: LedgerAuthzDenyReason };
+
+/**
+ * Pluggable authorization policy.
+ *
+ * Implementations decide only from the trusted server-side principal
+ * (issuer + subjectId). Browser fields, query parameters, request-body identity,
+ * GitHub/PAT actors, displayName and email are never authorization proof.
+ */
+export interface LedgerAuthorizer {
+  authorize(
+    principal: AuthenticatedHumanPrincipal,
+    capability: LedgerCapability,
+  ): Promise<LedgerAuthzDecision>;
+}
+
+export const ACCESS_POLICY_AUTHZ_MODE = "access-policy";
+
+/**
+ * Coarse staging authorizer: delegate the allowlist to the Cloudflare Access
+ * application policy.
+ *
+ * Rationale: every principal reaching the Worker with a verified Human Access JWT
+ * was already admitted by the Access application policy for this app. This
+ * authorizer therefore grants Ledger capabilities to Human principals of the
+ * single configured trusted issuer, and nothing else.
+ *
+ * It is intentionally replaceable by a future principal/role policy
+ * (per-(issuer + subjectId) allowlist) behind the same LedgerAuthorizer interface.
+ */
+export class AccessPolicyLedgerAuthorizer implements LedgerAuthorizer {
+  readonly #trustedIssuer: string;
+
+  constructor(trustedIssuer: string) {
+    this.#trustedIssuer = trustedIssuer.trim().replace(/\/$/, "");
+  }
+
+  async authorize(
+    principal: AuthenticatedHumanPrincipal,
+    capability: LedgerCapability,
+  ): Promise<LedgerAuthzDecision> {
+    if (!this.#trustedIssuer) {
+      return { allowed: false, reason: "AUTHZ_UNAVAILABLE" };
+    }
+    if (!principal.subjectId || principal.issuer !== this.#trustedIssuer) {
+      return { allowed: false, reason: "PRINCIPAL_NOT_AUTHORIZED" };
+    }
+    return { allowed: true, capability, policy: ACCESS_POLICY_AUTHZ_MODE };
+  }
+}
+
+export type LedgerAuthzEnv = {
+  /**
+   * Explicit opt-in for an authorization policy. Unset / unrecognized values
+   * leave authorization unavailable, which denies every request.
+   */
+  LEDGER_AUTHZ_MODE?: string;
+  ACCESS_TEAM_DOMAIN?: string;
+};
+
+/**
+ * Resolve the configured authorizer. Returns null when no authorization policy
+ * is explicitly and completely configured — callers must treat null as DENY.
+ */
+export function ledgerAuthorizerFromEnv(env: LedgerAuthzEnv): LedgerAuthorizer | null {
+  const mode = env.LEDGER_AUTHZ_MODE?.trim();
+  if (mode !== ACCESS_POLICY_AUTHZ_MODE) return null;
+
+  const trustedIssuer = env.ACCESS_TEAM_DOMAIN?.trim();
+  if (!trustedIssuer) return null;
+
+  return new AccessPolicyLedgerAuthorizer(trustedIssuer);
+}

--- a/src/worker/auth/ledgerGuard.ts
+++ b/src/worker/auth/ledgerGuard.ts
@@ -1,0 +1,88 @@
+import {
+  accessVerifierConfigFromEnv,
+  extractAccessJwt,
+  getAccessJwksResolver,
+  verifyAccessHumanJwt,
+  type AccessKeyResolver,
+  type AccessVerifyFailureReason,
+  type AuthenticatedHumanPrincipal,
+} from "./accessJwtVerifier";
+import {
+  ledgerAuthorizerFromEnv,
+  type LedgerAuthzDecision,
+  type LedgerAuthzDenyReason,
+  type LedgerAuthzEnv,
+  type LedgerCapability,
+} from "./ledgerAuthorizer";
+
+export type LedgerGuardEnv = LedgerAuthzEnv & {
+  ACCESS_TEAM_DOMAIN?: string;
+  ACCESS_AUD?: string;
+};
+
+export type LedgerGuardResult =
+  | {
+      ok: true;
+      principal: AuthenticatedHumanPrincipal;
+      decision: Extract<LedgerAuthzDecision, { allowed: true }>;
+    }
+  | {
+      ok: false;
+      /** 401 = not authenticated, 403 = authenticated but not authorized. */
+      status: 401 | 403;
+      code: "UNAUTHENTICATED" | "FORBIDDEN";
+      reason: AccessVerifyFailureReason | LedgerAuthzDenyReason;
+    };
+
+/**
+ * Fail-closed authenticate → authorize gate for privileged Ledger requests.
+ *
+ * 1. Verify the Cloudflare Access JWT (issuer + audience + signature + Human).
+ * 2. Resolve the configured LedgerAuthorizer; missing policy denies (deny-by-default).
+ * 3. Ask the authorizer whether this scoped principal may use the capability.
+ *
+ * `keyResolver` is injectable for tests; production uses the cached Access JWKS.
+ */
+export async function requireLedgerCapability(
+  request: Request,
+  env: LedgerGuardEnv,
+  capability: LedgerCapability,
+  keyResolver?: AccessKeyResolver,
+): Promise<LedgerGuardResult> {
+  const config = accessVerifierConfigFromEnv(env);
+  if (!config) {
+    return { ok: false, status: 401, code: "UNAUTHENTICATED", reason: "MISSING_CONFIGURATION" };
+  }
+
+  const token = extractAccessJwt(request);
+  const resolver = keyResolver ?? getAccessJwksResolver(config.expectedIssuer);
+  const verified = await verifyAccessHumanJwt(token, config, resolver);
+  if (!verified.ok) {
+    return { ok: false, status: 401, code: "UNAUTHENTICATED", reason: verified.reason };
+  }
+
+  const authorizer = ledgerAuthorizerFromEnv(env);
+  if (!authorizer) {
+    return { ok: false, status: 403, code: "FORBIDDEN", reason: "AUTHZ_UNAVAILABLE" };
+  }
+
+  const decision = await authorizer.authorize(verified.principal, capability);
+  if (!decision.allowed) {
+    return { ok: false, status: 403, code: "FORBIDDEN", reason: decision.reason };
+  }
+
+  return { ok: true, principal: verified.principal, decision };
+}
+
+/**
+ * Uniform denial response. Never leaks principal identity fields, and keeps
+ * granular verification failure reasons server-side only.
+ */
+export function ledgerGuardDenialResponse(
+  result: Extract<LedgerGuardResult, { ok: false }>,
+): Response {
+  return Response.json(
+    { error: result.code },
+    { status: result.status, headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/test/ledgerAuthorizer.test.ts
+++ b/test/ledgerAuthorizer.test.ts
@@ -1,0 +1,232 @@
+import { generateKeyPair, SignJWT, type JWTPayload } from "jose";
+import { describe, expect, it } from "vitest";
+import {
+  AccessPolicyLedgerAuthorizer,
+  ledgerAuthorizerFromEnv,
+} from "../src/worker/auth/ledgerAuthorizer";
+import {
+  ledgerGuardDenialResponse,
+  requireLedgerCapability,
+  type LedgerGuardEnv,
+} from "../src/worker/auth/ledgerGuard";
+
+const ISSUER = "https://example.cloudflareaccess.com";
+const AUDIENCE = "test-access-aud-tag";
+
+const authzEnv: LedgerGuardEnv = {
+  ACCESS_TEAM_DOMAIN: ISSUER,
+  ACCESS_AUD: AUDIENCE,
+  LEDGER_AUTHZ_MODE: "access-policy",
+};
+
+type SyntheticKeyPair = Awaited<ReturnType<typeof generateKeyPair>>;
+
+async function makeKeys(): Promise<SyntheticKeyPair> {
+  return generateKeyPair("RS256");
+}
+
+async function signToken(
+  privateKey: SyntheticKeyPair["privateKey"],
+  claims: JWTPayload,
+): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(privateKey);
+}
+
+function requestWithToken(token?: string): Request {
+  return new Request("https://example.test/api/ledger/records", {
+    method: "POST",
+    headers: token ? { "Cf-Access-Jwt-Assertion": token } : undefined,
+  });
+}
+
+describe("requireLedgerCapability (authenticate → authorize)", () => {
+  it("DENY: unauthenticated request (no token)", async () => {
+    const { publicKey } = await makeKeys();
+    const result = await requireLedgerCapability(requestWithToken(), authzEnv, "ledger.record", publicKey);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.code).toBe("UNAUTHENTICATED");
+      expect(result.reason).toBe("MISSING_TOKEN");
+    }
+  });
+
+  it("DENY: invalid token (bad signature)", async () => {
+    const { privateKey } = await makeKeys();
+    const other = await makeKeys();
+    const token = await signToken(privateKey, { type: "app", sub: "human-subject-1" });
+
+    const result = await requireLedgerCapability(
+      requestWithToken(token),
+      authzEnv,
+      "ledger.record",
+      other.publicKey,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.reason).toBe("INVALID_SIGNATURE");
+    }
+  });
+
+  it("DENY: service principal (Access service token shape)", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, {
+      type: "app",
+      common_name: "service-client-id.access",
+      sub: "service-client-id",
+    });
+
+    const result = await requireLedgerCapability(requestWithToken(token), authzEnv, "ledger.record", publicKey);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.reason).toBe("NON_HUMAN_PRINCIPAL");
+    }
+  });
+
+  it("DENY: authentication valid but authorization unavailable (no LEDGER_AUTHZ_MODE)", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { type: "app", sub: "human-subject-1" });
+
+    const result = await requireLedgerCapability(
+      requestWithToken(token),
+      { ACCESS_TEAM_DOMAIN: ISSUER, ACCESS_AUD: AUDIENCE },
+      "ledger.record",
+      publicKey,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+      expect(result.code).toBe("FORBIDDEN");
+      expect(result.reason).toBe("AUTHZ_UNAVAILABLE");
+    }
+  });
+
+  it("DENY: unrecognized LEDGER_AUTHZ_MODE stays deny-by-default", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { type: "app", sub: "human-subject-1" });
+
+    const result = await requireLedgerCapability(
+      requestWithToken(token),
+      { ...authzEnv, LEDGER_AUTHZ_MODE: "allow-everyone" },
+      "ledger.record",
+      publicKey,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+      expect(result.reason).toBe("AUTHZ_UNAVAILABLE");
+    }
+  });
+
+  it("ALLOW: authorized Human gets ledger.record with scoped principal", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, {
+      type: "app",
+      sub: "human-subject-1",
+      email: "human@example.com",
+    });
+
+    const result = await requireLedgerCapability(requestWithToken(token), authzEnv, "ledger.record", publicKey);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principal).toEqual({ issuer: ISSUER, subjectId: "human-subject-1" });
+      expect(result.decision).toEqual({
+        allowed: true,
+        capability: "ledger.record",
+        policy: "access-policy",
+      });
+    }
+  });
+
+  it("denial response exposes only the coarse code, never identity or granular reason", async () => {
+    const { publicKey } = await makeKeys();
+    const result = await requireLedgerCapability(requestWithToken(), authzEnv, "ledger.record", publicKey);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    const response = ledgerGuardDenialResponse(result);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(body).toEqual({ error: "UNAUTHENTICATED" });
+    expect(body).not.toHaveProperty("issuer");
+    expect(body).not.toHaveProperty("subjectId");
+    expect(body).not.toHaveProperty("reason");
+  });
+});
+
+describe("LedgerAuthorizer policy layer", () => {
+  it("browser-supplied identity fields are never consulted for authorization", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signToken(privateKey, { type: "app", sub: "human-subject-1" });
+
+    const request = new Request(
+      "https://example.test/api/ledger/records?approver=attacker@example.com&subjectId=fake",
+      {
+        method: "POST",
+        headers: {
+          "Cf-Access-Jwt-Assertion": token,
+          "X-Approver-Email": "attacker@example.com",
+        },
+        body: JSON.stringify({ approver: { issuer: "https://evil.test", subjectId: "fake" } }),
+      },
+    );
+
+    const result = await requireLedgerCapability(request, authzEnv, "ledger.record", publicKey);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Principal comes only from the verified JWT, never from the request surface.
+      expect(result.principal).toEqual({ issuer: ISSUER, subjectId: "human-subject-1" });
+    }
+  });
+
+  it("denies a principal from a different issuer even when policy is enabled", async () => {
+    const authorizer = new AccessPolicyLedgerAuthorizer(ISSUER);
+    const decision = await authorizer.authorize(
+      { issuer: "https://other.cloudflareaccess.com", subjectId: "human-subject-1" },
+      "ledger.record",
+    );
+    expect(decision).toEqual({ allowed: false, reason: "PRINCIPAL_NOT_AUTHORIZED" });
+  });
+
+  it("denies an empty subjectId", async () => {
+    const authorizer = new AccessPolicyLedgerAuthorizer(ISSUER);
+    const decision = await authorizer.authorize({ issuer: ISSUER, subjectId: "" }, "ledger.record");
+    expect(decision).toEqual({ allowed: false, reason: "PRINCIPAL_NOT_AUTHORIZED" });
+  });
+
+  it("authorizes ledger.read under the same coarse Access policy", async () => {
+    const authorizer = new AccessPolicyLedgerAuthorizer(ISSUER);
+    const decision = await authorizer.authorize(
+      { issuer: ISSUER, subjectId: "human-subject-1" },
+      "ledger.read",
+    );
+    expect(decision).toEqual({ allowed: true, capability: "ledger.read", policy: "access-policy" });
+  });
+
+  it("ledgerAuthorizerFromEnv returns null unless mode and issuer are both configured", () => {
+    expect(ledgerAuthorizerFromEnv({})).toBeNull();
+    expect(ledgerAuthorizerFromEnv({ LEDGER_AUTHZ_MODE: "access-policy" })).toBeNull();
+    expect(ledgerAuthorizerFromEnv({ ACCESS_TEAM_DOMAIN: ISSUER })).toBeNull();
+    expect(
+      ledgerAuthorizerFromEnv({ LEDGER_AUTHZ_MODE: "access-policy", ACCESS_TEAM_DOMAIN: ISSUER }),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Slice

MVP-3-APPROVAL-LEDGER-AUTHZ-V1 (umbrella GO slice A)

## What

Adds an explicit authorization boundary, separate from authentication:

- `src/worker/auth/ledgerAuthorizer.ts`
  - `LedgerAuthorizer` interface: `(AuthenticatedHumanPrincipal, capability) → ALLOW/DENY`
  - `AccessPolicyLedgerAuthorizer`: coarse staging policy that delegates the allowlist to the Cloudflare Access application policy (Human principal of the single configured trusted issuer). Replaceable by a future principal/role policy behind the same interface.
  - `ledgerAuthorizerFromEnv`: requires explicit `LEDGER_AUTHZ_MODE=access-policy` + configured trusted issuer; anything else returns null → deny-by-default.
- `src/worker/auth/ledgerGuard.ts`
  - `requireLedgerCapability`: fail-closed authenticate → authorize gate (401 unauthenticated, 403 authenticated-but-not-authorized).
  - `ledgerGuardDenialResponse`: exposes only a coarse error code; no identity fields, no granular verification reasons.

No persistence, no new endpoints, no runtime wiring yet — the guard is the interface abstraction consumed by LEDGER-CORE-V1.

## Authorization proof rules

Only the verified Access JWT principal (issuer + subjectId) is consulted. Browser fields, query parameters, request-body identity, GitHub/PAT actors, displayName, and email are never authorization proof (covered by test).

## Tests (12 new; 68 total)

- unauthenticated ⇒ DENY (401)
- invalid token ⇒ DENY (401)
- service principal ⇒ DENY (401)
- auth valid but authorization unavailable ⇒ DENY (403 AUTHZ_UNAVAILABLE)
- unrecognized authz mode ⇒ DENY (deny-by-default)
- authorized Human ⇒ ALLOW ledger.record
- browser-supplied identity fields ignored
- cross-issuer / empty-subject principals denied at policy layer
- env factory null unless mode + issuer both configured

`npm run verify` = PASS.

## Non-effects

GitHub write / SharePoint mutation / Action Gateway / Agent execution / production Cloudflare mutation = 0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d49c0dc-75c4-4736-994d-4b65916bafac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d49c0dc-75c4-4736-994d-4b65916bafac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

