### PR TITLE
feat(mvp3): MVP-3-APPROVAL-LEDGER-UI-V1 — 「Ledger に記録」 submission + history view

### DIFF
--- a/src/domain/ledgerSubmission.ts
+++ b/src/domain/ledgerSubmission.ts
@@ -1,0 +1,187 @@
+import type { ApprovalIntent } from "./approvalIntent";
+
+/**
+ * Client-side Ledger submission state machine.
+ *
+ * Pure logic (testable without React):
+ * - one idempotency key per submission attempt, generated when the Human
+ *   presses 「Ledger に記録」 and retained for blind retries;
+ * - unknown network results retry with the SAME key (never auto-regenerated);
+ * - 409 STALE_DECISION discards the stale local intent and requires the Human
+ *   to choose again after a status refresh — never auto-resubmits.
+ */
+export interface LedgerSubmissionAttempt {
+  idempotencyKey: string;
+  intent: ApprovalIntent;
+  expectedDecisionFingerprint: string;
+}
+
+/** Audit projection returned by the Ledger APIs. */
+export interface LedgerRecordSummary {
+  recordId: string;
+  repository: string;
+  sourceRefs: string[];
+  intent: string;
+  recordedAt: string;
+  observedAt: string;
+  decisionFingerprint: string;
+  submissionState: string;
+  externalEffect: boolean;
+  approver?: { issuer: string; subjectId: string };
+}
+
+export type LedgerSubmitOutcome =
+  | { kind: "RECORDED"; replayed: boolean; record: LedgerRecordSummary }
+  | { kind: "STALE_DECISION" }
+  | { kind: "NO_RECORDABLE_DECISION" }
+  | { kind: "IDEMPOTENCY_CONFLICT" }
+  | { kind: "UNAUTHENTICATED" }
+  | { kind: "FORBIDDEN" }
+  | { kind: "LEDGER_UNAVAILABLE" }
+  /** Result unknown (network failure / 5xx / malformed success) — retry with SAME key. */
+  | { kind: "UNKNOWN_RESULT" };
+
+export type LedgerSubmissionState =
+  | { phase: "IDLE" }
+  | { phase: "SUBMITTING"; attempt: LedgerSubmissionAttempt }
+  | { phase: "RECORDED"; record: LedgerRecordSummary; replayed: boolean }
+  /** Unknown result: keep the SAME attempt for manual retry. */
+  | { phase: "RETRYABLE"; attempt: LedgerSubmissionAttempt }
+  /** Stale decision: local intent discarded; Human must choose again. */
+  | { phase: "STALE" }
+  | {
+      phase: "REFUSED";
+      code: "NO_RECORDABLE_DECISION" | "IDEMPOTENCY_CONFLICT" | "UNAUTHENTICATED" | "FORBIDDEN" | "LEDGER_UNAVAILABLE";
+    };
+
+/**
+ * Create one submission attempt with a fresh idempotency key.
+ * Returns null when there is no server-provided fingerprint — the browser
+ * never invents the authoritative fingerprint.
+ */
+export function beginLedgerSubmission(
+  intent: ApprovalIntent,
+  expectedDecisionFingerprint: string | null | undefined,
+  generateKey: () => string = () => crypto.randomUUID(),
+): LedgerSubmissionAttempt | null {
+  if (!expectedDecisionFingerprint) return null;
+  return {
+    idempotencyKey: generateKey(),
+    intent,
+    expectedDecisionFingerprint,
+  };
+}
+
+/** The attempt to reuse for a manual retry after an unknown result — same key. */
+export function retryableAttempt(state: LedgerSubmissionState): LedgerSubmissionAttempt | null {
+  return state.phase === "RETRYABLE" ? state.attempt : null;
+}
+
+function parseRecordSummary(value: unknown): LedgerRecordSummary | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.recordId !== "string" || typeof record.recordedAt !== "string") return null;
+  if (record.externalEffect !== false || record.submissionState !== "RECORDED") return null;
+  return {
+    recordId: record.recordId,
+    repository: typeof record.repository === "string" ? record.repository : "",
+    sourceRefs: Array.isArray(record.sourceRefs)
+      ? record.sourceRefs.filter((ref): ref is string => typeof ref === "string")
+      : [],
+    intent: typeof record.intent === "string" ? record.intent : "",
+    recordedAt: record.recordedAt,
+    observedAt: typeof record.observedAt === "string" ? record.observedAt : "",
+    decisionFingerprint:
+      typeof record.decisionFingerprint === "string" ? record.decisionFingerprint : "",
+    submissionState: "RECORDED",
+    externalEffect: false,
+    approver:
+      typeof record.approver === "object" &&
+      record.approver !== null &&
+      typeof (record.approver as Record<string, unknown>).issuer === "string" &&
+      typeof (record.approver as Record<string, unknown>).subjectId === "string"
+        ? {
+            issuer: (record.approver as Record<string, string>).issuer,
+            subjectId: (record.approver as Record<string, string>).subjectId,
+          }
+        : undefined,
+  };
+}
+
+/**
+ * Classify an HTTP result from POST /api/ledger/records.
+ * Anything ambiguous is UNKNOWN_RESULT so the Human can retry with the same key.
+ */
+export function classifyLedgerResponse(status: number, body: unknown): LedgerSubmitOutcome {
+  const error =
+    typeof body === "object" && body !== null && typeof (body as Record<string, unknown>).error === "string"
+      ? ((body as Record<string, unknown>).error as string)
+      : null;
+
+  if (status === 200 || status === 201) {
+    const payload = body as Record<string, unknown> | null;
+    const record = payload ? parseRecordSummary(payload.record) : null;
+    if (payload?.recorded === true && record) {
+      return { kind: "RECORDED", replayed: payload.replayed === true, record };
+    }
+    return { kind: "UNKNOWN_RESULT" };
+  }
+
+  if (status === 409) {
+    if (error === "STALE_DECISION") return { kind: "STALE_DECISION" };
+    if (error === "NO_RECORDABLE_DECISION") return { kind: "NO_RECORDABLE_DECISION" };
+    if (error === "IDEMPOTENCY_CONFLICT") return { kind: "IDEMPOTENCY_CONFLICT" };
+    return { kind: "UNKNOWN_RESULT" };
+  }
+
+  if (status === 401) return { kind: "UNAUTHENTICATED" };
+  if (status === 403) return { kind: "FORBIDDEN" };
+  if (status === 503) return { kind: "LEDGER_UNAVAILABLE" };
+  if (status >= 400 && status < 500) return { kind: "UNKNOWN_RESULT" };
+  return { kind: "UNKNOWN_RESULT" };
+}
+
+export interface LedgerOutcomeEffect {
+  state: LedgerSubmissionState;
+  /** Discard the stale local intent draft (Human must choose again). */
+  discardIntent: boolean;
+  /** Re-fetch server status (fresh fingerprint) before the next choice. */
+  refreshStatus: boolean;
+}
+
+/** Apply a submission outcome. Never auto-resubmits. */
+export function applyLedgerOutcome(
+  attempt: LedgerSubmissionAttempt,
+  outcome: LedgerSubmitOutcome,
+): LedgerOutcomeEffect {
+  switch (outcome.kind) {
+    case "RECORDED":
+      return {
+        state: { phase: "RECORDED", record: outcome.record, replayed: outcome.replayed },
+        discardIntent: true,
+        refreshStatus: true,
+      };
+    case "STALE_DECISION":
+      return { state: { phase: "STALE" }, discardIntent: true, refreshStatus: true };
+    case "NO_RECORDABLE_DECISION":
+      return {
+        state: { phase: "REFUSED", code: "NO_RECORDABLE_DECISION" },
+        discardIntent: true,
+        refreshStatus: true,
+      };
+    case "IDEMPOTENCY_CONFLICT":
+      return {
+        state: { phase: "REFUSED", code: "IDEMPOTENCY_CONFLICT" },
+        discardIntent: true,
+        refreshStatus: true,
+      };
+    case "UNAUTHENTICATED":
+      return { state: { phase: "REFUSED", code: "UNAUTHENTICATED" }, discardIntent: false, refreshStatus: false };
+    case "FORBIDDEN":
+      return { state: { phase: "REFUSED", code: "FORBIDDEN" }, discardIntent: false, refreshStatus: false };
+    case "LEDGER_UNAVAILABLE":
+      return { state: { phase: "REFUSED", code: "LEDGER_UNAVAILABLE" }, discardIntent: false, refreshStatus: false };
+    case "UNKNOWN_RESULT":
+      return { state: { phase: "RETRYABLE", attempt }, discardIntent: false, refreshStatus: false };
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   buildApprovalIntentFingerprint,
   isApprovalIntentUiAllowed,
@@ -8,7 +8,17 @@ import {
   type ApprovalIntentDraft,
 } from "../domain/approvalIntent";
 import type { HumanAction } from "../domain/humanAction";
+import {
+  applyLedgerOutcome,
+  beginLedgerSubmission,
+  retryableAttempt,
+  type LedgerSubmissionAttempt,
+  type LedgerSubmissionState,
+} from "../domain/ledgerSubmission";
 import { ApprovalIntentPanel } from "./ApprovalIntentPanel";
+import { fetchLedgerHistory, postLedgerRecord, type LedgerHistoryResult } from "./ledgerApi";
+import { LedgerHistoryPanel } from "./LedgerHistoryPanel";
+import { LedgerRecordControls } from "./LedgerRecordControls";
 
 type PrEvidence = {
   pr: number;
@@ -31,6 +41,8 @@ type StatusResponse = {
   };
   evidence: PrEvidence[] | null;
   observedAt: string;
+  /** Server-computed; present only when a recordable decision candidate exists. */
+  decisionFingerprint?: string;
 };
 
 const fallback: HumanAction = {
@@ -45,34 +57,42 @@ export function App() {
   const [data, setData] = useState<StatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [intentDraft, setIntentDraft] = useState<ApprovalIntentDraft | null>(null);
+  const [submission, setSubmission] = useState<LedgerSubmissionState>({ phase: "IDLE" });
+  const [history, setHistory] = useState<LedgerHistoryResult | null>(null);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const response = await fetch("/api/status", { cache: "no-store" });
+      if (!response.ok) throw new Error("status request failed");
+      setData((await response.json()) as StatusResponse);
+    } catch {
+      setData({
+        action: fallback,
+        developmentStatus: {
+          repository: "severe-behavior-support-spfx",
+          main: "Unknown",
+          openPrCount: null,
+          evidenceState: "ERROR",
+        },
+        evidence: null,
+        observedAt: new Date().toISOString(),
+      });
+    }
+  }, []);
+
+  const loadHistory = useCallback(async () => {
+    setHistory(await fetchLedgerHistory());
+  }, []);
 
   useEffect(() => {
-    fetch("/api/status", { cache: "no-store" })
-      .then((response) => {
-        if (!response.ok) throw new Error("status request failed");
-        return response.json() as Promise<StatusResponse>;
-      })
-      .then(setData)
-      .catch(() =>
-        setData({
-          action: fallback,
-          developmentStatus: {
-            repository: "severe-behavior-support-spfx",
-            main: "Unknown",
-            openPrCount: null,
-            evidenceState: "ERROR",
-          },
-          evidence: null,
-          observedAt: new Date().toISOString(),
-        }),
-      )
-      .finally(() => setLoading(false));
-  }, []);
+    Promise.all([loadStatus(), loadHistory()]).finally(() => setLoading(false));
+  }, [loadStatus, loadHistory]);
 
   const action = data?.action ?? fallback;
   const evidenceState = data?.developmentStatus.evidenceState;
   const approvalAllowed = isApprovalIntentUiAllowed(action.status, evidenceState);
