### PR TITLE
chore(architecture): implement persistent AUTO-REFRESH disabled mode

### DIFF
--- a/.github/workflows/architecture-auto-refresh.yml
+++ b/.github/workflows/architecture-auto-refresh.yml
@@ -1,20 +1,25 @@
-# PERSISTENT-AUTO-REFRESH-V1 — EXAMPLE ONLY (HISTORICAL)
+# PERSISTENT-AUTO-REFRESH-V1 — DISABLED-MODE
 #
-# Prefer the real DISABLED-MODE workflow:
-#   .github/workflows/architecture-auto-refresh.yml
-# which uses workflow_dispatch only (Persistent AUTO-REFRESH = NOT ENABLED).
+# Persistent AUTO-REFRESH is NOT ENABLED.
+# This workflow validates the executable structure without push-to-main automation.
 #
-# This docs/ copy retains the eventual push+dispatch shape for enablement review.
-# GitHub Actions will NOT load files under docs/.
+# Active trigger: workflow_dispatch only
+# Not present: push to main, cron/schedule, webhook, external scheduler
+#
+# Future enablement slice may add (without redesigning jobs/steps):
+#   push:
+#     branches: [main]
+#     paths-ignore:
+#       - "docs/architecture/architecture.json"
+#       - "docs/architecture/architecture.html"
+#
+# Platform permissions (contents/pull-requests write) are broader than the
+# intended Draft-only capability enforced in repository-native publisher guards
+# (canMarkReady=false, canMerge=false, canClosePullRequest=false, …).
 
 name: architecture-auto-refresh
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "docs/architecture/architecture.json"
-      - "docs/architecture/architecture.html"
   workflow_dispatch:
 
 concurrency:
@@ -27,7 +32,6 @@ permissions:
 
 jobs:
   refresh:
-    if: false # EXAMPLE ONLY: never run even if misplaced under .github/workflows
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,10 +47,11 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Evaluate + regenerate + verify + Draft-only publish
+      - name: Evaluate + regenerate + verify + Draft-only publish capability
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSISTENT_AUTO_REFRESH_TRIGGER: workflow_dispatch
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: npm run auto-refresh:persistent -- --publish
 
       # Explicit non-goals (must never appear):

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 docs/handoff/handoff.json
 docs/handoff/handoff.md
 docs/architecture/auto-refresh-pilot-result.json
+docs/architecture/persistent-auto-refresh-result.json

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -20,6 +20,6 @@ Unknowns and assumptions are retained explicitly; they must not be upgraded to
 confirmed facts without repository evidence.
 
 AUTO-REFRESH-V1 is **designed**; a **manual** pilot exists
-(`npm run auto-refresh:pilot`). Persistent AUTO-REFRESH is **designed but not
-enabled** — see [`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md).
-No active scheduler/push workflow is installed by the design-only slice.
+(`npm run auto-refresh:pilot`). Persistent AUTO-REFRESH has a **DISABLED-MODE**
+workflow (`workflow_dispatch` only) and remains **NOT ENABLED** (no push-to-main
+automation) — see [`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md).

--- a/docs/architecture/auto-refresh-v1.md
+++ b/docs/architecture/auto-refresh-v1.md
@@ -14,8 +14,9 @@ It does **not** enable cron, push triggers, Ready, Merge, Action Gateway, or
 Agent execution.
 
 Persistent AUTO-REFRESH is designed separately in
-[`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md) and remains
-**NOT ENABLED** (no active `.github/workflows` trigger in this repository yet).
+[`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md). A
+**DISABLED-MODE** workflow exists (`workflow_dispatch` only) and Persistent
+AUTO-REFRESH remains **NOT ENABLED** (no push-to-main automatic publication).
 
 ---
 

--- a/docs/architecture/persistent-auto-refresh-v1.md
+++ b/docs/architecture/persistent-auto-refresh-v1.md
@@ -1,17 +1,22 @@
 # PERSISTENT-AUTO-REFRESH-V1
 
-**Status: DESIGNED · NOT ENABLED · NO ACTIVE TRIGGER · NO SCHEDULER**
+**Status: DISABLED-MODE IMPLEMENTED · NOT ENABLED · NO PUSH TRIGGER · NO SCHEDULER**
 
-This document designs the minimum safe **persistent** Architecture Snapshot
+This document designs and tracks the **persistent** Architecture Snapshot
 refresh mechanism. It builds on:
 
 - `docs/architecture/auto-refresh-v1.md` (eligibility / anti-loop / identity)
 - AUTO-REFRESH-PILOT-V1 (`npm run auto-refresh:pilot`) — manual proof path
+- DISABLED-MODE runner: `npm run auto-refresh:persistent`
+- DISABLED-MODE workflow: `.github/workflows/architecture-auto-refresh.yml`
+  (`workflow_dispatch` only)
 
-This design-only slice does **not** enable any always-on mutation path.
+**Persistent AUTO-REFRESH is NOT ENABLED.** Push-to-main automatic publication
+is absent. A later Human-authorized enablement slice may add the `push:`
+trigger without redesigning jobs/steps.
 
 Companion pure helpers: `src/domain/persistentAutoRefreshContract.ts`  
-Example (non-active) workflow sketch:
+Example (historical) workflow sketch:
 `docs/architecture/persistent-auto-refresh-workflow.example.yml`
 
 ---
@@ -58,11 +63,13 @@ Human **Ready** and Human **Merge** remain unchanged.
 
 ### Explicit non-enablement
 
-Until an accepted **implementation** slice lands:
+Until an accepted **enablement** slice lands:
 
-- no file under `.github/workflows/` may actively trigger AUTO-REFRESH
-- the example YAML in `docs/architecture/` is documentation only
-- Persistent AUTO-REFRESH remains **NOT ENABLED**
+- `.github/workflows/architecture-auto-refresh.yml` may exist only in
+  **DISABLED-MODE** (`workflow_dispatch` only; no `push`, no cron)
+- Persistent AUTO-REFRESH remains **NOT ENABLED** (no automatic push-to-main)
+- platform `pull-requests: write` is broader than intended Draft-only
+  capability; publisher guards keep Ready/Merge/close unauthorized
 
 ---
 
@@ -307,16 +314,18 @@ above.
 
 | Artifact | Role |
 |---|---|
-| `.github/workflows/architecture-auto-refresh.yml` | **Future** active wiring (not in this design-only PR) |
-| `docs/architecture/persistent-auto-refresh-workflow.example.yml` | Non-active example |
-| `scripts/run-auto-refresh-pilot.ts` | Reuse as runner core |
+| `.github/workflows/architecture-auto-refresh.yml` | DISABLED-MODE workflow (`workflow_dispatch` only); enablement adds `push` |
+| `docs/architecture/persistent-auto-refresh-workflow.example.yml` | Historical example with commented push shape |
+| `scripts/run-persistent-auto-refresh.ts` | DISABLED-MODE runner (`npm run auto-refresh:persistent`) |
+| `scripts/run-auto-refresh-pilot.ts` | Manual pilot runner |
 | `src/domain/autoRefreshContract.ts` | Eligibility / anti-loop / identity |
 | `src/domain/autoRefreshPilot.ts` | Publication decision helpers |
 | `src/domain/autoRefreshPublisher.ts` | Draft-only publisher caps |
-| `src/domain/persistentAutoRefreshContract.ts` | Concurrency / failure / draft disposition |
+| `src/domain/persistentAutoRefreshContract.ts` | Concurrency / failure / draft disposition / workflow inspection |
 
-Enablement requires a **separate Human-authorized** PR that moves the example
-into `.github/workflows/` with the designed filters and permissions.
+Enablement requires a **separate Human-authorized** PR that adds `push:` to
+the DISABLED-MODE workflow (with designed filters) while keeping Draft-only
+publisher guards.
 
 ---
 
@@ -326,8 +335,10 @@ into `.github/workflows/` with the designed filters and permissions.
 |---|---|
 | Persistent design | this document |
 | Pure contract helpers + tests | present |
