### PR TITLE
feat(mvp3): MVP-3-APPROVAL-LEDGER-CORE-V1 — append-only D1 Ledger, fingerprint, idempotency, record/read APIs

### DIFF
--- a/migrations/0001_approval_ledger.sql
+++ b/migrations/0001_approval_ledger.sql
@@ -1,0 +1,56 @@
+-- Migration 0001: Approval Ledger append-only record store (MVP-3-APPROVAL-LEDGER-CORE-V1)
+--
+-- Invariants enforced at the DB level:
+--   human_action_status = ACTION_REQUIRED
+--   evidence_state      = CONFIRMED
+--   intent              IN (APPROVE, REJECT, DEFER)
+--   submission_state    = RECORDED
+--   external_effect     = 0
+--   append-only: UPDATE / DELETE rejected by triggers
+--   idempotency scope:  (approver_issuer, approver_subject_id, idempotency_key) UNIQUE
+
+CREATE TABLE approval_ledger_records (
+  record_id TEXT PRIMARY KEY,
+  schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+
+  repository TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL,
+  decision_fingerprint TEXT NOT NULL,
+  decision_facts_json TEXT NOT NULL,
+
+  human_action_status TEXT NOT NULL CHECK (human_action_status = 'ACTION_REQUIRED'),
+  evidence_state TEXT NOT NULL CHECK (evidence_state = 'CONFIRMED'),
+  observed_at TEXT NOT NULL,
+
+  intent TEXT NOT NULL CHECK (intent IN ('APPROVE', 'REJECT', 'DEFER')),
+
+  recorded_at TEXT NOT NULL,
+
+  idempotency_key TEXT NOT NULL,
+
+  approver_issuer TEXT NOT NULL,
+  approver_subject_id TEXT NOT NULL,
+
+  submission_state TEXT NOT NULL CHECK (submission_state = 'RECORDED'),
+  external_effect INTEGER NOT NULL CHECK (external_effect = 0)
+);
+
+CREATE UNIQUE INDEX idx_approval_ledger_idempotency
+  ON approval_ledger_records (approver_issuer, approver_subject_id, idempotency_key);
+
+CREATE INDEX idx_approval_ledger_recorded_at
+  ON approval_ledger_records (recorded_at);
+
+-- DB-level append-only protection: recorded history must not be rewritten.
+-- Correction / revoke / supersede semantics append a NEW record.
+CREATE TRIGGER approval_ledger_records_no_update
+BEFORE UPDATE ON approval_ledger_records
+BEGIN
+  SELECT RAISE(ABORT, 'approval_ledger_records is append-only: UPDATE forbidden');
+END;
+
+CREATE TRIGGER approval_ledger_records_no_delete
+BEFORE DELETE ON approval_ledger_records
+BEGIN
+  SELECT RAISE(ABORT, 'approval_ledger_records is append-only: DELETE forbidden');
+END;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
+        "@types/node": "^26.2.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1887,6 +1888,16 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
@@ -2860,6 +2871,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
+    "@types/node": "^26.2.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/src/domain/decisionFingerprint.ts
+++ b/src/domain/decisionFingerprint.ts
@@ -1,0 +1,114 @@
+import type { HumanAction } from "./humanAction";
+import type { ObservedFacts, ObservedPullRequest } from "./observedFacts";
+
+/**
+ * Canonical decision-target facts for the Approval Ledger.
+ *
+ * The fingerprint covers only the facts the Human decision is about.
+ * It MUST exclude: observedAt, approver identity, recordedAt, recordId,
+ * idempotencyKey and any UI state (see docs/mvp-3-approval-ledger-contract-v1.md §5).
+ */
+export interface DecisionEvidenceFacts {
+  pr: number;
+  draft: boolean;
+  ci: string;
+  review: string;
+  mergeState: string;
+  humanDecision: string;
+  humanDecisionRequired: boolean | null;
+  sourceRefs: string[];
+}
+
+export interface DecisionFacts {
+  repository: string;
+  humanActionStatus: "ACTION_REQUIRED";
+  evidenceState: "CONFIRMED";
+  sourceRefs: string[];
+  evidence: DecisionEvidenceFacts[];
+}
+
+/**
+ * Derive the canonical decision facts for the current observation.
+ * Returns null unless there is a recordable decision candidate
+ * (ACTION_REQUIRED + CONFIRMED evidence + observed pull requests).
+ */
+export function buildDecisionFacts(
+  facts: ObservedFacts,
+  action: HumanAction,
+): DecisionFacts | null {
+  if (action.status !== "ACTION_REQUIRED") return null;
+  if (facts.evidenceState !== "CONFIRMED") return null;
+  if (facts.openPullRequests === null) return null;
+
+  return {
+    repository: facts.repository,
+    humanActionStatus: "ACTION_REQUIRED",
+    evidenceState: "CONFIRMED",
+    sourceRefs: normalizeRefs(action.sourceRefs),
+    evidence: facts.openPullRequests
+      .map(toEvidenceFacts)
+      .sort((a, b) => a.pr - b.pr),
+  };
+}
+
+function toEvidenceFacts(pr: ObservedPullRequest): DecisionEvidenceFacts {
+  return {
+    pr: pr.number,
+    draft: pr.draft,
+    ci: pr.ci,
+    review: pr.review,
+    mergeState: pr.mergeState,
+    humanDecision: pr.humanDecisionEvidence.state,
+    humanDecisionRequired: pr.humanDecisionRequired,
+    sourceRefs: normalizeRefs(pr.sourceRefs),
+  };
+}
+
+/** Source refs carry no ordering semantics — sort + dedupe before hashing. */
+function normalizeRefs(refs: string[]): string[] {
+  return [...new Set(refs)].sort();
+}
+
+/**
+ * Deterministic canonical JSON: recursively sorted object keys, arrays kept
+ * in (already normalized) order, no whitespace.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`);
+  return `{${entries.join(",")}}`;
+}
+
+/** SHA-256 hex over deterministic canonical JSON of the decision facts. */
+export async function computeDecisionFingerprint(facts: DecisionFacts): Promise<string> {
+  const canonical = canonicalJson(facts);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export interface RecordableDecision {
+  facts: DecisionFacts;
+  decisionFingerprint: string;
+}
+
+/**
+ * Server-side computation of the current recordable decision candidate.
+ * Null when there is nothing recordable — the browser never computes the
+ * authoritative fingerprint.
+ */
+export async function computeRecordableDecision(
+  observed: ObservedFacts,
+  action: HumanAction,
+): Promise<RecordableDecision | null> {
+  const facts = buildDecisionFacts(observed, action);
+  if (!facts) return null;
+  return { facts, decisionFingerprint: await computeDecisionFingerprint(facts) };
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,8 +1,10 @@
 import { resolveHumanAction } from "../domain/humanActionResolver";
 import { handleAuthStatus } from "./auth/authStatus";
 import { observeRepository } from "./github/readOnlyAdapter";
+import { handleLedgerRecordPost, handleLedgerRecordsGet, type LedgerApiEnv } from "./ledger/recordsApi";
+import { buildStatusPayload } from "./statusApi";
 
-interface Env {
+interface Env extends LedgerApiEnv {
   ASSETS: { fetch(request: Request): Promise<Response> };
   GITHUB_TOKEN?: string;
   /** Cloudflare Access team domain / JWT issuer. Optional until Access is configured. */
@@ -24,31 +26,18 @@ export default {
     if (request.method === "GET" && url.pathname === "/api/status") {
       const facts = await observeRepository(TARGET_REPOSITORY, env);
       const action = resolveHumanAction(facts);
+      const payload = await buildStatusPayload(facts, action);
+      return Response.json(payload, { headers: { "Cache-Control": "no-store" } });
+    }
 
-      return Response.json(
-        {
-          action,
-          developmentStatus: {
-            repository: facts.repository,
-            main: facts.currentMain ? "Observed" : "Unknown",
-            openPrCount: facts.openPullRequests?.length ?? null,
-            evidenceState: facts.evidenceState,
-          },
-          evidence:
-            facts.openPullRequests?.map((pr) => ({
-              pr: pr.number,
-              draft: pr.draft,
-              ci: pr.ci,
-              review: pr.review,
-              mergeState: pr.mergeState,
-              humanDecision: pr.humanDecisionEvidence.state,
-              humanDecisionSource: pr.humanDecisionEvidence.source,
-              sourceRefs: pr.sourceRefs,
-            })) ?? null,
-          observedAt: facts.observedAt,
-        },
-        { headers: { "Cache-Control": "no-store" } },
-      );
+    if (url.pathname === "/api/ledger/records") {
+      if (request.method === "POST") {
+        return handleLedgerRecordPost(request, env, {
+          observe: () => observeRepository(TARGET_REPOSITORY, env),
+        });
+      }
+      if (request.method === "GET") return handleLedgerRecordsGet(request, env);
+      return new Response("Method Not Allowed", { status: 405, headers: { Allow: "GET, POST" } });
     }
 
     if (url.pathname.startsWith("/api/")) {

--- a/src/worker/ledger/ledgerStore.ts
+++ b/src/worker/ledger/ledgerStore.ts
@@ -1,0 +1,239 @@
+/**
+ * Append-only D1 store for Approval Ledger records.
+ *
+ * The application layer exposes no UPDATE and no DELETE; migration 0001 also
+ * rejects UPDATE / DELETE with DB triggers. Structural D1 types keep the store
+ * testable against any SQLite-compatible binding.
+ */
+
+export interface D1PreparedStatementLike {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  all<T = Record<string, unknown>>(): Promise<{ results: T[] }>;
+  run(): Promise<unknown>;
+}
+
+export interface D1DatabaseLike {
+  prepare(query: string): D1PreparedStatementLike;
+}
+
+export const LEDGER_SCHEMA_VERSION = 1;
+
+export type ApprovalLedgerIntent = "APPROVE" | "REJECT" | "DEFER";
+
+export interface LedgerRecord {
+  recordId: string;
+  schemaVersion: number;
+  repository: string;
+  sourceRefs: string[];
+  decisionFingerprint: string;
+  decisionFactsJson: string;
+  humanActionStatus: "ACTION_REQUIRED";
+  evidenceState: "CONFIRMED";
+  observedAt: string;
+  intent: ApprovalLedgerIntent;
+  recordedAt: string;
+  idempotencyKey: string;
+  approverIssuer: string;
+  approverSubjectId: string;
+  submissionState: "RECORDED";
+  externalEffect: false;
+}
+
+export interface NewLedgerRecordInput {
+  recordId: string;
+  repository: string;
+  sourceRefs: string[];
+  decisionFingerprint: string;
+  decisionFactsJson: string;
+  observedAt: string;
+  intent: ApprovalLedgerIntent;
+  recordedAt: string;
+  idempotencyKey: string;
+  approverIssuer: string;
+  approverSubjectId: string;
+}
+
+export type AppendLedgerRecordResult =
+  /** New record appended. */
+  | { outcome: "RECORDED"; record: LedgerRecord }
+  /** Identical retry — existing record returned, nothing written. */
+  | { outcome: "REPLAYED"; record: LedgerRecord }
+  /** Same idempotency scope but different semantic payload — nothing written. */
+  | { outcome: "IDEMPOTENCY_CONFLICT" };
+
+type LedgerRow = {
+  record_id: string;
+  schema_version: number;
+  repository: string;
+  source_refs_json: string;
+  decision_fingerprint: string;
+  decision_facts_json: string;
+  human_action_status: string;
+  evidence_state: string;
+  observed_at: string;
+  intent: string;
+  recorded_at: string;
+  idempotency_key: string;
+  approver_issuer: string;
+  approver_subject_id: string;
+  submission_state: string;
+  external_effect: number;
+};
+
+const SELECT_COLUMNS = `record_id, schema_version, repository, source_refs_json,
+  decision_fingerprint, decision_facts_json, human_action_status, evidence_state,
+  observed_at, intent, recorded_at, idempotency_key, approver_issuer,
+  approver_subject_id, submission_state, external_effect`;
+
+function rowToRecord(row: LedgerRow): LedgerRecord {
+  return {
+    recordId: row.record_id,
+    schemaVersion: row.schema_version,
+    repository: row.repository,
+    sourceRefs: JSON.parse(row.source_refs_json) as string[],
+    decisionFingerprint: row.decision_fingerprint,
+    decisionFactsJson: row.decision_facts_json,
+    humanActionStatus: "ACTION_REQUIRED",
+    evidenceState: "CONFIRMED",
+    observedAt: row.observed_at,
+    intent: row.intent as ApprovalLedgerIntent,
+    recordedAt: row.recorded_at,
+    idempotencyKey: row.idempotency_key,
+    approverIssuer: row.approver_issuer,
+    approverSubjectId: row.approver_subject_id,
+    submissionState: "RECORDED",
+    externalEffect: false,
+  };
+}
+
+export async function findByIdempotencyScope(
+  db: D1DatabaseLike,
+  approverIssuer: string,
+  approverSubjectId: string,
+  idempotencyKey: string,
+): Promise<LedgerRecord | null> {
+  const row = await db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM approval_ledger_records
+       WHERE approver_issuer = ? AND approver_subject_id = ? AND idempotency_key = ?`,
+    )
+    .bind(approverIssuer, approverSubjectId, idempotencyKey)
+    .first<LedgerRow>();
+  return row ? rowToRecord(row) : null;
+}
+
+/**
+ * Identical retry means the same semantic decision payload:
+ * same decision fingerprint and same intent for the same repository.
+ */
+export function isIdenticalReplay(
+  existing: LedgerRecord,
+  input: Pick<NewLedgerRecordInput, "decisionFingerprint" | "intent" | "repository">,
+): boolean {
+  return (
+    existing.decisionFingerprint === input.decisionFingerprint &&
+    existing.intent === input.intent &&
+    existing.repository === input.repository
+  );
+}
+
+/**
+ * Append one immutable Ledger record.
+ *
+ * Idempotency scope = (approver issuer + approver subjectId + idempotencyKey).
+ * Retries with the identical payload return the existing record; the same key
+ * with a different semantic payload conflicts without writing. A racing insert
+ * on the unique index is re-read and resolved the same way.
+ */
+export async function appendLedgerRecord(
+  db: D1DatabaseLike,
+  input: NewLedgerRecordInput,
+): Promise<AppendLedgerRecordResult> {
+  const existing = await findByIdempotencyScope(
+    db,
+    input.approverIssuer,
+    input.approverSubjectId,
+    input.idempotencyKey,
+  );
+  if (existing) {
+    return isIdenticalReplay(existing, input)
+      ? { outcome: "REPLAYED", record: existing }
+      : { outcome: "IDEMPOTENCY_CONFLICT" };
+  }
+
+  try {
+    await db
+      .prepare(
+        `INSERT INTO approval_ledger_records (
+           record_id, schema_version, repository, source_refs_json,
+           decision_fingerprint, decision_facts_json, human_action_status,
+           evidence_state, observed_at, intent, recorded_at, idempotency_key,
+           approver_issuer, approver_subject_id, submission_state, external_effect
+         ) VALUES (?, ?, ?, ?, ?, ?, 'ACTION_REQUIRED', 'CONFIRMED', ?, ?, ?, ?, ?, ?, 'RECORDED', 0)`,
+      )
+      .bind(
+        input.recordId,
+        LEDGER_SCHEMA_VERSION,
+        input.repository,
+        JSON.stringify(input.sourceRefs),
+        input.decisionFingerprint,
+        input.decisionFactsJson,
+        input.observedAt,
+        input.intent,
+        input.recordedAt,
+        input.idempotencyKey,
+        input.approverIssuer,
+        input.approverSubjectId,
+      )
+      .run();
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      const raced = await findByIdempotencyScope(
+        db,
+        input.approverIssuer,
+        input.approverSubjectId,
+        input.idempotencyKey,
+      );
+      if (raced) {
+        return isIdenticalReplay(raced, input)
+          ? { outcome: "REPLAYED", record: raced }
+          : { outcome: "IDEMPOTENCY_CONFLICT" };
+      }
+    }
+    throw error;
+  }
+
+  const record = await findByIdempotencyScope(
+    db,
+    input.approverIssuer,
+    input.approverSubjectId,
+    input.idempotencyKey,
+  );
+  if (!record) throw new Error("ledger record not found after append");
+  return { outcome: "RECORDED", record };
+}
+
+export const LEDGER_LIST_DEFAULT_LIMIT = 50;
+export const LEDGER_LIST_MAX_LIMIT = 50;
+
+/** Most recent records first. Read-only; no UPDATE/DELETE exists in this store. */
+export async function listLedgerRecords(
+  db: D1DatabaseLike,
+  limit: number = LEDGER_LIST_DEFAULT_LIMIT,
+): Promise<LedgerRecord[]> {
+  const bounded = Math.max(1, Math.min(LEDGER_LIST_MAX_LIMIT, Math.floor(limit)));
+  const { results } = await db
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM approval_ledger_records
+       ORDER BY recorded_at DESC, record_id DESC LIMIT ?`,
+    )
+    .bind(bounded)
+    .all<LedgerRow>();
+  return results.map(rowToRecord);
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /UNIQUE constraint failed|SQLITE_CONSTRAINT/i.test(message);
+}

--- a/src/worker/ledger/recordsApi.ts
+++ b/src/worker/ledger/recordsApi.ts
@@ -1,0 +1,213 @@
+import { computeRecordableDecision } from "../../domain/decisionFingerprint";
+import { resolveHumanAction } from "../../domain/humanActionResolver";
+import type { ObservedFacts } from "../../domain/observedFacts";
+import type { AccessKeyResolver } from "../auth/accessJwtVerifier";
+import {
+  ledgerGuardDenialResponse,
+  requireLedgerCapability,
+  type LedgerGuardEnv,
+} from "../auth/ledgerGuard";
+import {
+  appendLedgerRecord,
+  findByIdempotencyScope,
+  listLedgerRecords,
+  LEDGER_LIST_DEFAULT_LIMIT,
+  type ApprovalLedgerIntent,
+  type D1DatabaseLike,
+  type LedgerRecord,
+} from "./ledgerStore";
+
+export type LedgerApiEnv = LedgerGuardEnv & {
+  /** Canonical Approval Ledger store (Cloudflare D1). */
+  LEDGER_DB?: D1DatabaseLike;
+};
+
+/** Injectable seams for tests; production uses live observation and real time. */
+export interface LedgerApiDeps {
+  observe: () => Promise<ObservedFacts>;
+  keyResolver?: AccessKeyResolver;
+  now?: () => Date;
+  newRecordId?: () => string;
+}
+
+const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+const INTENTS: readonly ApprovalLedgerIntent[] = ["APPROVE", "REJECT", "DEFER"];
+
+const noStore = { "Cache-Control": "no-store" } as const;
+
+function errorResponse(status: number, error: string, extra?: Record<string, unknown>): Response {
+  return Response.json({ error, recorded: false, ...extra }, { status, headers: noStore });
+}
+
+/**
+ * Audit-UI projection of a Ledger record. No secrets, no raw JWT material.
+ * Approver is the scoped principal only (issuer + subjectId).
+ */
+export function serializeLedgerRecord(record: LedgerRecord): Record<string, unknown> {
+  return {
+    recordId: record.recordId,
+    schemaVersion: record.schemaVersion,
+    repository: record.repository,
+    sourceRefs: record.sourceRefs,
+    decisionFingerprint: record.decisionFingerprint,
+    humanActionStatus: record.humanActionStatus,
+    evidenceState: record.evidenceState,
+    observedAt: record.observedAt,
+    intent: record.intent,
+    recordedAt: record.recordedAt,
+    approver: {
+      issuer: record.approverIssuer,
+      subjectId: record.approverSubjectId,
+    },
+    submissionState: record.submissionState,
+    externalEffect: record.externalEffect,
+  };
+}
+
+type RecordRequestBody = {
+  intent: ApprovalLedgerIntent;
+  expectedDecisionFingerprint: string;
+};
+
+function parseRecordBody(raw: unknown): RecordRequestBody | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const body = raw as Record<string, unknown>;
+  const intent = body.intent;
+  const expected = body.expectedDecisionFingerprint;
+  if (typeof intent !== "string" || !INTENTS.includes(intent as ApprovalLedgerIntent)) return null;
+  if (typeof expected !== "string" || expected.trim().length === 0) return null;
+  return {
+    intent: intent as ApprovalLedgerIntent,
+    expectedDecisionFingerprint: expected.trim(),
+  };
+}
+
+function extractIdempotencyKey(request: Request): string | null {
+  const key = request.headers.get(IDEMPOTENCY_KEY_HEADER)?.trim() ?? "";
+  if (key.length === 0 || key.length > 200) return null;
+  return key;
+}
+
+/**
+ * POST /api/ledger/records
+ *
+ * authenticate → authorize → validate body → idempotent-replay check
+ * → live observeRepository() → resolveHumanAction() → require CONFIRMED
+ * + ACTION_REQUIRED → compute current server fingerprint → compare
+ * expectedDecisionFingerprint → append one immutable record.
+ *
+ * Stale fingerprint ⇒ 409 STALE_DECISION with zero writes. The client request
+ * is never silently refreshed and recorded anyway.
+ */
+export async function handleLedgerRecordPost(
+  request: Request,
+  env: LedgerApiEnv,
+  deps: LedgerApiDeps,
+): Promise<Response> {
+  const guard = await requireLedgerCapability(request, env, "ledger.record", deps.keyResolver);
+  if (!guard.ok) return ledgerGuardDenialResponse(guard);
+
+  const db = env.LEDGER_DB;
+  if (!db) return errorResponse(503, "LEDGER_UNAVAILABLE");
+
+  const idempotencyKey = extractIdempotencyKey(request);
+  if (!idempotencyKey) return errorResponse(400, "MISSING_IDEMPOTENCY_KEY");
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return errorResponse(400, "INVALID_REQUEST_BODY");
+  }
+  const body = parseRecordBody(rawBody);
+  if (!body) return errorResponse(400, "INVALID_REQUEST_BODY");
+
+  // Idempotent retry must return the existing record without re-observing,
+  // so a blind retry after an unknown network result cannot duplicate or
+  // spuriously fail stale. The key is scoped by the verified principal and is
+  // never identity proof by itself.
+  const { principal } = guard;
+  const existing = await findByIdempotencyScope(
+    db,
+    principal.issuer,
+    principal.subjectId,
+    idempotencyKey,
+  );
+  if (existing) {
+    if (
+      existing.decisionFingerprint === body.expectedDecisionFingerprint &&
+      existing.intent === body.intent
+    ) {
+      return Response.json(
+        { recorded: true, replayed: true, record: serializeLedgerRecord(existing) },
+        { status: 200, headers: noStore },
+      );
+    }
+    return errorResponse(409, "IDEMPOTENCY_CONFLICT");
+  }
+
+  const observed = await deps.observe();
+  const action = resolveHumanAction(observed);
+  const decision = await computeRecordableDecision(observed, action);
+  if (!decision) {
+    return errorResponse(409, "NO_RECORDABLE_DECISION");
+  }
+
+  if (decision.decisionFingerprint !== body.expectedDecisionFingerprint) {
+    return errorResponse(409, "STALE_DECISION");
+  }
+
+  const now = deps.now?.() ?? new Date();
+  const result = await appendLedgerRecord(db, {
+    recordId: deps.newRecordId?.() ?? crypto.randomUUID(),
+    repository: decision.facts.repository,
+    sourceRefs: decision.facts.sourceRefs,
+    decisionFingerprint: decision.decisionFingerprint,
+    decisionFactsJson: JSON.stringify(decision.facts),
+    observedAt: observed.observedAt,
+    intent: body.intent,
+    recordedAt: now.toISOString(),
+    idempotencyKey,
+    approverIssuer: principal.issuer,
+    approverSubjectId: principal.subjectId,
+  });
+
+  if (result.outcome === "IDEMPOTENCY_CONFLICT") {
+    return errorResponse(409, "IDEMPOTENCY_CONFLICT");
+  }
+
+  return Response.json(
+    {
+      recorded: true,
+      replayed: result.outcome === "REPLAYED",
+      record: serializeLedgerRecord(result.record),
+    },
+    { status: result.outcome === "RECORDED" ? 201 : 200, headers: noStore },
+  );
+}
+
+/**
+ * GET /api/ledger/records — most recent 50, newest first.
+ * Authenticated + authorized read of audit fields only.
+ */
+export async function handleLedgerRecordsGet(
+  request: Request,
+  env: LedgerApiEnv,
+  deps: Pick<LedgerApiDeps, "keyResolver"> = {},
+): Promise<Response> {
+  const guard = await requireLedgerCapability(request, env, "ledger.read", deps.keyResolver);
+  if (!guard.ok) return ledgerGuardDenialResponse(guard);
+
+  const db = env.LEDGER_DB;
+  if (!db) return errorResponse(503, "LEDGER_UNAVAILABLE");
+
+  const limitParam = new URL(request.url).searchParams.get("limit");
+  const parsed = limitParam ? Number.parseInt(limitParam, 10) : NaN;
+  const limit = Number.isFinite(parsed) && parsed > 0 ? parsed : LEDGER_LIST_DEFAULT_LIMIT;
+
+  const records = await listLedgerRecords(db, limit);
+  return Response.json(
+    { records: records.map(serializeLedgerRecord) },
+    { headers: noStore },
+  );
+}

--- a/src/worker/statusApi.ts
+++ b/src/worker/statusApi.ts
@@ -1,0 +1,40 @@
+import { computeRecordableDecision } from "../domain/decisionFingerprint";
+import type { HumanAction } from "../domain/humanAction";
+import type { ObservedFacts } from "../domain/observedFacts";
+
+/**
+ * Server-computed status payload.
+ *
+ * `decisionFingerprint` is present when and only when there is a recordable
+ * decision candidate (ACTION_REQUIRED + CONFIRMED). The browser never computes
+ * the authoritative fingerprint.
+ */
+export async function buildStatusPayload(
+  facts: ObservedFacts,
+  action: HumanAction,
+): Promise<Record<string, unknown>> {
+  const decision = await computeRecordableDecision(facts, action);
+
+  return {
+    action,
+    developmentStatus: {
+      repository: facts.repository,
+      main: facts.currentMain ? "Observed" : "Unknown",
+      openPrCount: facts.openPullRequests?.length ?? null,
+      evidenceState: facts.evidenceState,
+    },
+    evidence:
+      facts.openPullRequests?.map((pr) => ({
+        pr: pr.number,
+        draft: pr.draft,
+        ci: pr.ci,
+        review: pr.review,
+        mergeState: pr.mergeState,
+        humanDecision: pr.humanDecisionEvidence.state,
+        humanDecisionSource: pr.humanDecisionEvidence.source,
+        sourceRefs: pr.sourceRefs,
+      })) ?? null,
+    observedAt: facts.observedAt,
+    ...(decision ? { decisionFingerprint: decision.decisionFingerprint } : {}),
+  };
+}

--- a/test/decisionFingerprint.test.ts
+++ b/test/decisionFingerprint.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDecisionFacts,
+  canonicalJson,
+  computeDecisionFingerprint,
+  computeRecordableDecision,
+} from "../src/domain/decisionFingerprint";
+import type { HumanAction } from "../src/domain/humanAction";
+import type { ObservedFacts, ObservedPullRequest } from "../src/domain/observedFacts";
+
+function makePr(overrides: Partial<ObservedPullRequest> = {}): ObservedPullRequest {
+  return {
+    number: 7,
+    title: "feat: something",
+    draft: false,
+    ci: "PASS",
+    review: "PASS",
+    mergeState: "CLEAN",
+    humanDecisionRequired: true,
+    humanDecisionEvidence: {
+      state: "REQUIRED",
+      source: "PR_BODY_MARKER",
+      matchedMarkers: ["Human-Decision: REQUIRED"],
+    },
+    sourceRefs: ["https://github.com/o/r/pull/7"],
+    ...overrides,
+  };
+}
+
+function makeFacts(overrides: Partial<ObservedFacts> = {}): ObservedFacts {
+  return {
+    repository: "yasutakesougo/severe-behavior-support-spfx",
+    observedAt: "2026-08-11T10:00:00.000Z",
+    evidenceState: "CONFIRMED",
+    currentMain: "abc123",
+    openPullRequests: [makePr()],
+    relevantIssueStates: {},
+    errors: [],
+    sourceRefs: ["github:repo:yasutakesougo/severe-behavior-support-spfx"],
+    ...overrides,
+  };
+}
+
+function makeAction(overrides: Partial<HumanAction> = {}): HumanAction {
+  return {
+    status: "ACTION_REQUIRED",
+    title: "PR #7 の判断が必要です",
+    instruction: "PRの内容を確認し、次のHuman Decisionを行ってください。",
+    reason: "CIとReviewが完了し、明示的にHuman Decision待ちと確認されています。",
+    sourceRefs: ["https://github.com/o/r/pull/7"],
+    ...overrides,
+  };
+}
+
+async function fingerprintOf(facts: ObservedFacts, action: HumanAction): Promise<string> {
+  const decision = buildDecisionFacts(facts, action);
+  expect(decision).not.toBeNull();
+  return computeDecisionFingerprint(decision!);
+}
+
+describe("decision fingerprint canonicalization", () => {
+  it("same facts / different observedAt ⇒ SAME fingerprint", async () => {
+    const a = await fingerprintOf(makeFacts({ observedAt: "2026-08-11T10:00:00.000Z" }), makeAction());
+    const b = await fingerprintOf(makeFacts({ observedAt: "2026-08-12T23:59:59.999Z" }), makeAction());
+    expect(a).toBe(b);
+  });
+
+  it("same facts / non-semantic array ordering difference ⇒ SAME fingerprint", async () => {
+    const pr = makePr({ sourceRefs: ["ref:b", "ref:a"] });
+    const prReordered = makePr({ sourceRefs: ["ref:a", "ref:b"] });
+    const action = makeAction({ sourceRefs: ["ref:2", "ref:1"] });
+    const actionReordered = makeAction({ sourceRefs: ["ref:1", "ref:2"] });
+
+    const a = await fingerprintOf(makeFacts({ openPullRequests: [pr] }), action);
+    const b = await fingerprintOf(makeFacts({ openPullRequests: [prReordered] }), actionReordered);
+    expect(a).toBe(b);
+  });
+
+  it("multiple PRs in different observation order ⇒ SAME fingerprint", async () => {
+    const pr7 = makePr({ number: 7 });
+    const pr9 = makePr({ number: 9, sourceRefs: ["https://github.com/o/r/pull/9"] });
+
+    const a = await fingerprintOf(makeFacts({ openPullRequests: [pr7, pr9] }), makeAction());
+    const b = await fingerprintOf(makeFacts({ openPullRequests: [pr9, pr7] }), makeAction());
+    expect(a).toBe(b);
+  });
+
+  it("sourceRefs change ⇒ DIFFERENT fingerprint", async () => {
+    const a = await fingerprintOf(makeFacts(), makeAction());
+    const b = await fingerprintOf(
+      makeFacts(),
+      makeAction({ sourceRefs: ["https://github.com/o/r/pull/8"] }),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("CI-relevant fact change ⇒ DIFFERENT fingerprint", async () => {
+    const a = await fingerprintOf(makeFacts(), makeAction());
+    const b = await fingerprintOf(
+      makeFacts({ openPullRequests: [makePr({ ci: "FAIL" })] }),
+      makeAction(),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("review fact change ⇒ DIFFERENT fingerprint", async () => {
+    const a = await fingerprintOf(makeFacts(), makeAction());
+    const b = await fingerprintOf(
+      makeFacts({ openPullRequests: [makePr({ review: "CHANGES_REQUESTED" })] }),
+      makeAction(),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("mergeState fact change ⇒ DIFFERENT fingerprint", async () => {
+    const a = await fingerprintOf(makeFacts(), makeAction());
+    const b = await fingerprintOf(
+      makeFacts({ openPullRequests: [makePr({ mergeState: "BLOCKED" })] }),
+      makeAction(),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("humanDecision evidence change ⇒ DIFFERENT fingerprint", async () => {
+    const a = await fingerprintOf(makeFacts(), makeAction());
+    const b = await fingerprintOf(
+      makeFacts({
+        openPullRequests: [
+          makePr({
+            humanDecisionRequired: false,
+            humanDecisionEvidence: {
+              state: "NONE",
+              source: "PR_BODY_MARKER",
+              matchedMarkers: ["Human-Decision: NONE"],
+            },
+          }),
+        ],
+      }),
+      makeAction(),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("repository change ⇒ DIFFERENT fingerprint", async () => {
+    const a = await fingerprintOf(makeFacts(), makeAction());
+    const b = await fingerprintOf(makeFacts({ repository: "yasutakesougo/other-repo" }), makeAction());
+    expect(a).not.toBe(b);
+  });
+
+  it("ACTION_REQUIRED change ⇒ no recordable fingerprint at all", async () => {
+    for (const status of ["WAIT", "NO_ACTION", "UNKNOWN"] as const) {
+      expect(buildDecisionFacts(makeFacts(), makeAction({ status }))).toBeNull();
+    }
+    expect(await computeRecordableDecision(makeFacts(), makeAction({ status: "WAIT" }))).toBeNull();
+  });
+
+  it("non-CONFIRMED evidence ⇒ no recordable fingerprint", () => {
+    for (const evidenceState of ["MISSING", "CONTRADICTORY", "ERROR"] as const) {
+      expect(buildDecisionFacts(makeFacts({ evidenceState }), makeAction())).toBeNull();
+    }
+  });
+
+  it("fingerprint excludes approver identity, recordedAt, recordId, idempotencyKey and UI state", () => {
+    const facts = buildDecisionFacts(makeFacts(), makeAction());
+    const canonical = canonicalJson(facts);
+    expect(canonical).not.toContain("observedAt");
+    expect(canonical).not.toContain("approver");
+    expect(canonical).not.toContain("recordedAt");
+    expect(canonical).not.toContain("recordId");
+    expect(canonical).not.toContain("idempotency");
+  });
+
+  it("canonical JSON sorts object keys deterministically", () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: [3, null] } })).toBe(
+      '{"a":{"c":[3,null],"d":2},"b":1}',
+    );
+  });
+
+  it("produces a 64-char lowercase SHA-256 hex fingerprint", async () => {
+    const decision = await computeRecordableDecision(makeFacts(), makeAction());
+    expect(decision).not.toBeNull();
+    expect(decision!.decisionFingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/test/helpers/sqliteLedgerDb.ts
+++ b/test/helpers/sqliteLedgerDb.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+import type {
+  D1DatabaseLike,
+  D1PreparedStatementLike,
+} from "../../src/worker/ledger/ledgerStore";
+
+/**
+ * Test double for Cloudflare D1 backed by real SQLite (node:sqlite), so tests
+ * exercise the actual migration SQL, CHECK constraints, unique indexes and
+ * append-only triggers with genuine SQLite semantics (D1 is SQLite-based).
+ */
+class SqlitePreparedStatement implements D1PreparedStatementLike {
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+    private readonly params: unknown[] = [],
+  ) {}
+
+  bind(...values: unknown[]): D1PreparedStatementLike {
+    return new SqlitePreparedStatement(this.db, this.sql, values);
+  }
+
+  async first<T = Record<string, unknown>>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.params as never[]));
+    return (row ?? null) as T | null;
+  }
+
+  async all<T = Record<string, unknown>>(): Promise<{ results: T[] }> {
+    const rows = this.db.prepare(this.sql).all(...(this.params as never[]));
+    return { results: rows as T[] };
+  }
+
+  async run(): Promise<unknown> {
+    return this.db.prepare(this.sql).run(...(this.params as never[]));
+  }
+}
+
+export interface SqliteLedgerTestDb extends D1DatabaseLike {
+  /** Direct handle for trigger/constraint assertions in tests. */
+  raw: DatabaseSync;
+}
+
+export function createLedgerTestDb(): SqliteLedgerTestDb {
+  const db = new DatabaseSync(":memory:");
+  const migration = readFileSync(
+    fileURLToPath(new URL("../../migrations/0001_approval_ledger.sql", import.meta.url)),
+    "utf8",
+  );
+  db.exec(migration);
+
+  return {
+    raw: db,
+    prepare(query: string): D1PreparedStatementLike {
+      return new SqlitePreparedStatement(db, query);
+    },
+  };
+}

--- a/test/ledgerRecordsApi.test.ts
+++ b/test/ledgerRecordsApi.test.ts
@@ -1,0 +1,488 @@
+import { generateKeyPair, SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import { computeRecordableDecision } from "../src/domain/decisionFingerprint";
+import type { HumanAction } from "../src/domain/humanAction";
+import { resolveHumanAction } from "../src/domain/humanActionResolver";
+import type { ObservedFacts, ObservedPullRequest } from "../src/domain/observedFacts";
+import {
+  handleLedgerRecordPost,
+  handleLedgerRecordsGet,
+  type LedgerApiEnv,
+} from "../src/worker/ledger/recordsApi";
+import { buildStatusPayload } from "../src/worker/statusApi";
+import { createLedgerTestDb } from "./helpers/sqliteLedgerDb";
+
+const ISSUER = "https://example.cloudflareaccess.com";
+const AUDIENCE = "test-access-aud-tag";
+
+type SyntheticKeyPair = Awaited<ReturnType<typeof generateKeyPair>>;
+
+async function makeKeys(): Promise<SyntheticKeyPair> {
+  return generateKeyPair("RS256");
+}
+
+async function signHumanToken(
+  privateKey: SyntheticKeyPair["privateKey"],
+  sub = "human-subject-1",
+): Promise<string> {
+  return new SignJWT({ type: "app", sub })
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setIssuedAt()
+    .setSubject(sub)
+    .setExpirationTime("5m")
+    .sign(privateKey);
+}
+
+function makePr(overrides: Partial<ObservedPullRequest> = {}): ObservedPullRequest {
+  return {
+    number: 7,
+    title: "feat: something",
+    draft: false,
+    ci: "PASS",
+    review: "PASS",
+    mergeState: "CLEAN",
+    humanDecisionRequired: true,
+    humanDecisionEvidence: {
+      state: "REQUIRED",
+      source: "PR_BODY_MARKER",
+      matchedMarkers: ["Human-Decision: REQUIRED"],
+    },
+    sourceRefs: ["https://github.com/o/r/pull/7"],
+    ...overrides,
+  };
+}
+
+function makeFacts(overrides: Partial<ObservedFacts> = {}): ObservedFacts {
+  return {
+    repository: "yasutakesougo/severe-behavior-support-spfx",
+    observedAt: "2026-08-11T10:00:00.000Z",
+    evidenceState: "CONFIRMED",
+    currentMain: "abc123",
+    openPullRequests: [makePr()],
+    relevantIssueStates: {},
+    errors: [],
+    sourceRefs: ["github:repo:yasutakesougo/severe-behavior-support-spfx"],
+    ...overrides,
+  };
+}
+
+async function currentFingerprint(facts: ObservedFacts): Promise<string> {
+  const decision = await computeRecordableDecision(facts, resolveHumanAction(facts));
+  expect(decision).not.toBeNull();
+  return decision!.decisionFingerprint;
+}
+
+function makeEnv(db = createLedgerTestDb()): LedgerApiEnv & { LEDGER_DB: ReturnType<typeof createLedgerTestDb> } {
+  return {
+    ACCESS_TEAM_DOMAIN: ISSUER,
+    ACCESS_AUD: AUDIENCE,
+    LEDGER_AUTHZ_MODE: "access-policy",
+    LEDGER_DB: db,
+  };
+}
+
+function postRequest(options: {
+  token?: string;
+  idempotencyKey?: string;
+  body?: unknown;
+}): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (options.token) headers["Cf-Access-Jwt-Assertion"] = options.token;
+  if (options.idempotencyKey) headers["Idempotency-Key"] = options.idempotencyKey;
+  return new Request("https://example.test/api/ledger/records", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(options.body ?? {}),
+  });
+}
+
+describe("POST /api/ledger/records", () => {
+  it("appends one immutable record for a valid current decision", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const env = makeEnv();
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+
+    const response = await handleLedgerRecordPost(
+      postRequest({
+        token,
+        idempotencyKey: "11111111-1111-4111-8111-111111111111",
+        body: { intent: "APPROVE", expectedDecisionFingerprint: fingerprint },
+      }),
+      env,
+      { observe: async () => facts, keyResolver: publicKey },
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    const record = body.record as Record<string, unknown>;
+
+    expect(response.status).toBe(201);
+    expect(body.recorded).toBe(true);
+    expect(body.replayed).toBe(false);
+    expect(record.intent).toBe("APPROVE");
+    expect(record.decisionFingerprint).toBe(fingerprint);
+    expect(record.submissionState).toBe("RECORDED");
+    expect(record.externalEffect).toBe(false);
+    expect(record.humanActionStatus).toBe("ACTION_REQUIRED");
+    expect(record.evidenceState).toBe("CONFIRMED");
+    expect(record.approver).toEqual({ issuer: ISSUER, subjectId: "human-subject-1" });
+  });
+
+  it("denies unauthenticated and unauthorized requests without writing", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const env = makeEnv();
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+    const deps = { observe: async () => facts, keyResolver: publicKey };
+    const body = { intent: "APPROVE", expectedDecisionFingerprint: fingerprint };
+
+    const unauthenticated = await handleLedgerRecordPost(
+      postRequest({ idempotencyKey: "k-1", body }),
+      env,
+      deps,
+    );
+    expect(unauthenticated.status).toBe(401);
+
+    const token = await signHumanToken(privateKey);
+    const noAuthz = await handleLedgerRecordPost(
+      postRequest({ token, idempotencyKey: "k-2", body }),
+      { ...env, LEDGER_AUTHZ_MODE: undefined },
+      deps,
+    );
+    expect(noAuthz.status).toBe(403);
+
+    const list = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records", {
+        headers: { "Cf-Access-Jwt-Assertion": token },
+      }),
+      env,
+      { keyResolver: publicKey },
+    );
+    const listBody = (await list.json()) as { records: unknown[] };
+    expect(listBody.records).toHaveLength(0);
+  });
+
+  it("requires an Idempotency-Key header", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+
+    const response = await handleLedgerRecordPost(
+      postRequest({ token, body: { intent: "APPROVE", expectedDecisionFingerprint: fingerprint } }),
+      makeEnv(),
+      { observe: async () => facts, keyResolver: publicKey },
+    );
+
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as { error: string }).error).toBe("MISSING_IDEMPOTENCY_KEY");
+  });
+
+  it("rejects invalid intents and missing fingerprints", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const facts = makeFacts();
+    const deps = { observe: async () => facts, keyResolver: publicKey };
+    const env = makeEnv();
+
+    for (const body of [
+      { intent: "MERGE", expectedDecisionFingerprint: "x" },
+      { intent: "APPROVE" },
+      { intent: "APPROVE", expectedDecisionFingerprint: "" },
+      "not-an-object",
+    ]) {
+      const response = await handleLedgerRecordPost(
+        postRequest({ token, idempotencyKey: "k-1", body }),
+        env,
+        deps,
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it("409 STALE_DECISION when the expected fingerprint no longer matches; nothing recorded", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const env = makeEnv();
+    const staleFingerprint = await currentFingerprint(makeFacts());
+    // Live re-observation sees changed decision facts (CI now FAIL ⇒ different candidate).
+    const liveFacts = makeFacts({
+      openPullRequests: [makePr({ sourceRefs: ["https://github.com/o/r/pull/9"], number: 9 })],
+    });
+
+    const response = await handleLedgerRecordPost(
+      postRequest({
+        token,
+        idempotencyKey: "k-1",
+        body: { intent: "APPROVE", expectedDecisionFingerprint: staleFingerprint },
+      }),
+      env,
+      { observe: async () => liveFacts, keyResolver: publicKey },
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("STALE_DECISION");
+    expect(body.recorded).toBe(false);
+
+    const list = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records", {
+        headers: { "Cf-Access-Jwt-Assertion": token },
+      }),
+      env,
+      { keyResolver: publicKey },
+    );
+    expect(((await list.json()) as { records: unknown[] }).records).toHaveLength(0);
+  });
+
+  it("409 NO_RECORDABLE_DECISION when live observation is not ACTION_REQUIRED + CONFIRMED", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const env = makeEnv();
+    const fingerprint = await currentFingerprint(makeFacts());
+
+    for (const liveFacts of [
+      makeFacts({ openPullRequests: [] }), // NO_ACTION
+      makeFacts({ evidenceState: "ERROR", currentMain: null, openPullRequests: null }), // UNKNOWN
+      makeFacts({ openPullRequests: [makePr({ ci: "PENDING" })] }), // WAIT
+    ]) {
+      const response = await handleLedgerRecordPost(
+        postRequest({
+          token,
+          idempotencyKey: crypto.randomUUID(),
+          body: { intent: "APPROVE", expectedDecisionFingerprint: fingerprint },
+        }),
+        env,
+        { observe: async () => liveFacts, keyResolver: publicKey },
+      );
+      expect(response.status).toBe(409);
+      expect(((await response.json()) as { error: string }).error).toBe("NO_RECORDABLE_DECISION");
+    }
+  });
+
+  it("identical retry with the same idempotency key returns the existing record, no duplicate", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const env = makeEnv();
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+    const key = "22222222-2222-4222-8222-222222222222";
+    const deps = { observe: async () => facts, keyResolver: publicKey };
+    const body = { intent: "REJECT", expectedDecisionFingerprint: fingerprint };
+
+    const first = await handleLedgerRecordPost(postRequest({ token, idempotencyKey: key, body }), env, deps);
+    expect(first.status).toBe(201);
+    const firstRecord = ((await first.json()) as { record: { recordId: string } }).record;
+
+    const retry = await handleLedgerRecordPost(postRequest({ token, idempotencyKey: key, body }), env, deps);
+    const retryBody = (await retry.json()) as {
+      recorded: boolean;
+      replayed: boolean;
+      record: { recordId: string };
+    };
+
+    expect(retry.status).toBe(200);
+    expect(retryBody.replayed).toBe(true);
+    expect(retryBody.record.recordId).toBe(firstRecord.recordId);
+
+    const list = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records", {
+        headers: { "Cf-Access-Jwt-Assertion": token },
+      }),
+      env,
+      { keyResolver: publicKey },
+    );
+    expect(((await list.json()) as { records: unknown[] }).records).toHaveLength(1);
+  });
+
+  it("retry works even after the live decision changed (record already durable)", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const env = makeEnv();
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+    const key = "33333333-3333-4333-8333-333333333333";
+    const body = { intent: "APPROVE", expectedDecisionFingerprint: fingerprint };
+
+    const first = await handleLedgerRecordPost(postRequest({ token, idempotencyKey: key, body }), env, {
+      observe: async () => facts,
+      keyResolver: publicKey,
+    });
+    expect(first.status).toBe(201);
+
+    // Same request retried while live facts changed: still replays the durable record.
+    const retry = await handleLedgerRecordPost(postRequest({ token, idempotencyKey: key, body }), env, {
+      observe: async () => makeFacts({ openPullRequests: [] }),
+      keyResolver: publicKey,
+    });
+    expect(retry.status).toBe(200);
+    expect(((await retry.json()) as { replayed: boolean }).replayed).toBe(true);
+  });
+
+  it("409 IDEMPOTENCY_CONFLICT for the same key with a different semantic payload", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const env = makeEnv();
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+    const key = "44444444-4444-4444-8444-444444444444";
+    const deps = { observe: async () => facts, keyResolver: publicKey };
+
+    const first = await handleLedgerRecordPost(
+      postRequest({ token, idempotencyKey: key, body: { intent: "APPROVE", expectedDecisionFingerprint: fingerprint } }),
+      env,
+      deps,
+    );
+    expect(first.status).toBe(201);
+
+    const conflicting = await handleLedgerRecordPost(
+      postRequest({ token, idempotencyKey: key, body: { intent: "REJECT", expectedDecisionFingerprint: fingerprint } }),
+      env,
+      deps,
+    );
+    expect(conflicting.status).toBe(409);
+    expect(((await conflicting.json()) as { error: string }).error).toBe("IDEMPOTENCY_CONFLICT");
+
+    const list = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records", {
+        headers: { "Cf-Access-Jwt-Assertion": token },
+      }),
+      env,
+      { keyResolver: publicKey },
+    );
+    expect(((await list.json()) as { records: unknown[] }).records).toHaveLength(1);
+  });
+
+  it("client-supplied idempotency key never overrides the verified principal scope", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const env = makeEnv();
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+    const key = "55555555-5555-4555-8555-555555555555";
+    const deps = { observe: async () => facts, keyResolver: publicKey };
+    const body = { intent: "APPROVE", expectedDecisionFingerprint: fingerprint };
+
+    const tokenA = await signHumanToken(privateKey, "human-subject-1");
+    const tokenB = await signHumanToken(privateKey, "human-subject-2");
+
+    const first = await handleLedgerRecordPost(postRequest({ token: tokenA, idempotencyKey: key, body }), env, deps);
+    const second = await handleLedgerRecordPost(postRequest({ token: tokenB, idempotencyKey: key, body }), env, deps);
+
+    expect(first.status).toBe(201);
+    // Different Human, same key ⇒ distinct record, not a replay of Human A's record.
+    expect(second.status).toBe(201);
+
+    const list = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records", {
+        headers: { "Cf-Access-Jwt-Assertion": tokenA },
+      }),
+      env,
+      { keyResolver: publicKey },
+    );
+    expect(((await list.json()) as { records: unknown[] }).records).toHaveLength(2);
+  });
+
+  it("503 LEDGER_UNAVAILABLE when no D1 binding is configured", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+    const env = makeEnv();
+
+    const response = await handleLedgerRecordPost(
+      postRequest({
+        token,
+        idempotencyKey: "k-1",
+        body: { intent: "APPROVE", expectedDecisionFingerprint: fingerprint },
+      }),
+      { ...env, LEDGER_DB: undefined },
+      { observe: async () => facts, keyResolver: publicKey },
+    );
+    expect(response.status).toBe(503);
+  });
+});
+
+describe("GET /api/ledger/records", () => {
+  it("requires authentication and authorization", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const env = makeEnv();
+
+    const unauthenticated = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records"),
+      env,
+      { keyResolver: publicKey },
+    );
+    expect(unauthenticated.status).toBe(401);
+
+    const token = await signHumanToken(privateKey);
+    const noAuthz = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records", {
+        headers: { "Cf-Access-Jwt-Assertion": token },
+      }),
+      { ...env, LEDGER_AUTHZ_MODE: undefined },
+      { keyResolver: publicKey },
+    );
+    expect(noAuthz.status).toBe(403);
+  });
+
+  it("returns newest-first audit fields without secrets", async () => {
+    const { privateKey, publicKey } = await makeKeys();
+    const token = await signHumanToken(privateKey);
+    const env = makeEnv();
+    const facts = makeFacts();
+    const fingerprint = await currentFingerprint(facts);
+    const deps = { observe: async () => facts, keyResolver: publicKey };
+
+    let tick = 0;
+    for (const intent of ["APPROVE", "DEFER"] as const) {
+      const response = await handleLedgerRecordPost(
+        postRequest({
+          token,
+          idempotencyKey: `key-${intent}`,
+          body: { intent, expectedDecisionFingerprint: fingerprint },
+        }),
+        env,
+        { ...deps, now: () => new Date(Date.UTC(2026, 7, 11, 10, tick++)) },
+      );
+      expect(response.status).toBe(201);
+    }
+
+    const list = await handleLedgerRecordsGet(
+      new Request("https://example.test/api/ledger/records", {
+        headers: { "Cf-Access-Jwt-Assertion": token },
+      }),
+      env,
+      { keyResolver: publicKey },
+    );
+    const body = (await list.json()) as { records: Array<Record<string, unknown>> };
+
+    expect(list.status).toBe(200);
+    expect(body.records).toHaveLength(2);
+    expect(body.records[0].intent).toBe("DEFER");
+    expect(body.records[1].intent).toBe("APPROVE");
+    for (const record of body.records) {
+      expect(record.externalEffect).toBe(false);
+      expect(record.submissionState).toBe("RECORDED");
+      expect(record).not.toHaveProperty("idempotencyKey");
+      expect(record).not.toHaveProperty("decisionFactsJson");
+    }
+  });
+});
+
+describe("GET /api/status decision fingerprint exposure", () => {
+  it("exposes the server-computed fingerprint only for a recordable decision", async () => {
+    const recordable = makeFacts();
+    const payload = await buildStatusPayload(recordable, resolveHumanAction(recordable));
+    expect(payload.decisionFingerprint).toMatch(/^[0-9a-f]{64}$/);
+
+    const notRecordable = makeFacts({ openPullRequests: [] });
+    const noAction = await buildStatusPayload(notRecordable, resolveHumanAction(notRecordable));
+    expect(noAction).not.toHaveProperty("decisionFingerprint");
+
+    const error = makeFacts({ evidenceState: "ERROR", currentMain: null, openPullRequests: null });
+    const errorPayload = await buildStatusPayload(error, resolveHumanAction(error));
+    expect(errorPayload).not.toHaveProperty("decisionFingerprint");
+  });
+});