-  const fingerprint = data
+  const serverFingerprint = data?.decisionFingerprint ?? null;
+  const localFingerprint = data
     ? buildApprovalIntentFingerprint({
         actionStatus: action.status,
         evidenceState,
@@ -83,12 +103,38 @@ export function App() {
     : "";
 
   useEffect(() => {
-    setIntentDraft((current) => reconcileApprovalIntentDraft(current, fingerprint, approvalAllowed));
-  }, [fingerprint, approvalAllowed]);
+    setIntentDraft((current) => reconcileApprovalIntentDraft(current, localFingerprint, approvalAllowed));
+  }, [localFingerprint, approvalAllowed]);
 
   function handleSelectIntent(intent: ApprovalIntent) {
-    const result = selectApprovalIntent(approvalAllowed, intent, fingerprint);
+    const result = selectApprovalIntent(approvalAllowed, intent, localFingerprint);
     setIntentDraft(result.draft);
+    // A fresh choice starts a fresh submission context (a later press generates a new key).
+    setSubmission({ phase: "IDLE" });
+  }
+
+  async function submitAttempt(attempt: LedgerSubmissionAttempt) {
+    setSubmission({ phase: "SUBMITTING", attempt });
+    const outcome = await postLedgerRecord(attempt);
+    const effect = applyLedgerOutcome(attempt, outcome);
+    setSubmission(effect.state);
+    if (effect.discardIntent) setIntentDraft(null);
+    if (effect.refreshStatus) await loadStatus();
+    if (effect.state.phase === "RECORDED") await loadHistory();
+  }
+
+  function handleRecord() {
+    if (!intentDraft) return;
+    const attempt = beginLedgerSubmission(intentDraft.intent, serverFingerprint);
+    if (!attempt) return;
+    void submitAttempt(attempt);
+  }
+
+  function handleRetry() {
+    // Blind retry after an unknown result reuses the SAME idempotency key.
+    const attempt = retryableAttempt(submission);
+    if (!attempt) return;
+    void submitAttempt(attempt);
   }
 
   return (
@@ -120,6 +166,18 @@ export function App() {
           onSelect={handleSelectIntent}
         />
       )}
+
+      {!loading && (approvalAllowed || submission.phase !== "IDLE") && (
+        <LedgerRecordControls
+          draft={intentDraft}
+          decisionFingerprint={serverFingerprint}
+          submission={submission}
+          onRecord={handleRecord}
+          onRetry={handleRetry}
+        />
+      )}
+
+      {!loading && <LedgerHistoryPanel history={history} />}
 
       <details className="details-card">
         <summary>理由と参照元を見る</summary>

--- a/src/ui/ApprovalIntentPanel.tsx
+++ b/src/ui/ApprovalIntentPanel.tsx
@@ -41,7 +41,8 @@ export function ApprovalIntentPanel({
     <section className="approval-intent-card" aria-label="Approval Intent local draft">
       <h2>Approval Intent（案）</h2>
       <p className="approval-intent-note">
-        これは実際の承認ではありません。選択は端末上の一時案のみで、外部へ送信・保存されません。
+        これは実際の承認ではありません。選択は端末上の一時案です。「Ledger に記録」を押した場合のみ
+        監査用 Ledger に追記されます（実行・Merge・外部システムへの反映は行われません）。
       </p>
 
       <dl className="approval-intent-evidence">

--- a/src/ui/LedgerHistoryPanel.tsx
+++ b/src/ui/LedgerHistoryPanel.tsx
@@ -1,0 +1,94 @@
+import type { LedgerRecordSummary } from "../domain/ledgerSubmission";
+import type { LedgerHistoryResult } from "./ledgerApi";
+
+type Props = {
+  history: LedgerHistoryResult | null;
+};
+
+/**
+ * Compact append-only Ledger history (newest first).
+ * Raw approver issuer/subjectId appear only inside expandable audit details.
+ */
+export function LedgerHistoryPanel({ history }: Props) {
+  return (
+    <section className="ledger-history-card" aria-label="Ledger history">
+      <h2>Ledger 履歴</h2>
+
+      {history === null && <p>Ledger 履歴を読み込んでいます…</p>}
+
+      {history && !history.ok && (
+        <p role="status">
+          {history.reason === "UNAUTHENTICATED" || history.reason === "FORBIDDEN"
+            ? "Ledger 履歴を表示するには認証・認可が必要です。"
+            : "Ledger 履歴を取得できませんでした。"}
+        </p>
+      )}
+
+      {history?.ok && history.records.length === 0 && <p>Ledger 記録はまだありません。</p>}
+
+      {history?.ok && history.records.length > 0 && (
+        <ul className="ledger-history-list">
+          {history.records.map((record) => (
+            <li key={record.recordId}>
+              <div className="ledger-history-main">
+                <strong>{record.intent}</strong>
+                {" — "}
+                {record.recordedAt}
+                {" / "}
+                {shortRepo(record.repository)}
+                <span className="ledger-history-flag">NOT EXECUTED</span>
+              </div>
+              <div className="ledger-history-refs">
+                {record.sourceRefs.length > 0 ? record.sourceRefs.join(", ") : "(no source refs)"}
+              </div>
+              <div className="ledger-history-id">recordId: {record.recordId}</div>
+              <details>
+                <summary>監査詳細</summary>
+                <AuditDetails record={record} />
+              </details>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function AuditDetails({ record }: { record: LedgerRecordSummary }) {
+  return (
+    <dl className="ledger-history-audit">
+      <div>
+        <dt>decisionFingerprint</dt>
+        <dd>{record.decisionFingerprint}</dd>
+      </div>
+      <div>
+        <dt>observedAt</dt>
+        <dd>{record.observedAt}</dd>
+      </div>
+      <div>
+        <dt>submissionState</dt>
+        <dd>{record.submissionState}</dd>
+      </div>
+      <div>
+        <dt>externalEffect</dt>
+        <dd>{String(record.externalEffect)}</dd>
+      </div>
+      {record.approver && (
+        <>
+          <div>
+            <dt>approver.issuer</dt>
+            <dd>{record.approver.issuer}</dd>
+          </div>
+          <div>
+            <dt>approver.subjectId</dt>
+            <dd>{record.approver.subjectId}</dd>
+          </div>
+        </>
+      )}
+    </dl>
+  );
+}
+
+function shortRepo(repository: string): string {
+  return repository.split("/").at(-1) ?? repository;
+}

--- a/src/ui/LedgerRecordControls.tsx
+++ b/src/ui/LedgerRecordControls.tsx
@@ -1,0 +1,108 @@
+import { approvalIntentLabel, type ApprovalIntentDraft } from "../domain/approvalIntent";
+import type { LedgerSubmissionState } from "../domain/ledgerSubmission";
+
+type Props = {
+  draft: ApprovalIntentDraft | null;
+  /** Server-provided authoritative fingerprint; null when nothing is recordable. */
+  decisionFingerprint: string | null;
+  submission: LedgerSubmissionState;
+  onRecord: () => void;
+  onRetry: () => void;
+};
+
+/**
+ * 「Ledger に記録」 controls.
+ * Recording appends one immutable Ledger record. It never executes, merges or
+ * reflects anything externally — result wording states NOT EXECUTED explicitly.
+ */
+export function LedgerRecordControls({
+  draft,
+  decisionFingerprint,
+  submission,
+  onRecord,
+  onRetry,
+}: Props) {
+  const busy = submission.phase === "SUBMITTING";
+
+  return (
+    <section className="ledger-record-card" aria-label="Ledger record controls">
+      <h2>Ledger 記録</h2>
+      <p className="ledger-record-note">
+        「Ledger に記録」は現在の判断案を監査用 Ledger
+        に追記するだけです。実行・Merge・外部システムへの反映は行われません。
+      </p>
+
+      {draft && decisionFingerprint && (
+        <div className="ledger-record-submit">
+          <p>
+            記録する判断案: <strong>{approvalIntentLabel(draft.intent)}</strong>（{draft.intent}）
+          </p>
+          <button type="button" onClick={onRecord} disabled={busy}>
+            {busy ? "記録中…" : "Ledger に記録"}
+          </button>
+        </div>
+      )}
+
+      {draft && !decisionFingerprint && (
+        <p role="status">
+          サーバーの decision fingerprint が取得できないため、Ledger 記録は行えません。
+        </p>
+      )}
+
+      {submission.phase === "RECORDED" && (
+        <div className="ledger-record-result recorded" role="status">
+          <p>
+            <strong>Ledger に記録済み</strong>
+            {submission.replayed ? "（再送を検出し、既存の記録を返しました）" : ""}
+          </p>
+          <p>NOT EXECUTED</p>
+          <p>外部システムには反映されていません</p>
+          <p className="ledger-record-meta">
+            recordId: {submission.record.recordId} / intent: {submission.record.intent} / recordedAt:{" "}
+            {submission.record.recordedAt}
+          </p>
+        </div>
+      )}
+
+      {submission.phase === "RETRYABLE" && (
+        <div className="ledger-record-result retryable" role="status">
+          <p>通信結果が不明です。記録されたかどうか確認できませんでした。</p>
+          <p>同じ Idempotency-Key で再試行できます（重複記録は発生しません）。</p>
+          <button type="button" onClick={onRetry}>
+            同じキーで再試行
+          </button>
+        </div>
+      )}
+
+      {submission.phase === "STALE" && (
+        <div className="ledger-record-result stale" role="status">
+          <p>判断対象の状態が変わったため、記録しませんでした（STALE_DECISION）。</p>
+          <p>最新の状態を確認し、もう一度選択してください。ローカルの判断案は破棄されました。</p>
+        </div>
+      )}
+
+      {submission.phase === "REFUSED" && (
+        <div className="ledger-record-result refused" role="status">
+          <p>{refusedMessage(submission.code)}</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function refusedMessage(
+  code: Extract<LedgerSubmissionState, { phase: "REFUSED" }>["code"],
+): string {
+  switch (code) {
+    case "NO_RECORDABLE_DECISION":
+      return "現在は記録可能な判断対象がありません。最新の状態を確認してください。";
+    case "IDEMPOTENCY_CONFLICT":
+      return "同じキーで内容の異なる記録要求が検出されたため、記録しませんでした。もう一度選択からやり直してください。";
+    case "UNAUTHENTICATED":
+      return "認証されていないため、Ledger に記録できません。";
+    case "FORBIDDEN":
+      return "この操作は許可されていないため、Ledger に記録できません。";
+    case "LEDGER_UNAVAILABLE":
+      return "Ledger ストレージが利用できないため、記録できません。";
+  }
+}

--- a/src/ui/ledgerApi.ts
+++ b/src/ui/ledgerApi.ts
@@ -1,0 +1,53 @@
+import {
+  classifyLedgerResponse,
+  type LedgerRecordSummary,
+  type LedgerSubmissionAttempt,
+  type LedgerSubmitOutcome,
+} from "../domain/ledgerSubmission";
+
+/** POST one Ledger record attempt. Network failures classify as UNKNOWN_RESULT. */
+export async function postLedgerRecord(
+  attempt: LedgerSubmissionAttempt,
+): Promise<LedgerSubmitOutcome> {
+  try {
+    const response = await fetch("/api/ledger/records", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": attempt.idempotencyKey,
+      },
+      body: JSON.stringify({
+        intent: attempt.intent,
+        expectedDecisionFingerprint: attempt.expectedDecisionFingerprint,
+      }),
+    });
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+    return classifyLedgerResponse(response.status, body);
+  } catch {
+    return { kind: "UNKNOWN_RESULT" };
+  }
+}
+
+export type LedgerHistoryResult =
+  | { ok: true; records: LedgerRecordSummary[] }
+  | { ok: false; reason: "UNAUTHENTICATED" | "FORBIDDEN" | "UNAVAILABLE" };
+
+/** GET recent Ledger history (newest first, server-capped at 50). */
+export async function fetchLedgerHistory(): Promise<LedgerHistoryResult> {
+  try {
+    const response = await fetch("/api/ledger/records", { cache: "no-store" });
+    if (response.status === 401) return { ok: false, reason: "UNAUTHENTICATED" };
+    if (response.status === 403) return { ok: false, reason: "FORBIDDEN" };
+    if (!response.ok) return { ok: false, reason: "UNAVAILABLE" };
+    const body = (await response.json()) as { records?: unknown };
+    if (!Array.isArray(body.records)) return { ok: false, reason: "UNAVAILABLE" };
+    return { ok: true, records: body.records as LedgerRecordSummary[] };
+  } catch {
+    return { ok: false, reason: "UNAVAILABLE" };
+  }
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -7,7 +7,8 @@
 body { margin: 0; min-width: 320px; min-height: 100vh; }
 button, input, textarea, select { font: inherit; }
 .shell { width: min(100%, 720px); margin: 0 auto; padding: 20px 16px 48px; }
-.action-card, .status-card, .details-card, .approval-intent-card {
+.action-card, .status-card, .details-card, .approval-intent-card,
+.ledger-record-card, .ledger-history-card {
   background: #fff;
   border: 1px solid #dfe5dc;
   border-radius: 20px;
@@ -65,6 +66,55 @@ summary { cursor: pointer; font-weight: 700; }
 }
 .approval-intent-draft p { margin: 0 0 6px; color: #5f675f; line-height: 1.5; }
 .approval-intent-draft p:last-child { margin-bottom: 0; }
+.ledger-record-card, .ledger-history-card { margin-top: 16px; padding: 20px; }
+.ledger-record-card h2, .ledger-history-card h2 { margin: 0 0 8px; font-size: 1.05rem; }
+.ledger-record-note { margin: 0 0 16px; color: #5f675f; line-height: 1.6; }
+.ledger-record-submit p { margin: 0 0 10px; line-height: 1.6; }
+.ledger-record-submit button, .ledger-record-result button {
+  border: 1px solid #355d3a;
+  background: #355d3a;
+  color: #fff;
+  border-radius: 12px;
+  padding: 10px 16px;
+  cursor: pointer;
+  font-weight: 700;
+}
+.ledger-record-submit button:disabled { opacity: 0.6; cursor: wait; }
+.ledger-record-result {
+  margin-top: 16px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid #c9d2c6;
+  background: #f8faf6;
+}
+.ledger-record-result p { margin: 0 0 6px; line-height: 1.55; color: #3c463d; }
+.ledger-record-result p:last-child { margin-bottom: 0; }
+.ledger-record-result.recorded { border-color: #355d3a; background: #e7efe6; }
+.ledger-record-result.stale { border-color: #8a722a; background: #fff9eb; }
+.ledger-record-result.retryable { border-color: #8a722a; background: #fff9eb; }
+.ledger-record-result.refused { border-color: #a25050; background: #fdf1f0; }
+.ledger-record-meta { font-size: 0.85rem; color: #657066; overflow-wrap: anywhere; }
+.ledger-history-list { list-style: none; margin: 0; padding: 0; }
+.ledger-history-list li { padding: 12px 0; border-top: 1px solid #edf0eb; }
+.ledger-history-list li:first-child { border-top: 0; }
+.ledger-history-main { line-height: 1.6; }
+.ledger-history-flag {
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #eef1ec;
+  color: #52755a;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+.ledger-history-refs, .ledger-history-id {
+  color: #657066;
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+  line-height: 1.5;
+}
+.ledger-history-audit { margin: 8px 0 0; }
+.ledger-history-audit div { grid-template-columns: 160px 1fr; }
 @media (min-width: 640px) {
   .shell { padding-top: 40px; }
   .action-card { padding: 32px; }

--- a/test/ledgerSubmission.test.ts
+++ b/test/ledgerSubmission.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyLedgerOutcome,
+  beginLedgerSubmission,
+  classifyLedgerResponse,
+  retryableAttempt,
+  type LedgerRecordSummary,
+  type LedgerSubmissionAttempt,
+} from "../src/domain/ledgerSubmission";
+
+const RECORD: LedgerRecordSummary = {
+  recordId: "rec-1",
+  repository: "yasutakesougo/severe-behavior-support-spfx",
+  sourceRefs: ["https://github.com/o/r/pull/7"],
+  intent: "APPROVE",
+  recordedAt: "2026-08-11T10:01:00.000Z",
+  observedAt: "2026-08-11T10:00:00.000Z",
+  decisionFingerprint: "f".repeat(64),
+  submissionState: "RECORDED",
+  externalEffect: false,
+};
+
+function makeAttempt(): LedgerSubmissionAttempt {
+  return beginLedgerSubmission("APPROVE", "f".repeat(64), () => "key-fixed")!;
+}
+
+describe("beginLedgerSubmission", () => {
+  it("generates one idempotency key per submission attempt", () => {
+    let count = 0;
+    const generate = () => `key-${++count}`;
+    const first = beginLedgerSubmission("APPROVE", "fp", generate);
+    const second = beginLedgerSubmission("REJECT", "fp", generate);
+
+    expect(first?.idempotencyKey).toBe("key-1");
+    expect(second?.idempotencyKey).toBe("key-2");
+    expect(first?.intent).toBe("APPROVE");
+    expect(first?.expectedDecisionFingerprint).toBe("fp");
+  });
+
+  it("defaults to crypto.randomUUID for key generation", () => {
+    const attempt = beginLedgerSubmission("DEFER", "fp");
+    expect(attempt?.idempotencyKey).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("refuses to build an attempt without a server-provided fingerprint", () => {
+    expect(beginLedgerSubmission("APPROVE", null)).toBeNull();
+    expect(beginLedgerSubmission("APPROVE", undefined)).toBeNull();
+    expect(beginLedgerSubmission("APPROVE", "")).toBeNull();
+  });
+});
+
+describe("classifyLedgerResponse", () => {
+  it("classifies a recorded result", () => {
+    const outcome = classifyLedgerResponse(201, { recorded: true, replayed: false, record: RECORD });
+    expect(outcome).toEqual({ kind: "RECORDED", replayed: false, record: RECORD });
+  });
+
+  it("classifies an idempotent replay", () => {
+    const outcome = classifyLedgerResponse(200, { recorded: true, replayed: true, record: RECORD });
+    expect(outcome.kind).toBe("RECORDED");
+    if (outcome.kind === "RECORDED") expect(outcome.replayed).toBe(true);
+  });
+
+  it("treats a malformed success payload as UNKNOWN_RESULT (safe to retry with same key)", () => {
+    expect(classifyLedgerResponse(200, null).kind).toBe("UNKNOWN_RESULT");
+    expect(classifyLedgerResponse(201, { recorded: true }).kind).toBe("UNKNOWN_RESULT");
+    expect(
+      classifyLedgerResponse(201, {
+        recorded: true,
+        record: { ...RECORD, externalEffect: true },
+      }).kind,
+    ).toBe("UNKNOWN_RESULT");
+  });
+
+  it("classifies 409 refusals", () => {
+    expect(classifyLedgerResponse(409, { error: "STALE_DECISION" }).kind).toBe("STALE_DECISION");
+    expect(classifyLedgerResponse(409, { error: "NO_RECORDABLE_DECISION" }).kind).toBe(
+      "NO_RECORDABLE_DECISION",
+    );
+    expect(classifyLedgerResponse(409, { error: "IDEMPOTENCY_CONFLICT" }).kind).toBe(
+      "IDEMPOTENCY_CONFLICT",
+    );
+  });
+
+  it("classifies auth and availability failures", () => {
+    expect(classifyLedgerResponse(401, { error: "UNAUTHENTICATED" }).kind).toBe("UNAUTHENTICATED");
+    expect(classifyLedgerResponse(403, { error: "FORBIDDEN" }).kind).toBe("FORBIDDEN");
+    expect(classifyLedgerResponse(503, { error: "LEDGER_UNAVAILABLE" }).kind).toBe("LEDGER_UNAVAILABLE");
+  });
+
+  it("classifies 5xx as UNKNOWN_RESULT", () => {
+    expect(classifyLedgerResponse(500, null).kind).toBe("UNKNOWN_RESULT");
+    expect(classifyLedgerResponse(502, "bad gateway").kind).toBe("UNKNOWN_RESULT");
+  });
+});
+
+describe("applyLedgerOutcome", () => {
+  it("RECORDED shows the record and refreshes state", () => {
+    const attempt = makeAttempt();
+    const effect = applyLedgerOutcome(attempt, { kind: "RECORDED", replayed: false, record: RECORD });
+
+    expect(effect.state).toEqual({ phase: "RECORDED", record: RECORD, replayed: false });
+    expect(effect.discardIntent).toBe(true);
+    expect(effect.refreshStatus).toBe(true);
+  });
+
+  it("STALE_DECISION discards the stale local intent and refreshes status (no auto-resubmit)", () => {
+    const attempt = makeAttempt();
+    const effect = applyLedgerOutcome(attempt, { kind: "STALE_DECISION" });
+
+    expect(effect.state).toEqual({ phase: "STALE" });
+    expect(effect.discardIntent).toBe(true);
+    expect(effect.refreshStatus).toBe(true);
+    // No retry attempt is preserved: the Human must choose again.
+    expect(retryableAttempt(effect.state)).toBeNull();
+  });
+
+  it("UNKNOWN_RESULT keeps the SAME attempt (same idempotency key) for manual retry", () => {
+    const attempt = makeAttempt();
+    const effect = applyLedgerOutcome(attempt, { kind: "UNKNOWN_RESULT" });
+
+    expect(effect.state.phase).toBe("RETRYABLE");
+    expect(effect.discardIntent).toBe(false);
+    const retry = retryableAttempt(effect.state);
+    expect(retry).toBe(attempt);
+    expect(retry?.idempotencyKey).toBe("key-fixed");
+  });
+
+  it("IDEMPOTENCY_CONFLICT requires starting over (no retry with the same key)", () => {
+    const attempt = makeAttempt();
+    const effect = applyLedgerOutcome(attempt, { kind: "IDEMPOTENCY_CONFLICT" });
+
+    expect(effect.state).toEqual({ phase: "REFUSED", code: "IDEMPOTENCY_CONFLICT" });
+    expect(effect.discardIntent).toBe(true);
+    expect(retryableAttempt(effect.state)).toBeNull();
+  });
+
+  it("auth failures do not discard the local intent (Human may re-authenticate)", () => {
+    const attempt = makeAttempt();
+    for (const kind of ["UNAUTHENTICATED", "FORBIDDEN"] as const) {
+      const effect = applyLedgerOutcome(attempt, { kind });
+      expect(effect.state).toEqual({ phase: "REFUSED", code: kind });
+      expect(effect.discardIntent).toBe(false);
+      expect(retryableAttempt(effect.state)).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Slice

MVP-3-APPROVAL-LEDGER-UI-V1 (umbrella GO slice C)

## What

Connects the existing Approval Intent UI (APPROVE / REJECT / DEFER local selection, unchanged) to the Ledger:

- `src/domain/ledgerSubmission.ts` — pure, tested submission state machine:
  - `beginLedgerSubmission` generates one `crypto.randomUUID()` idempotency key per submission attempt and refuses to build an attempt without the server-provided `expectedDecisionFingerprint` (browser never invents the authoritative fingerprint).
  - `classifyLedgerResponse` maps HTTP results; anything ambiguous (network failure, 5xx, malformed success) is `UNKNOWN_RESULT`.
  - `applyLedgerOutcome`: unknown result keeps the SAME attempt (same key) for manual retry — no automatic new key for blind retry; `STALE_DECISION` discards the stale local intent, triggers a status refresh, and requires the Human to choose again — never auto-resubmits.
- `src/ui/LedgerRecordControls.tsx` — explicit 「Ledger に記録」 action (never 承認する/実行する/反映する/Merge). Success wording: 「Ledger に記録済み」+「NOT EXECUTED」+「外部システムには反映されていません」. No execution-implying wording anywhere.
- `src/ui/LedgerHistoryPanel.tsx` — compact history: recordedAt, intent, repository/target refs, recordId, NOT EXECUTED badge. Raw approver issuer + subjectId only inside expandable 監査詳細.
- `src/ui/App.tsx` — uses server `decisionFingerprint` from `/api/status`; reloads status + history after outcomes per the state machine effects.
- Approval Intent panel note updated to reflect that recording only appends to the audit Ledger.

## Tests (+14; 119 total, verify PASS)

Key-per-attempt generation, same-key blind retry, no-fingerprint refusal, response classification (recorded/replayed/stale/conflict/auth/5xx-unknown), stale discards intent with no retained retry attempt, conflict requires starting over.

## Local runtime smoke (wrangler dev, no Access/D1 config)

`GET /` 200; `GET|POST /api/ledger/records` 401 (fail closed); `PUT` 405; `/api/auth/status` 401.

## Non-effects

No GitHub/SharePoint/Agent runtime capability; recording appends one Ledger row only; production untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d49c0dc-75c4-4736-994d-4b65916bafac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d49c0dc-75c4-4736-994d-4b65916bafac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