-| Example workflow YAML | docs only (non-triggering) |
-| Active `.github/workflows` AUTO-REFRESH | **NOT ENABLED** |
+| DISABLED-MODE workflow | `.github/workflows/architecture-auto-refresh.yml` (`workflow_dispatch` only) |
+| DISABLED-MODE runner | `npm run auto-refresh:persistent` |
+| Example workflow YAML | docs only (non-triggering historical sketch) |
+| Active push-to-main AUTO-REFRESH | **NOT ENABLED** |
 | cron / webhook mutation | **NOT ENABLED** |
 | Ready / Merge automation | **NOT ENABLED** |
 | Action Gateway / Agent execution | **NOT IMPLEMENTED** |

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -65,8 +65,10 @@ HANDOFF-V1 does not regenerate the Architecture Snapshot.
 
 AUTO-REFRESH-V1 is **designed** with a **manual** pilot
 (`npm run auto-refresh:pilot`) that may open a Draft refresh PR only.
-Persistent AUTO-REFRESH is **designed but NOT ENABLED**
-(`docs/architecture/persistent-auto-refresh-v1.md`). Snapshot staleness is
+Persistent AUTO-REFRESH has a **DISABLED-MODE** implementation
+(`docs/architecture/persistent-auto-refresh-v1.md`,
+`.github/workflows/architecture-auto-refresh.yml` with `workflow_dispatch` only)
+and remains **NOT ENABLED** (no push-to-main automation). Snapshot staleness is
 maintenance evidence only and must never be upgraded into HANDOFF / Approval
 Ledger `ACTION_REQUIRED`.
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "architecture:snapshot": "node scripts/generate-architecture-snapshot.mjs",
     "handoff": "vite-node scripts/run-handoff.ts",
     "auto-refresh:pilot": "vite-node scripts/run-auto-refresh-pilot.ts",
+    "auto-refresh:persistent": "vite-node scripts/run-persistent-auto-refresh.ts",
     "dev": "vite",
     "build": "vite build",
     "preview": "npm run build && vite preview",