--- a/test/ledgerStore.test.ts
+++ b/test/ledgerStore.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendLedgerRecord,
+  findByIdempotencyScope,
+  listLedgerRecords,
+  type NewLedgerRecordInput,
+} from "../src/worker/ledger/ledgerStore";
+import { createLedgerTestDb } from "./helpers/sqliteLedgerDb";
+
+function makeInput(overrides: Partial<NewLedgerRecordInput> = {}): NewLedgerRecordInput {
+  return {
+    recordId: "rec-1",
+    repository: "yasutakesougo/severe-behavior-support-spfx",
+    sourceRefs: ["https://github.com/o/r/pull/7"],
+    decisionFingerprint: "f".repeat(64),
+    decisionFactsJson: JSON.stringify({ repository: "yasutakesougo/severe-behavior-support-spfx" }),
+    observedAt: "2026-08-11T10:00:00.000Z",
+    intent: "APPROVE",
+    recordedAt: "2026-08-11T10:01:00.000Z",
+    idempotencyKey: "key-1",
+    approverIssuer: "https://example.cloudflareaccess.com",
+    approverSubjectId: "human-subject-1",
+    ...overrides,
+  };
+}
+
+describe("appendLedgerRecord (D1/SQLite)", () => {
+  it("appends one immutable record with contract invariants", async () => {
+    const db = createLedgerTestDb();
+    const result = await appendLedgerRecord(db, makeInput());
+
+    expect(result.outcome).toBe("RECORDED");
+    if (result.outcome !== "RECORDED") return;
+    expect(result.record.recordId).toBe("rec-1");
+    expect(result.record.schemaVersion).toBe(1);
+    expect(result.record.humanActionStatus).toBe("ACTION_REQUIRED");
+    expect(result.record.evidenceState).toBe("CONFIRMED");
+    expect(result.record.submissionState).toBe("RECORDED");
+    expect(result.record.externalEffect).toBe(false);
+    expect(result.record.sourceRefs).toEqual(["https://github.com/o/r/pull/7"]);
+  });
+
+  it("identical retry returns the existing record without duplicating", async () => {
+    const db = createLedgerTestDb();
+    const first = await appendLedgerRecord(db, makeInput({ recordId: "rec-1" }));
+    const retry = await appendLedgerRecord(db, makeInput({ recordId: "rec-2-should-not-be-used" }));
+
+    expect(first.outcome).toBe("RECORDED");
+    expect(retry.outcome).toBe("REPLAYED");
+    if (retry.outcome !== "REPLAYED") return;
+    expect(retry.record.recordId).toBe("rec-1");
+
+    const all = await listLedgerRecords(db);
+    expect(all).toHaveLength(1);
+  });
+
+  it("same idempotency key with different semantic payload ⇒ IDEMPOTENCY_CONFLICT, no write", async () => {
+    const db = createLedgerTestDb();
+    await appendLedgerRecord(db, makeInput());
+
+    const differentIntent = await appendLedgerRecord(
+      db,
+      makeInput({ recordId: "rec-2", intent: "REJECT" }),
+    );
+    const differentFingerprint = await appendLedgerRecord(
+      db,
+      makeInput({ recordId: "rec-3", decisionFingerprint: "e".repeat(64) }),
+    );
+
+    expect(differentIntent.outcome).toBe("IDEMPOTENCY_CONFLICT");
+    expect(differentFingerprint.outcome).toBe("IDEMPOTENCY_CONFLICT");
+    expect(await listLedgerRecords(db)).toHaveLength(1);
+  });
+
+  it("idempotency scope includes approver issuer + subjectId", async () => {
+    const db = createLedgerTestDb();
+    await appendLedgerRecord(db, makeInput());
+
+    const otherHuman = await appendLedgerRecord(
+      db,
+      makeInput({ recordId: "rec-2", approverSubjectId: "human-subject-2", intent: "REJECT" }),
+    );
+    const otherIssuer = await appendLedgerRecord(
+      db,
+      makeInput({
+        recordId: "rec-3",
+        approverIssuer: "https://other.cloudflareaccess.com",
+        intent: "DEFER",
+      }),
+    );
+
+    expect(otherHuman.outcome).toBe("RECORDED");
+    expect(otherIssuer.outcome).toBe("RECORDED");
+    expect(await listLedgerRecords(db)).toHaveLength(3);
+  });
+
+  it("DB unique index rejects a raced duplicate insert and the store resolves it as replay", async () => {
+    const db = createLedgerTestDb();
+    await appendLedgerRecord(db, makeInput({ recordId: "rec-1" }));
+
+    // Simulate a race: insert directly (bypassing the pre-check) with the same scope.
+    expect(() =>
+      db.raw
+        .prepare(
+          `INSERT INTO approval_ledger_records (
+             record_id, schema_version, repository, source_refs_json,
+             decision_fingerprint, decision_facts_json, human_action_status,
+             evidence_state, observed_at, intent, recorded_at, idempotency_key,
+             approver_issuer, approver_subject_id, submission_state, external_effect
+           ) VALUES ('rec-x', 1, 'r', '[]', 'fp', '{}', 'ACTION_REQUIRED', 'CONFIRMED',
+             'o', 'APPROVE', 'r', 'key-1', 'https://example.cloudflareaccess.com',
+             'human-subject-1', 'RECORDED', 0)`,
+        )
+        .run(),
+    ).toThrow(/UNIQUE constraint failed/);
+  });
+});
+
+describe("listLedgerRecords", () => {
+  it("returns newest first, capped at 50", async () => {
+    const db = createLedgerTestDb();
+    for (let i = 0; i < 55; i++) {
+      await appendLedgerRecord(
+        db,
+        makeInput({
+          recordId: `rec-${i}`,
+          idempotencyKey: `key-${i}`,
+          recordedAt: `2026-08-11T10:${String(i).padStart(2, "0")}:00.000Z`,
+        }),
+      );
+    }
+
+    const records = await listLedgerRecords(db);
+    expect(records).toHaveLength(50);
+    expect(records[0].recordId).toBe("rec-54");
+    expect(records[49].recordId).toBe("rec-5");
+
+    const limited = await listLedgerRecords(db, 3);
+    expect(limited.map((r) => r.recordId)).toEqual(["rec-54", "rec-53", "rec-52"]);
+
+    const overCap = await listLedgerRecords(db, 500);
+    expect(overCap).toHaveLength(50);
+  });
+});
+
+describe("append-only DB protection (migration 0001 triggers + CHECKs)", () => {
+  it("rejects UPDATE of a recorded ledger record", async () => {
+    const db = createLedgerTestDb();
+    await appendLedgerRecord(db, makeInput());
+
+    expect(() =>
+      db.raw.prepare("UPDATE approval_ledger_records SET intent = 'REJECT'").run(),
+    ).toThrow(/append-only: UPDATE forbidden/);
+
+    const record = await findByIdempotencyScope(
+      db,
+      "https://example.cloudflareaccess.com",
+      "human-subject-1",
+      "key-1",
+    );
+    expect(record?.intent).toBe("APPROVE");
+  });
+
+  it("rejects DELETE of a recorded ledger record", async () => {
+    const db = createLedgerTestDb();
+    await appendLedgerRecord(db, makeInput());
+
+    expect(() => db.raw.prepare("DELETE FROM approval_ledger_records").run()).toThrow(
+      /append-only: DELETE forbidden/,
+    );
+    expect(await listLedgerRecords(db)).toHaveLength(1);
+  });
+
+  it("rejects rows violating contract invariants at the DB level", async () => {
+    const db = createLedgerTestDb();
+    const insert = (columns: Record<string, unknown>) => {
+      const base: Record<string, unknown> = {
+        record_id: "rec-bad",
+        schema_version: 1,
+        repository: "r",
+        source_refs_json: "[]",
+        decision_fingerprint: "fp",
+        decision_facts_json: "{}",
+        human_action_status: "ACTION_REQUIRED",
+        evidence_state: "CONFIRMED",
+        observed_at: "o",
+        intent: "APPROVE",
+        recorded_at: "r",
+        idempotency_key: "k-bad",
+        approver_issuer: "i",
+        approver_subject_id: "s",
+        submission_state: "RECORDED",
+        external_effect: 0,
+        ...columns,
+      };
+      const keys = Object.keys(base);
+      db.raw
+        .prepare(
+          `INSERT INTO approval_ledger_records (${keys.join(", ")})
+           VALUES (${keys.map(() => "?").join(", ")})`,
+        )
+        .run(...(Object.values(base) as never[]));
+    };
+
+    expect(() => insert({ human_action_status: "NO_ACTION" })).toThrow(/CHECK constraint failed/);
+    expect(() => insert({ evidence_state: "MISSING" })).toThrow(/CHECK constraint failed/);
+    expect(() => insert({ intent: "MERGE" })).toThrow(/CHECK constraint failed/);
+    expect(() => insert({ submission_state: "EXECUTED" })).toThrow(/CHECK constraint failed/);
+    expect(() => insert({ external_effect: 1 })).toThrow(/CHECK constraint failed/);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
   "include": ["src", "test", "vite.config.ts"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Slice

MVP-3-APPROVAL-LEDGER-CORE-V1 (umbrella GO slice B)

## Stable decision fingerprint

`src/domain/decisionFingerprint.ts`

- Canonical decision-target facts: repository, action sourceRefs, humanActionStatus, evidenceState, per-PR evidence (number, draft, ci, review, mergeState, humanDecision, humanDecisionRequired, sourceRefs).
- Excludes observedAt, approver identity, recordedAt, recordId, idempotencyKey, UI state.
- Normalization before hashing: sourceRefs sorted + deduped, PR evidence sorted by number, recursive key-sorted canonical JSON, SHA-256 hex.
- `computeRecordableDecision` returns a fingerprint only for ACTION_REQUIRED + CONFIRMED — the browser never computes the authoritative fingerprint.

## Status API

`GET /api/status` now includes `decisionFingerprint` when and only when a recordable decision candidate exists (`src/worker/statusApi.ts`).

## D1 schema (versioned migration)

`migrations/0001_approval_ledger.sql` — `approval_ledger_records` with all contract fields; DB-level CHECKs pin `human_action_status='ACTION_REQUIRED'`, `evidence_state='CONFIRMED'`, `intent IN (APPROVE,REJECT,DEFER)`, `submission_state='RECORDED'`, `external_effect=0`; UNIQUE index on (approver_issuer, approver_subject_id, idempotency_key); BEFORE UPDATE / BEFORE DELETE triggers raise ABORT (append-only at the DB level, in addition to the application layer exposing no UPDATE/DELETE endpoint).

## Record API — POST /api/ledger/records

authenticate → authorize (slice A guard) → validate body → idempotent-replay check → live `observeRepository()` → `resolveHumanAction()` → require CONFIRMED + ACTION_REQUIRED → compute server fingerprint → compare `expectedDecisionFingerprint` → append.

- Fingerprint mismatch ⇒ `409 STALE_DECISION`, zero writes; the request is never silently refreshed and recorded.
- Non-recordable live state ⇒ `409 NO_RECORDABLE_DECISION`, zero writes.
- `Idempotency-Key` header required; scope = approver issuer + subjectId + key. Identical retry replays the existing record (HTTP 200, no duplicate) — the replay check runs before re-observation so a blind retry after an unknown network result still returns the durable record. Same key + different semantic payload ⇒ `409 IDEMPOTENCY_CONFLICT`, no write. The key is never identity proof — scope comes from the verified principal only.
- Unique-index race on insert is re-read and resolved as replay/conflict.

## Read API — GET /api/ledger/records

Authenticated + authorized (`ledger.read`); most recent 50, newest first; audit fields only (no idempotency key, no raw decision-facts JSON, no secrets).

## Tests (+37; 105 total, verify PASS)

Fingerprint: same facts/different observedAt ⇒ SAME; non-semantic array ordering ⇒ SAME; sourceRefs / CI / review / mergeState / humanDecision / repository change ⇒ DIFFERENT; non-ACTION_REQUIRED / non-CONFIRMED ⇒ no fingerprint.
Store tests run against the real migration SQL on real SQLite (`node:sqlite`), proving triggers block UPDATE/DELETE and CHECKs reject invariant violations.
API tests cover the full guard→observe→compare→append flow, stale refusal, replay, conflict, cross-principal key isolation and 503 without a D1 binding.

## Non-effects

No wrangler deploy config change, no production mutation, no GitHub/SharePoint/Agent effects. `external_effect = 0` is enforced at the DB level.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d49c0dc-75c4-4736-994d-4b65916bafac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d49c0dc-75c4-4736-994d-4b65916bafac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