--- a/scripts/run-persistent-auto-refresh.ts
+++ b/scripts/run-persistent-auto-refresh.ts
@@ -1,0 +1,588 @@
+/**
+ * PERSISTENT-AUTO-REFRESH-V1 — DISABLED-MODE runner.
+ *
+ * observe → evaluate → regenerate → verify → recheck main →
+ * duplicate check → Draft publication capability → STOP
+ *
+ * Persistent AUTO-REFRESH remains NOT ENABLED (no push-to-main automatic execution).
+ * workflow_dispatch / explicit CLI only. No Ready/Merge/close.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isArchitectureSnapshot } from "../src/domain/architectureSnapshot";
+import {
+  evaluateAutoRefresh,
+  hasMaterialSnapshotDiff,
+  SNAPSHOT_GENERATOR_VERSION,
+  type ExistingRefreshPr,
+} from "../src/domain/autoRefreshContract";
+import {
+  formatRefreshIdentityMarker,
+  parseRefreshIdentityFromBody,
+  recheckMain,
+} from "../src/domain/autoRefreshPilot";
+import {
+  createDraftPullRequest,
+  listOpenPullRequests,
+} from "../src/domain/autoRefreshPublisher";
+import {
+  assertGeneratedFromMatchesSourceMain,
+  assertPersistentAutoRefreshNotEnabled,
+  assertPersistentPublisherCannotReadyOrMerge,
+  classifyPersistentDraftDisposition,
+  classifyPersistentFailure,
+  decidePersistentPublication,
+  mayRetryPublication,
+  PERSISTENT_AUTO_REFRESH_MODE,
+  type PersistentAutoRefreshRunReport,
+  type PersistentFailureClass,
+} from "../src/domain/persistentAutoRefreshContract";
+import { writeSnapshot } from "./generate-architecture-snapshot.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const snapshotPath = resolve(root, "docs/architecture/architecture.json");
+const defaultOutDir = resolve(root, "docs/architecture");
+const snapshotArtifacts = [
+  "docs/architecture/architecture.json",
+  "docs/architecture/architecture.html",
+] as const;
+
+function git(args: string[]): string {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function readCurrentMain(): string | null {
+  try {
+    try {
+      return git(["rev-parse", "origin/main"]);
+    } catch {
+      return git(["rev-parse", "main"]);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function readChangedPaths(fromCommit: string, toCommit: string): string[] | null {
+  try {
+    const output = git(["diff", "--name-only", `${fromCommit}..${toCommit}`]);
+    if (!output) return [];
+    return output.split("\n").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function runNpm(script: string): { ok: boolean; output: string } {
+  try {
+    const output = execFileSync("npm", ["run", script], {
+      cwd: root,
+      encoding: "utf8",
+      env: process.env,
+    });
+    return { ok: true, output };
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    return {
+      ok: false,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}${err.message ?? "npm run failed"}`,
+    };
+  }
+}
+
+function parseArgs(argv: string[]): {
+  publish: boolean;
+  skipLive: boolean;
+  jsonOut: string;
+} {
+  let publish = false;
+  let skipLive = false;
+  let jsonOut = resolve(defaultOutDir, "persistent-auto-refresh-result.json");
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--publish") publish = true;
+    else if (arg === "--skip-live") skipLive = true;
+    else if (arg === "--json-out") jsonOut = resolve(argv[++i]);
+  }
+  return { publish, skipLive, jsonOut };
+}
+
+function mapExistingPulls(
+  pulls: Awaited<ReturnType<typeof listOpenPullRequests>>,
+): ExistingRefreshPr[] {
+  return pulls
+    .map((pr) => {
+      const identity = parseRefreshIdentityFromBody(pr.body);
+      if (!identity) return null;
+      return {
+        number: pr.number,
+        refreshIdentity: identity,
+        state: pr.draft ? ("DRAFT" as const) : ("READY" as const),
+        targetMainSha: identity.split("::")[2] ?? "",
+      };
+    })
+    .filter((pr): pr is ExistingRefreshPr => pr !== null);
+}
+
+async function main(): Promise<void> {
+  assertPersistentAutoRefreshNotEnabled();
+  assertPersistentPublisherCannotReadyOrMerge();
+
+  const args = parseArgs(process.argv.slice(2));
+  const evaluatedAt = new Date().toISOString();
+  const triggerEnv = process.env.PERSISTENT_AUTO_REFRESH_TRIGGER;
+  const trigger =
+    triggerEnv === "workflow_dispatch"
+      ? ("workflow_dispatch" as const)
+      : ("manual_cli" as const);
+  const runId = process.env.GITHUB_RUN_ID ?? null;
+
+  const raw = JSON.parse(readFileSync(snapshotPath, "utf8"));
+  if (!isArchitectureSnapshot(raw)) {
+    throw new Error("docs/architecture/architecture.json is not a valid Architecture Snapshot");
+  }
+
+  const startMain = readCurrentMain();
+  const generatedFrom = raw.generatedFrom.commit as string;
+  const changedPaths = startMain === null ? null : readChangedPaths(generatedFrom, startMain);
+  const repository = `yasutakesougo/${raw.generatedFrom.repository}`;
+  const [owner, repo] = repository.split("/");
+
+  let existingRefreshPrs: ExistingRefreshPr[] = [];
+  let existingPrObservationFailed = false;
+  let duplicateState: PersistentAutoRefreshRunReport["duplicateState"] = "NONE";
+
+  if (!args.skipLive) {
+    try {
+      const token = process.env.GITHUB_TOKEN;
+      const pulls = await listOpenPullRequests({ owner, repo, token });
+      existingRefreshPrs = mapExistingPulls(pulls);
+    } catch {
+      existingPrObservationFailed = true;
+      duplicateState = "LOOKUP_FAILED";
+    }
+  }
+
+  let failureClass: PersistentFailureClass | null = null;
+  if (startMain === null) {
+    failureClass = classifyPersistentFailure({ kind: "observation_unavailable" });
+  } else if (changedPaths === null) {
+    failureClass = classifyPersistentFailure({ kind: "changed_paths_unavailable" });
+  } else if (existingPrObservationFailed) {
+    failureClass = classifyPersistentFailure({ kind: "duplicate_check_unavailable" });
+  }
+
+  const eligibilityReport = evaluateAutoRefresh({
+    repository,
+    observedMain: startMain,
+    snapshotGeneratedFrom: generatedFrom,
+    changedPaths,
+    existingRefreshPrs: existingPrObservationFailed ? null : existingRefreshPrs,
+    existingPrObservationFailed,
+    handoffStaleClassification: null,
+    materialSnapshotDiff: null,
+    evaluatedAt,
+  });
+
+  const eligible =
+    eligibilityReport.refreshRequired === true &&
+    (eligibilityReport.nextAction === "CREATE_DRAFT" ||
+      eligibilityReport.nextAction === "REUSE_EXISTING_DRAFT");
+
+  const refreshIdentity =
+    eligibilityReport.refreshIdentity ??
+    (startMain
+      ? `${repository}::${generatedFrom}::${startMain}::${SNAPSHOT_GENERATOR_VERSION}`
+      : null);
+
+  const disposition =
+    refreshIdentity && startMain
+      ? classifyPersistentDraftDisposition({
+          refreshIdentity,
+          targetMainSha: startMain,
+          eligible: eligible && !existingPrObservationFailed && failureClass === null,
+          existing: existingRefreshPrs,
+        })
+      : ("NO_ACTION" as const);
+
+  if (disposition === "REUSE") duplicateState = "REUSE";
+  if (disposition === "SUPERSEDED_CANDIDATE") duplicateState = "SUPERSEDED_CANDIDATE";
+  if (existingPrObservationFailed) duplicateState = "LOOKUP_FAILED";
+
+  const report: PersistentAutoRefreshRunReport = {
+    schemaVersion: "1.0",
+    mode: PERSISTENT_AUTO_REFRESH_MODE,
+    trigger,
+    repository,
+    runId,
+    observedMain: startMain,
+    snapshotGeneratedFrom: generatedFrom,
+    changedPaths: changedPaths ?? [],
+    architectureRelevantPaths: eligibilityReport.sourceArchitectureRelevantPaths,
+    refreshRequired: eligibilityReport.refreshRequired,
+    refreshIdentity,
+    status: "EVALUATING",
+    reason: eligibilityReport.reason,
+    verification: {
+      architectureSnapshot: "NOT_RUN",
+      handoff: "NOT_RUN",
+      verify: "NOT_RUN",
+    },
+    duplicateState,
+    mainRecheck: "NOT_RUN",
+    publicationOutcome: "NO_PUBLICATION",
+    draftPr: null,
+    mutations: {
+      featureBranch: false,
+      snapshotCommit: false,
+      draftPrCreated: false,
+    },
+    failureClass,
+    approvalActionRequired: false,
+    persistentAutoRefreshEnabled: false,
+    evaluatedAt,
+  };
+
+  if (failureClass || !startMain || !refreshIdentity) {
+    report.status = failureClass === "OUTCOME_UNKNOWN" ? "OUTCOME_UNKNOWN" : "HOLD";
+    report.publicationOutcome = "HOLD";
+    report.reason =
+      failureClass === null
+        ? "observation incomplete; fail closed"
+        : `fail closed (${failureClass}): ${report.reason}`;
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (disposition === "REUSE") {
+    const existing = existingRefreshPrs.find((pr) => pr.refreshIdentity === refreshIdentity);
+    report.status = "REUSED_EXISTING";
+    report.publicationOutcome = "REUSED_EXISTING";
+    report.reason = eligibilityReport.reason;
+    report.draftPr = existing
+      ? {
+          number: existing.number,
+          url: `https://github.com/${repository}/pull/${existing.number}`,
+          headSha: "",
+        }
+      : null;
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    return;
+  }
+
+  if (disposition === "SUPERSEDED_CANDIDATE") {
+    const decided = decidePersistentPublication({
+      disposition,
+      mainRecheck: "MATCH",
+      verificationPassed: true,
+      materialSnapshotDiff: null,
+      failureClass: null,
+    });
+    report.status = decided.status;
+    report.publicationOutcome = decided.decision;
+    report.reason = decided.reason;
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (disposition === "NO_ACTION" || !eligible) {
+    report.status = "NOT_REQUIRED";
+    report.publicationOutcome = "NO_PUBLICATION";
+    report.reason = eligibilityReport.reason;
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    return;
+  }
+
+  // NEW_DRAFT_REQUIRED — regenerate from exact observed main SHA.
+  report.status = "GENERATING";
+  const beforeSnapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+  try {
+    writeSnapshot({ commit: startMain });
+  } catch {
+    failureClass = classifyPersistentFailure({ kind: "generator_failed" });
+    report.failureClass = failureClass;
+    report.status = "HOLD";
+    report.publicationOutcome = "HOLD";
+    report.verification.architectureSnapshot = "FAIL";
+    report.reason = "generator failure; no Draft publication";
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    process.exitCode = 1;
+    return;
+  }
+
+  const afterSnapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+  try {
+    assertGeneratedFromMatchesSourceMain({
+      generatedFromCommit: afterSnapshot.generatedFrom.commit,
+      sourceMainSha: startMain,
+    });
+    report.verification.architectureSnapshot = "PASS";
+  } catch {
+    failureClass = classifyPersistentFailure({ kind: "generator_failed" });
+    report.failureClass = failureClass;
+    report.status = "HOLD";
+    report.publicationOutcome = "HOLD";
+    report.verification.architectureSnapshot = "FAIL";
+    report.reason = "generatedFrom.commit does not match source main after regeneration";
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    process.exitCode = 1;
+    return;
+  }
+
+  const materialDiff = hasMaterialSnapshotDiff(beforeSnapshot, afterSnapshot);
+
+  report.status = "VERIFYING";
+  const handoffRun = runNpm("handoff");
+  report.verification.handoff = handoffRun.ok ? "PASS" : "FAIL";
+  if (!handoffRun.ok) {
+    failureClass = classifyPersistentFailure({ kind: "handoff_failed" });
+  }
+
+  const verifyRun = runNpm("verify");
+  report.verification.verify = verifyRun.ok ? "PASS" : "FAIL";
+  if (!verifyRun.ok && failureClass === null) {
+    failureClass = classifyPersistentFailure({ kind: "verification_failed" });
+  }
+
+  const verificationPassed =
+    report.verification.architectureSnapshot === "PASS" &&
+    handoffRun.ok &&
+    verifyRun.ok;
+
+  const currentMain = readCurrentMain();
+  if (currentMain === null) {
+    report.mainRecheck = "UNAVAILABLE";
+    failureClass = classifyPersistentFailure({ kind: "main_recheck_unavailable" });
+  } else {
+    report.mainRecheck = recheckMain(startMain, currentMain);
+  }
+
+  // Second duplicate check immediately before publication.
+  if (!args.skipLive) {
+    try {
+      const token = process.env.GITHUB_TOKEN;
+      const pulls = await listOpenPullRequests({ owner, repo, token });
+      existingRefreshPrs = mapExistingPulls(pulls);
+      const postDisposition = classifyPersistentDraftDisposition({
+        refreshIdentity,
+        targetMainSha: startMain,
+        eligible: true,
+        existing: existingRefreshPrs,
+      });
+      if (postDisposition === "REUSE") {
+        report.duplicateState = "REUSE";
+        report.status = "REUSED_EXISTING";
+        report.publicationOutcome = "REUSED_EXISTING";
+        const existing = existingRefreshPrs.find((pr) => pr.refreshIdentity === refreshIdentity);
+        report.draftPr = existing
+          ? {
+              number: existing.number,
+              url: `https://github.com/${repository}/pull/${existing.number}`,
+              headSha: "",
+            }
+          : null;
+        report.reason = "second duplicate check found equivalent Draft/Ready";
+        writeResult(args.jsonOut, report);
+        printSummary(report);
+        return;
+      }
+      if (postDisposition === "SUPERSEDED_CANDIDATE") {
+        report.duplicateState = "SUPERSEDED_CANDIDATE";
+        const decided = decidePersistentPublication({
+          disposition: postDisposition,
+          mainRecheck: report.mainRecheck === "MOVED" ? "MOVED" : "MATCH",
+          verificationPassed,
+          materialSnapshotDiff: materialDiff,
+          failureClass: null,
+        });
+        report.status = decided.status;
+        report.publicationOutcome = decided.decision;
+        report.reason = decided.reason;
+        writeResult(args.jsonOut, report);
+        printSummary(report);
+        process.exitCode = 1;
+        return;
+      }
+      report.duplicateState = "NONE";
+    } catch {
+      failureClass = classifyPersistentFailure({ kind: "duplicate_check_unavailable" });
+      report.duplicateState = "LOOKUP_FAILED";
+    }
+  }
+
+  report.failureClass = failureClass;
+  const decided = decidePersistentPublication({
+    disposition: "NEW_DRAFT_REQUIRED",
+    mainRecheck: report.mainRecheck,
+    verificationPassed,
+    materialSnapshotDiff: materialDiff,
+    failureClass,
+  });
+  report.status = decided.status;
+  report.publicationOutcome = decided.decision;
+  report.reason = decided.reason;
+
+  if (decided.decision !== "PUBLISH_DRAFT") {
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    if (decided.decision !== "NO_PUBLICATION") process.exitCode = 1;
+    return;
+  }
+
+  if (!args.publish) {
+    report.status = "ELIGIBLE";
+    report.publicationOutcome = "NO_PUBLICATION";
+    report.reason = `${decided.reason}; --publish not set (DISABLED-MODE dry evaluation)`;
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    return;
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    report.failureClass = classifyPersistentFailure({ kind: "publish_rejected" });
+    report.status = "HOLD";
+    report.publicationOutcome = "HOLD";
+    report.reason = "GITHUB_TOKEN missing; cannot publish Draft PR";
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    process.exitCode = 1;
+    return;
+  }
+
+  report.status = "DRAFT_PUBLISHING";
+  const branch = `auto-refresh/persistent-${startMain.slice(0, 12)}`;
+
+  try {
+    git(["checkout", "-B", branch]);
+    report.mutations.featureBranch = true;
+    git(["add", ...snapshotArtifacts]);
+    git(["commit", "-m", `docs(architecture): persistent auto-refresh Snapshot (${startMain.slice(0, 7)})`]);
+    report.mutations.snapshotCommit = true;
+    git(["push", "-u", "origin", `HEAD:${branch}`]);
+  } catch {
+    report.failureClass = classifyPersistentFailure({ kind: "commit_push_failed" });
+    report.status = "HOLD";
+    report.publicationOutcome = "HOLD";
+    report.reason = "branch/commit/push failed; no Draft publication";
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    process.exitCode = 1;
+    return;
+  }
+
+  const headSha = git(["rev-parse", "HEAD"]);
+  const body = [
+    "## PERSISTENT-AUTO-REFRESH-V1 (DISABLED-MODE run)",
+    "",
+    "Architecture Snapshot refresh Draft. Persistent push-to-main automation remains **NOT ENABLED**.",
+    "",
+    `- observed / source main: \`${startMain}\``,
+    `- prior generatedFrom: \`${generatedFrom}\``,
+    `- new generatedFrom: \`${afterSnapshot.generatedFrom.commit}\``,
+    `- ${formatRefreshIdentityMarker(refreshIdentity)}`,
+    `- generatorVersion: \`${SNAPSHOT_GENERATOR_VERSION}\``,
+    `- mode: \`${PERSISTENT_AUTO_REFRESH_MODE}\``,
+    `- architecture-relevant source paths: ${report.architectureRelevantPaths.map((p) => `\`${p}\``).join(", ") || "(none)"}`,
+    "",
+    "Ready: **NOT AUTHORIZED**",
+    "Merge: **NOT AUTHORIZED**",
+    "",
+    "This Draft stops for Human review.",
+  ].join("\n");
+
+  try {
+    const created = await createDraftPullRequest({
+      owner,
+      repo,
+      title: "docs(architecture): persistent auto-refresh Snapshot",
+      body,
+      head: branch,
+      base: "main",
+      token,
+    });
+    report.mutations.draftPrCreated = true;
+    report.draftPr = {
+      number: created.number,
+      url: created.htmlUrl,
+      headSha,
+    };
+    report.status = "DRAFT_OPEN";
+    report.publicationOutcome = "PUBLISH_DRAFT";
+    report.reason = "Draft PR created; persistent automation still NOT ENABLED";
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Ambiguous transport / server outcome → never blind-retry.
+    const unknown =
+      /fetch failed|network|ECONNRESET|ETIMEDOUT|socket|502|503|504/i.test(message) ||
+      /unknown/i.test(message);
+    report.failureClass = classifyPersistentFailure({
+      kind: unknown ? "publish_transport_unknown" : "publish_rejected",
+    });
+    report.status =
+      report.failureClass === "OUTCOME_UNKNOWN" ? "OUTCOME_UNKNOWN" : "HOLD";
+    report.publicationOutcome =
+      report.failureClass === "OUTCOME_UNKNOWN" ? "OUTCOME_UNKNOWN" : "HOLD";
+    report.reason = `Draft publication failed (${report.failureClass}): ${message}`;
+    // Explicit: OUTCOME_UNKNOWN must not authorize blind retry.
+    if (
+      report.failureClass === "OUTCOME_UNKNOWN" &&
+      mayRetryPublication({
+        failureClass: report.failureClass,
+        equivalentDraftStillAbsent: true,
+      })
+    ) {
+      throw new Error("invariant violated: OUTCOME_UNKNOWN must not be retryable");
+    }
+    writeResult(args.jsonOut, report);
+    printSummary(report);
+    process.exitCode = 1;
+    return;
+  }
+
+  writeResult(args.jsonOut, report);
+  printSummary(report);
+}
+
+function writeResult(path: string, result: PersistentAutoRefreshRunReport): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(result, null, 2)}\n`);
+}
+
+function printSummary(result: PersistentAutoRefreshRunReport): void {
+  process.stdout.write(`# PERSISTENT-AUTO-REFRESH-V1 (${result.mode})\n`);
+  process.stdout.write(`- trigger: ${result.trigger}\n`);
+  process.stdout.write(`- observedMain: ${result.observedMain}\n`);
+  process.stdout.write(`- snapshotGeneratedFrom: ${result.snapshotGeneratedFrom}\n`);
+  process.stdout.write(
+    `- architectureRelevantPaths: ${JSON.stringify(result.architectureRelevantPaths)}\n`,
+  );
+  process.stdout.write(`- refreshRequired: ${result.refreshRequired}\n`);
+  process.stdout.write(`- refreshIdentity: ${result.refreshIdentity}\n`);
+  process.stdout.write(`- status: ${result.status}\n`);
+  process.stdout.write(`- reason: ${result.reason}\n`);
+  process.stdout.write(`- verification: ${JSON.stringify(result.verification)}\n`);
+  process.stdout.write(`- duplicateState: ${result.duplicateState}\n`);
+  process.stdout.write(`- mainRecheck: ${result.mainRecheck}\n`);
+  process.stdout.write(`- publicationOutcome: ${result.publicationOutcome}\n`);
+  process.stdout.write(`- draftPr: ${result.draftPr?.url ?? null}\n`);
+  process.stdout.write(`- failureClass: ${result.failureClass}\n`);
+  process.stdout.write(`- persistentAutoRefreshEnabled: ${result.persistentAutoRefreshEnabled}\n`);
+  process.stdout.write(`- approvalActionRequired: ${result.approvalActionRequired}\n`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/src/domain/persistentAutoRefreshContract.ts
+++ b/src/domain/persistentAutoRefreshContract.ts
@@ -1,10 +1,10 @@
 /**
- * PERSISTENT-AUTO-REFRESH-V1 design contract helpers.
+ * PERSISTENT-AUTO-REFRESH-V1 contract helpers.
  *
- * DESIGNED · NOT ENABLED · NO ACTIVE TRIGGER
+ * DISABLED-MODE IMPLEMENTATION · NOT ENABLED (no push-to-main automatic execution)
  *
- * Concurrency, failure, and Draft disposition logic only.
- * Does not create workflows, PRs, or enable cron.
+ * Concurrency, failure, Draft disposition, workflow static inspection, and
+ * publication decision logic. Does not enable cron or push triggers.
  */
 
 import {
@@ -15,13 +15,61 @@ import {
 import {
   AUTO_REFRESH_PILOT_PUBLISHER,
   assertPilotPublisherCannotReadyOrMerge,
+  type AutoRefreshPilotPublisher,
 } from "./autoRefreshPublisher";
+import type { MainRecheckResult } from "./autoRefreshPilot";
 
 export const PERSISTENT_AUTO_REFRESH_DESIGN = "PERSISTENT-AUTO-REFRESH-DESIGN-V1" as const;
+export const PERSISTENT_AUTO_REFRESH_MODE = "DISABLED_MODE" as const;
+
+/** Push-to-main / scheduled persistent automation remains off. */
 export const PERSISTENT_AUTO_REFRESH_ENABLED = false as const;
 
 export const PERSISTENT_CONCURRENCY_GROUP = "architecture-auto-refresh-main" as const;
+export const PERSISTENT_CONCURRENCY_GROUP_EXPRESSION =
+  "architecture-auto-refresh-${{ github.repository }}-main" as const;
 export const PERSISTENT_CANCEL_IN_PROGRESS = true as const;
+
+export const PERSISTENT_WORKFLOW_PATH =
+  ".github/workflows/architecture-auto-refresh.yml" as const;
+
+/** Active triggers in DISABLED-MODE (push/cron must remain absent). */
+export const PERSISTENT_ACTIVE_TRIGGERS = ["workflow_dispatch"] as const;
+
+/**
+ * Designed preference for a future enablement slice.
+ * Scheduler is not selected for V1.
+ */
+export type PersistentTriggerKind = "push_main" | "workflow_dispatch" | "schedule";
+
+export const PERSISTENT_TRIGGER_PREFERENCE: PersistentTriggerKind[] = [
+  "push_main",
+  "workflow_dispatch",
+];
+
+export const PERSISTENT_PATHS_IGNORE = [
+  "docs/architecture/architecture.json",
+  "docs/architecture/architecture.html",
+] as const;
+
+export const PERSISTENT_GITHUB_PERMISSIONS = {
+  contents: "write",
+  pullRequests: "write",
+  issues: "none",
+  deployments: "none",
+  actions: "none",
+  idToken: "none",
+  packages: "none",
+} as const;
+
+/**
+ * Draft-only publisher capabilities (reuse pilot publisher; no parallel policy).
+ * Platform `pull-requests: write` is broader than these intended capabilities.
+ */
+export const PERSISTENT_AUTO_REFRESH_PUBLISHER = {
+  ...AUTO_REFRESH_PILOT_PUBLISHER,
+  canCreateDraft: true,
+} as const satisfies AutoRefreshPilotPublisher & { canCreateDraft: true };
 
 export type PersistentWorkflowStatus =
   | "IDLE"
@@ -46,34 +94,91 @@ export type PersistentDraftDisposition =
 
 export type PersistentFailureClass = "SAFE_RETRY" | "OUTCOME_UNKNOWN" | "HOLD";
 
-export type PersistentTriggerKind = "push_main" | "workflow_dispatch" | "schedule";
+export type PersistentPublicationDecision =
+  | "PUBLISH_DRAFT"
+  | "REUSED_EXISTING"
+  | "ABORTED_MAIN_MOVED"
+  | "NO_PUBLICATION"
+  | "HOLD"
+  | "OUTCOME_UNKNOWN";
 
-/** Designed trigger preference. Scheduler is not selected for V1. */
-export const PERSISTENT_TRIGGER_PREFERENCE: PersistentTriggerKind[] = [
-  "push_main",
-  "workflow_dispatch",
-];
+export interface PersistentWorkflowInspection {
+  path: typeof PERSISTENT_WORKFLOW_PATH;
+  hasWorkflowDispatch: boolean;
+  hasPushTrigger: boolean;
+  hasScheduleCron: boolean;
+  concurrencyGroupExpression: string | null;
+  cancelInProgress: boolean | null;
+  permissionsContents: string | null;
+  permissionsPullRequests: string | null;
+  grantsIssuesWrite: boolean;
+  grantsActionsWrite: boolean;
+  grantsDeploymentsWrite: boolean;
+  grantsIdTokenWrite: boolean;
+  grantsPackagesWrite: boolean;
+  invokesReadyOrMerge: boolean;
+  mode: typeof PERSISTENT_AUTO_REFRESH_MODE;
+  persistentEnabled: typeof PERSISTENT_AUTO_REFRESH_ENABLED;
+}
 
-export const PERSISTENT_PATHS_IGNORE = [
-  "docs/architecture/architecture.json",
-  "docs/architecture/architecture.html",
-] as const;
-
-export const PERSISTENT_GITHUB_PERMISSIONS = {
-  contents: "write",
-  pullRequests: "write",
-  issues: "none",
-  deployments: "none",
-} as const;
+export interface PersistentAutoRefreshRunReport {
+  schemaVersion: "1.0";
+  mode: typeof PERSISTENT_AUTO_REFRESH_MODE;
+  trigger: "workflow_dispatch" | "manual_cli" | "unknown";
+  repository: string;
+  runId: string | null;
+  observedMain: string | null;
+  snapshotGeneratedFrom: string | null;
+  changedPaths: string[];
+  architectureRelevantPaths: string[];
+  refreshRequired: boolean | null;
+  refreshIdentity: string | null;
+  status: PersistentWorkflowStatus;
+  reason: string;
+  verification: {
+    architectureSnapshot: "PASS" | "FAIL" | "NOT_RUN";
+    handoff: "PASS" | "FAIL" | "NOT_RUN";
+    verify: "PASS" | "FAIL" | "NOT_RUN";
+  };
+  duplicateState:
+    | "NONE"
+    | "REUSE"
+    | "SUPERSEDED_CANDIDATE"
+    | "NOT_CHECKED"
+    | "LOOKUP_FAILED";
+  mainRecheck: MainRecheckResult | "NOT_RUN" | "UNAVAILABLE";
+  publicationOutcome: PersistentPublicationDecision;
+  draftPr: { number: number; url: string; headSha: string } | null;
+  mutations: {
+    featureBranch: boolean;
+    snapshotCommit: boolean;
+    draftPrCreated: boolean;
+  };
+  failureClass: PersistentFailureClass | null;
+  approvalActionRequired: false;
+  persistentAutoRefreshEnabled: false;
+  evaluatedAt: string;
+}
 
 export function assertPersistentAutoRefreshNotEnabled(): void {
   if (PERSISTENT_AUTO_REFRESH_ENABLED) {
-    throw new Error("PERSISTENT-AUTO-REFRESH-V1 must remain NOT ENABLED in design-only state");
+    throw new Error(
+      "PERSISTENT-AUTO-REFRESH-V1 must remain NOT ENABLED (no push-to-main automatic execution)",
+    );
   }
 }
 
 export function assertPersistentPublisherCannotReadyOrMerge(): void {
   assertPilotPublisherCannotReadyOrMerge(AUTO_REFRESH_PILOT_PUBLISHER);
+  if (!PERSISTENT_AUTO_REFRESH_PUBLISHER.canCreateDraft) {
+    throw new Error("PERSISTENT-AUTO-REFRESH-V1 Draft creation capability missing");
+  }
+  if (PERSISTENT_AUTO_REFRESH_PUBLISHER.canMarkReady) {
+    throw new Error("PERSISTENT-AUTO-REFRESH-V1 must not authorize Ready");
+  }
+  if (PERSISTENT_AUTO_REFRESH_PUBLISHER.canMerge) {
+    throw new Error("PERSISTENT-AUTO-REFRESH-V1 must not authorize Merge");
+  }
 }
 
 /**
@@ -92,6 +197,13 @@ export function isPersistentRefreshEligibleFromPaths(changedPaths: string[]): bo
   return filterSourceArchitectureRelevantPaths(changedPaths).length > 0;
 }
 
+/**
+ * Draft disposition per persistent design.
+ *
+ * SUPERSEDED_CANDIDATE is report-only: this contract does **not** authorize a
+ * new Draft while an obsolete open refresh Draft/Ready remains (fail closed /
+ * HOLD at publication). Equivalent identity → REUSE.
+ */
 export function classifyPersistentDraftDisposition(input: {
   refreshIdentity: string;
   targetMainSha: string;
@@ -124,11 +236,15 @@ export function classifyPersistentDraftDisposition(input: {
 export function classifyPersistentFailure(input: {
   kind:
     | "github_read_transient"
+    | "observation_unavailable"
     | "changed_paths_unavailable"
     | "generator_failed"
+    | "handoff_failed"
     | "verification_failed"
     | "main_recheck_unavailable"
     | "duplicate_check_unavailable"
+    | "branch_mutation_failed"
+    | "commit_push_failed"
     | "publish_transport_unknown"
     | "publish_rejected";
 }): PersistentFailureClass {
@@ -139,11 +255,15 @@ export function classifyPersistentFailure(input: {
       return "SAFE_RETRY";
     case "publish_transport_unknown":
       return "OUTCOME_UNKNOWN";
+    case "observation_unavailable":
     case "changed_paths_unavailable":
     case "generator_failed":
+    case "handoff_failed":
     case "verification_failed":
     case "main_recheck_unavailable":
     case "duplicate_check_unavailable":
+    case "branch_mutation_failed":
+    case "commit_push_failed":
       return "HOLD";
     default:
       return "HOLD";
@@ -171,6 +291,7 @@ export function resolvePersistentStatus(input: {
   if (input.failureClass === "HOLD") return "HOLD";
   if (input.mainMoved) return "ABORTED_MAIN_MOVED";
   if (input.verificationPassed === false) return "FAILED";
+  if (input.disposition === "SUPERSEDED_CANDIDATE") return "HOLD";
   if (!input.eligible) return "NOT_REQUIRED";
   if (input.disposition === "REUSE") return "REUSED_EXISTING";
   if (input.published) return "DRAFT_OPEN";
@@ -178,13 +299,206 @@ export function resolvePersistentStatus(input: {
   return "IDLE";
 }
 
+/**
+ * Publication gate combining disposition, main recheck, verification, and failures.
+ * Does not invent new Draft authorization while SUPERSEDED_CANDIDATE applies.
+ */
+export function decidePersistentPublication(input: {
+  disposition: PersistentDraftDisposition;
+  mainRecheck: MainRecheckResult | "UNAVAILABLE" | "NOT_RUN";
+  verificationPassed: boolean;
+  materialSnapshotDiff: boolean | null;
+  failureClass: PersistentFailureClass | null;
+}): { decision: PersistentPublicationDecision; status: PersistentWorkflowStatus; reason: string } {
+  if (input.failureClass === "OUTCOME_UNKNOWN") {
+    return {
+      decision: "OUTCOME_UNKNOWN",
+      status: "OUTCOME_UNKNOWN",
+      reason: "publication outcome unknown; no blind retry",
+    };
+  }
+  if (input.failureClass === "HOLD") {
+    return {
+      decision: "HOLD",
+      status: "HOLD",
+      reason: "failure classified HOLD; no Draft publication",
+    };
+  }
+  if (input.mainRecheck === "UNAVAILABLE" || input.mainRecheck === "NOT_RUN") {
+    return {
+      decision: "HOLD",
+      status: "HOLD",
+      reason: "main recheck unavailable; fail closed before publication",
+    };
+  }
+  if (input.mainRecheck === "MOVED") {
+    return {
+      decision: "ABORTED_MAIN_MOVED",
+      status: "ABORTED_MAIN_MOVED",
+      reason: "main moved before publication; do not publish stale artifacts",
+    };
+  }
+  if (!input.verificationPassed) {
+    return {
+      decision: "HOLD",
+      status: "FAILED",
+      reason: "verification failed; no Draft publication",
+    };
+  }
+  if (input.disposition === "REUSE") {
+    return {
+      decision: "REUSED_EXISTING",
+      status: "REUSED_EXISTING",
+      reason: "equivalent refresh identity Draft/Ready already open",
+    };
+  }
+  if (input.disposition === "SUPERSEDED_CANDIDATE") {
+    return {
+      decision: "HOLD",
+      status: "HOLD",
+      reason:
+        "obsolete open refresh Draft/Ready present (SUPERSEDED_CANDIDATE); no auto-close and no new Draft authorized",
+    };
+  }
+  if (input.disposition === "NO_ACTION") {
+    return {
+      decision: "NO_PUBLICATION",
+      status: "NOT_REQUIRED",
+      reason: "not eligible for Draft publication",
+    };
+  }
+  if (input.materialSnapshotDiff === false) {
+    return {
+      decision: "NO_PUBLICATION",
+      status: "NOT_REQUIRED",
+      reason: "no material Snapshot diff after regeneration",
+    };
+  }
+  return {
+    decision: "PUBLISH_DRAFT",
+    status: "ELIGIBLE",
+    reason: "NEW_DRAFT_REQUIRED, verification passed, main unchanged, no equivalent Draft",
+  };
+}
+
+/** Assert generatedFrom.commit equals the exact source main used for generation. */
+export function assertGeneratedFromMatchesSourceMain(input: {
+  generatedFromCommit: string;
+  sourceMainSha: string;
+}): void {
+  if (input.generatedFromCommit !== input.sourceMainSha) {
+    throw new Error(
+      `generatedFrom.commit (${input.generatedFromCommit}) must equal source main (${input.sourceMainSha})`,
+    );
+  }
+}
+
 /** Designed concurrency policy projection for tests/docs. */
 export function persistentConcurrencyPolicy(): {
   group: typeof PERSISTENT_CONCURRENCY_GROUP;
+  groupExpression: typeof PERSISTENT_CONCURRENCY_GROUP_EXPRESSION;
   cancelInProgress: typeof PERSISTENT_CANCEL_IN_PROGRESS;
 } {
   return {
     group: PERSISTENT_CONCURRENCY_GROUP,
+    groupExpression: PERSISTENT_CONCURRENCY_GROUP_EXPRESSION,
     cancelInProgress: PERSISTENT_CANCEL_IN_PROGRESS,
   };
+}
+
+/**
+ * Static inspection of the DISABLED-MODE workflow YAML text.
+ * Uses conservative string checks (no YAML dependency).
+ */
+export function inspectPersistentWorkflowYaml(yaml: string): PersistentWorkflowInspection {
+  const withoutComments = yaml
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+
+  const hasWorkflowDispatch = /^\s*workflow_dispatch\s*:/m.test(withoutComments);
+  // Active push trigger only if an uncommented `push:` appears under `on:`.
+  const hasPushTrigger = /^\s*push\s*:/m.test(withoutComments);
+  const hasScheduleCron =
+    /^\s*schedule\s*:/m.test(withoutComments) || /^\s*-\s*cron\s*:/m.test(withoutComments);
+
+  const concurrencyMatch = withoutComments.match(
+    /concurrency:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+group:\s*([^\n]+)/,
+  );
+  const concurrencyGroupExpression = concurrencyMatch?.[1]?.trim() ?? null;
+
+  const cancelMatch = withoutComments.match(/cancel-in-progress:\s*(true|false)/);
+  const cancelInProgress = cancelMatch ? cancelMatch[1] === "true" : null;
+
+  const contentsMatch = withoutComments.match(/^\s*contents:\s*(\w+)/m);
+  const prMatch = withoutComments.match(/^\s*pull-requests:\s*(\w+)/m);
+
+  const grantsIssuesWrite = /^\s*issues:\s*write\b/m.test(withoutComments);
+  const grantsActionsWrite = /^\s*actions:\s*write\b/m.test(withoutComments);
+  const grantsDeploymentsWrite = /^\s*deployments:\s*write\b/m.test(withoutComments);
+  const grantsIdTokenWrite = /^\s*id-token:\s*write\b/m.test(withoutComments);
+  const grantsPackagesWrite = /^\s*packages:\s*write\b/m.test(withoutComments);
+
+  const invokesReadyOrMerge =
+    /gh\s+pr\s+ready/.test(withoutComments) ||
+    /gh\s+pr\s+merge/.test(withoutComments) ||
+    /auto-merge/.test(withoutComments);
+
+  return {
+    path: PERSISTENT_WORKFLOW_PATH,
+    hasWorkflowDispatch,
+    hasPushTrigger,
+    hasScheduleCron,
+    concurrencyGroupExpression,
+    cancelInProgress,
+    permissionsContents: contentsMatch?.[1] ?? null,
+    permissionsPullRequests: prMatch?.[1] ?? null,
+    grantsIssuesWrite,
+    grantsActionsWrite,
+    grantsDeploymentsWrite,
+    grantsIdTokenWrite,
+    grantsPackagesWrite,
+    invokesReadyOrMerge,
+    mode: PERSISTENT_AUTO_REFRESH_MODE,
+    persistentEnabled: PERSISTENT_AUTO_REFRESH_ENABLED,
+  };
+}
+
+export function assertDisabledModeWorkflow(inspection: PersistentWorkflowInspection): void {
+  if (!inspection.hasWorkflowDispatch) {
+    throw new Error("DISABLED-MODE workflow must include workflow_dispatch");
+  }
+  if (inspection.hasPushTrigger) {
+    throw new Error("DISABLED-MODE workflow must not include push trigger");
+  }
+  if (inspection.hasScheduleCron) {
+    throw new Error("DISABLED-MODE workflow must not include cron/schedule");
+  }
+  if (inspection.persistentEnabled) {
+    throw new Error("DISABLED-MODE must keep PERSISTENT_AUTO_REFRESH_ENABLED=false");
+  }
+  if (inspection.concurrencyGroupExpression !== PERSISTENT_CONCURRENCY_GROUP_EXPRESSION) {
+    throw new Error("DISABLED-MODE workflow concurrency group mismatch");
+  }
+  if (inspection.cancelInProgress !== true) {
+    throw new Error("DISABLED-MODE workflow must set cancel-in-progress: true");
+  }
+  if (inspection.permissionsContents !== "write") {
+    throw new Error("DISABLED-MODE workflow contents permission must be write");
+  }
+  if (inspection.permissionsPullRequests !== "write") {
+    throw new Error("DISABLED-MODE workflow pull-requests permission must be write");
+  }
+  if (
+    inspection.grantsIssuesWrite ||
+    inspection.grantsActionsWrite ||
+    inspection.grantsDeploymentsWrite ||
+    inspection.grantsIdTokenWrite ||
+    inspection.grantsPackagesWrite
+  ) {
+    throw new Error("DISABLED-MODE workflow grants excess permissions");
+  }
+  if (inspection.invokesReadyOrMerge) {
+    throw new Error("DISABLED-MODE workflow must not Ready/Merge/auto-merge");
+  }
 }

--- a/test/persistentAutoRefreshDisabledMode.test.ts
+++ b/test/persistentAutoRefreshDisabledMode.test.ts
@@ -1,0 +1,286 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import {
+  buildRefreshIdentity,
+  filterSourceArchitectureRelevantPaths,
+  hasMaterialSnapshotDiff,
+} from "../src/domain/autoRefreshContract";
+import { AUTO_REFRESH_PILOT_PUBLISHER } from "../src/domain/autoRefreshPublisher";
+import {
+  assertDisabledModeWorkflow,
+  assertGeneratedFromMatchesSourceMain,
+  assertPersistentAutoRefreshNotEnabled,
+  assertPersistentPublisherCannotReadyOrMerge,
+  classifyPersistentDraftDisposition,
+  classifyPersistentFailure,
+  decidePersistentPublication,
+  inspectPersistentWorkflowYaml,
+  isGeneratedOnlyChange,
+  isPersistentRefreshEligibleFromPaths,
+  mayRetryPublication,
+  PERSISTENT_ACTIVE_TRIGGERS,
+  PERSISTENT_AUTO_REFRESH_ENABLED,
+  PERSISTENT_AUTO_REFRESH_MODE,
+  PERSISTENT_AUTO_REFRESH_PUBLISHER,
+  PERSISTENT_CONCURRENCY_GROUP_EXPRESSION,
+  PERSISTENT_GITHUB_PERMISSIONS,
+  PERSISTENT_PATHS_IGNORE,
+  PERSISTENT_WORKFLOW_PATH,
+  persistentConcurrencyPolicy,
+  resolvePersistentStatus,
+} from "../src/domain/persistentAutoRefreshContract";
+
+const repo = "yasutakesougo/ai-development-control-center";
+const from = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const mainA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const mainB = "cccccccccccccccccccccccccccccccccccccccc";
+
+const workflowYaml = readFileSync(
+  new URL("../.github/workflows/architecture-auto-refresh.yml", import.meta.url),
+  "utf8",
+);
+
+describe("PERSISTENT-AUTO-REFRESH-V1 DISABLED-MODE", () => {
+  it("remains NOT ENABLED in DISABLED_MODE with workflow_dispatch-only active triggers", () => {
+    expect(PERSISTENT_AUTO_REFRESH_ENABLED).toBe(false);
+    expect(PERSISTENT_AUTO_REFRESH_MODE).toBe("DISABLED_MODE");
+    expect(PERSISTENT_ACTIVE_TRIGGERS).toEqual(["workflow_dispatch"]);
+    expect(PERSISTENT_ACTIVE_TRIGGERS).not.toContain("push_main");
+    expect(PERSISTENT_ACTIVE_TRIGGERS).not.toContain("schedule");
+    expect(() => assertPersistentAutoRefreshNotEnabled()).not.toThrow();
+  });
+
+  it("workflow only has workflow_dispatch; no push; no cron", () => {
+    const inspection = inspectPersistentWorkflowYaml(workflowYaml);
+    expect(inspection.path).toBe(PERSISTENT_WORKFLOW_PATH);
+    expect(inspection.hasWorkflowDispatch).toBe(true);
+    expect(inspection.hasPushTrigger).toBe(false);
+    expect(inspection.hasScheduleCron).toBe(false);
+    expect(() => assertDisabledModeWorkflow(inspection)).not.toThrow();
+  });
+
+  it("permissions are expected minimum and concurrency group exists", () => {
+    const inspection = inspectPersistentWorkflowYaml(workflowYaml);
+    expect(inspection.permissionsContents).toBe("write");
+    expect(inspection.permissionsPullRequests).toBe("write");
+    expect(inspection.grantsIssuesWrite).toBe(false);
+    expect(inspection.grantsActionsWrite).toBe(false);
+    expect(inspection.grantsDeploymentsWrite).toBe(false);
+    expect(inspection.grantsIdTokenWrite).toBe(false);
+    expect(inspection.grantsPackagesWrite).toBe(false);
+    expect(inspection.concurrencyGroupExpression).toBe(
+      PERSISTENT_CONCURRENCY_GROUP_EXPRESSION,
+    );
+    expect(inspection.cancelInProgress).toBe(true);
+    expect(inspection.invokesReadyOrMerge).toBe(false);
+    expect(PERSISTENT_GITHUB_PERMISSIONS.contents).toBe("write");
+    expect(PERSISTENT_GITHUB_PERMISSIONS.pullRequests).toBe("write");
+    expect(persistentConcurrencyPolicy().cancelInProgress).toBe(true);
+  });
+
+  it("generated-only change → no refresh", () => {
+    const paths = [...PERSISTENT_PATHS_IGNORE];
+    expect(isGeneratedOnlyChange(paths)).toBe(true);
+    expect(isPersistentRefreshEligibleFromPaths(paths)).toBe(false);
+  });
+
+  it("relevant source change → eligible", () => {
+    const paths = ["src/worker/index.ts", "README.md"];
+    expect(isPersistentRefreshEligibleFromPaths(paths)).toBe(true);
+    expect(filterSourceArchitectureRelevantPaths(paths)).toEqual(["src/worker/index.ts"]);
+  });
+
+  it("main moves → abort", () => {
+    const decided = decidePersistentPublication({
+      disposition: "NEW_DRAFT_REQUIRED",
+      mainRecheck: "MOVED",
+      verificationPassed: true,
+      materialSnapshotDiff: true,
+      failureClass: null,
+    });
+    expect(decided.decision).toBe("ABORTED_MAIN_MOVED");
+    expect(decided.status).toBe("ABORTED_MAIN_MOVED");
+    expect(
+      resolvePersistentStatus({
+        mainMoved: true,
+        eligible: true,
+        verificationPassed: true,
+        disposition: "NEW_DRAFT_REQUIRED",
+        failureClass: null,
+        published: false,
+      }),
+    ).toBe("ABORTED_MAIN_MOVED");
+  });
+
+  it("duplicate identity → reuse", () => {
+    const identity = buildRefreshIdentity({
+      repository: repo,
+      snapshotGeneratedFrom: from,
+      targetMainSha: mainA,
+    });
+    expect(
+      classifyPersistentDraftDisposition({
+        refreshIdentity: identity,
+        targetMainSha: mainA,
+        eligible: true,
+        existing: [
+          {
+            number: 10,
+            refreshIdentity: identity,
+            state: "DRAFT",
+            targetMainSha: mainA,
+          },
+        ],
+      }),
+    ).toBe("REUSE");
+  });
+
+  it("obsolete Draft → superseded candidate / no mutation / HOLD publication", () => {
+    const identity = buildRefreshIdentity({
+      repository: repo,
+      snapshotGeneratedFrom: from,
+      targetMainSha: mainB,
+    });
+    const disposition = classifyPersistentDraftDisposition({
+      refreshIdentity: identity,
+      targetMainSha: mainB,
+      eligible: true,
+      existing: [
+        {
+          number: 12,
+          refreshIdentity: buildRefreshIdentity({
+            repository: repo,
+            snapshotGeneratedFrom: from,
+            targetMainSha: mainA,
+          }),
+          state: "DRAFT",
+          targetMainSha: mainA,
+        },
+      ],
+    });
+    expect(disposition).toBe("SUPERSEDED_CANDIDATE");
+    const decided = decidePersistentPublication({
+      disposition,
+      mainRecheck: "MATCH",
+      verificationPassed: true,
+      materialSnapshotDiff: true,
+      failureClass: null,
+    });
+    expect(decided.decision).toBe("HOLD");
+    expect(decided.status).toBe("HOLD");
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canClosePullRequest).toBe(false);
+  });
+
+  it("verification fail → no publication", () => {
+    const decided = decidePersistentPublication({
+      disposition: "NEW_DRAFT_REQUIRED",
+      mainRecheck: "MATCH",
+      verificationPassed: false,
+      materialSnapshotDiff: true,
+      failureClass: classifyPersistentFailure({ kind: "verification_failed" }),
+    });
+    expect(decided.decision).toBe("HOLD");
+    expect(["HOLD", "FAILED"]).toContain(decided.status);
+  });
+
+  it("duplicate lookup unavailable → fail closed", () => {
+    expect(classifyPersistentFailure({ kind: "duplicate_check_unavailable" })).toBe("HOLD");
+    const decided = decidePersistentPublication({
+      disposition: "NEW_DRAFT_REQUIRED",
+      mainRecheck: "MATCH",
+      verificationPassed: true,
+      materialSnapshotDiff: true,
+      failureClass: classifyPersistentFailure({ kind: "duplicate_check_unavailable" }),
+    });
+    expect(decided.decision).toBe("HOLD");
+  });
+
+  it("publication OUTCOME_UNKNOWN → no blind retry", () => {
+    const failureClass = classifyPersistentFailure({ kind: "publish_transport_unknown" });
+    expect(failureClass).toBe("OUTCOME_UNKNOWN");
+    expect(
+      mayRetryPublication({ failureClass, equivalentDraftStillAbsent: true }),
+    ).toBe(false);
+    const decided = decidePersistentPublication({
+      disposition: "NEW_DRAFT_REQUIRED",
+      mainRecheck: "MATCH",
+      verificationPassed: true,
+      materialSnapshotDiff: true,
+      failureClass,
+    });
+    expect(decided.decision).toBe("OUTCOME_UNKNOWN");
+  });
+
+  it("publisher cannot Ready / Merge / close PR / Issue", () => {
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canCreateDraft).toBe(true);
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canMarkReady).toBe(false);
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canMerge).toBe(false);
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canClosePullRequest).toBe(false);
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canCloseIssue).toBe(false);
+    expect(AUTO_REFRESH_PILOT_PUBLISHER.canMarkReady).toBe(false);
+    expect(() => assertPersistentPublisherCannotReadyOrMerge()).not.toThrow();
+  });
+
+  it("generatedFrom source invariant", () => {
+    const require = createRequire(import.meta.url);
+    const mod = require("../scripts/generate-architecture-snapshot.mjs") as {
+      buildSnapshot: (
+        commit: string,
+        generatedAt?: string,
+      ) => { generatedFrom: { commit: string } };
+    };
+    const source = "dddddddddddddddddddddddddddddddddddddddd";
+    const snapshot = mod.buildSnapshot(source, "2026-08-12T00:00:00.000Z");
+    expect(snapshot.generatedFrom.commit).toBe(source);
+    expect(() =>
+      assertGeneratedFromMatchesSourceMain({
+        generatedFromCommit: snapshot.generatedFrom.commit,
+        sourceMainSha: source,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertGeneratedFromMatchesSourceMain({
+        generatedFromCommit: "feature-branch-head",
+        sourceMainSha: source,
+      }),
+    ).toThrow(/must equal source main/);
+
+    const before = JSON.parse(
+      readFileSync(new URL("../docs/architecture/architecture.json", import.meta.url), "utf8"),
+    );
+    const projected = {
+      ...before,
+      generatedFrom: { ...before.generatedFrom, commit: source },
+    };
+    expect(hasMaterialSnapshotDiff(before, projected)).toBe(true);
+  });
+
+  it("stale maintenance state != approval ACTION_REQUIRED", () => {
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canMarkReady).toBe(false);
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canMerge).toBe(false);
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canInvokeActionGateway).toBe(false);
+    expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canExecuteAgent).toBe(false);
+    // Run report type always pins approvalActionRequired: false at the contract layer.
+    const approvalActionRequired = false as const;
+    expect(approvalActionRequired).toBe(false);
+  });
+
+  it("rejects a push-triggered workflow YAML in DISABLED-MODE inspection", () => {
+    const bad = [
+      "on:",
+      "  push:",
+      "    branches: [main]",
+      "  workflow_dispatch:",
+      "concurrency:",
+      `  group: ${PERSISTENT_CONCURRENCY_GROUP_EXPRESSION}`,
+      "  cancel-in-progress: true",
+      "permissions:",
+      "  contents: write",
+      "  pull-requests: write",
+    ].join("\n");
+    const inspection = inspectPersistentWorkflowYaml(bad);
+    expect(inspection.hasPushTrigger).toBe(true);
+    expect(() => assertDisabledModeWorkflow(inspection)).toThrow(/must not include push/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Persistent AUTO-REFRESH is NOT ENABLED.**

This slice installs a real GitHub Actions workflow and repository-native runner in **DISABLED-MODE** so the executable structure can be reviewed before any push-to-main activation.

## Observed baseline

- **observed main:** `54c7a208f4446cd2ee281c7dc361665f47dd8015`
- **Snapshot generatedFrom:** `1af9d5b7e60a59c9df0ab9f8e6f0b88820cb6201`
- Open PRs at implementation start: none

## Disabled trigger

- **Active:** `workflow_dispatch` only
- **Not present:** `push` to `main`, cron/schedule, webhook, external scheduler
- Future enablement can add `push:` without redesigning jobs/steps (commented in workflow)

## Permissions

```yaml
permissions:
  contents: write
  pull-requests: write
```

No `issues` / `actions` / `deployments` / `id-token` / `packages` write.

Platform `pull-requests: write` is broader than intended Draft-only capability; publisher guards keep Ready/Merge/close unauthorized.

## Concurrency

```yaml
concurrency:
  group: architecture-auto-refresh-${{ github.repository }}-main
  cancel-in-progress: true
```

Plus deterministic refresh identity + second duplicate check immediately before publication.

## Duplicate protection

- Workflow concurrency
- Deterministic refresh identity
- Open equivalent PR check
- Second duplicate check before publish
- Equivalent → `REUSED_EXISTING`
- Obsolete → `SUPERSEDED_CANDIDATE` (report only; **no auto-close**; **no new Draft** while obsolete remains)

## Main movement

Re-observe main before publication. If tip moved → `ABORTED_MAIN_MOVED` (no publish).

## Failure semantics

`SAFE_RETRY` / `HOLD` / `OUTCOME_UNKNOWN`.  
`OUTCOME_UNKNOWN` never authorizes blind duplicate publication retry.

## Publication boundary

Publisher may only create/update its feature branch, commit Snapshot artifacts, and create one Draft PR.

- `canCreateDraft=true`
- `canMarkReady=false`
- `canMerge=false`
- `canClosePullRequest=false`
- `canCloseIssue=false`

## Artifacts

- `.github/workflows/architecture-auto-refresh.yml`
- `scripts/run-persistent-auto-refresh.ts` (`npm run auto-refresh:persistent`)
- `src/domain/persistentAutoRefreshContract.ts` (extended)
- `test/persistentAutoRefreshDisabledMode.test.ts`

## Verification

- `npm run verify` — **PASS** (**194/194** tests)
- Workflow static contract inspection — **PASS** (dispatch-only, concurrency, least-privilege permissions)

## Explicit statements

- **Persistent AUTO-REFRESH is NOT ENABLED.**
- **`workflow_dispatch` was NOT executed** in this slice.
- No test Draft was created through the new persistent workflow.

## Expected follow-up refresh after merge

**YES** — `package.json` is architecture-relevant (new `auto-refresh:persistent` script). Do **not** auto-run that refresh from this PR.

## Human gate

Draft PR review only. Do not mark Ready / Merge here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff3bd-613c-7d0a-b59d-d9615a722c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff3bd-613c-7d0a-b59d-d9615a722c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

