### PR TITLE
chore(architecture): enable persistent AUTO-REFRESH on main

### DIFF
--- a/.github/workflows/architecture-auto-refresh.yml
+++ b/.github/workflows/architecture-auto-refresh.yml
@@ -1,17 +1,13 @@
-# PERSISTENT-AUTO-REFRESH-V1 — DISABLED-MODE
+# PERSISTENT-AUTO-REFRESH-V1 — ENABLED (push to main + workflow_dispatch)
 #
-# Persistent AUTO-REFRESH is NOT ENABLED.
-# This workflow validates the executable structure without push-to-main automation.
+# Persistent AUTO-REFRESH becomes ENABLED when this workflow is on the default
+# branch with the push trigger below. Draft-only publication boundary is
+# unchanged (Ready/Merge/close remain unauthorized in repository-native guards).
 #
-# Active trigger: workflow_dispatch only
-# Not present: push to main, cron/schedule, webhook, external scheduler
-#
-# Future enablement slice may add (without redesigning jobs/steps):
-#   push:
-#     branches: [main]
-#     paths-ignore:
-#       - "docs/architecture/architecture.json"
-#       - "docs/architecture/architecture.html"
+# Active triggers:
+#   - push to main (primary)
+#   - workflow_dispatch (manual fallback)
+# Not present: cron/schedule, pull_request, repository_dispatch, webhook
 #
 # Platform permissions (contents/pull-requests write) are broader than the
 # intended Draft-only capability enforced in repository-native publisher guards
@@ -20,6 +16,12 @@
 name: architecture-auto-refresh
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/architecture/architecture.json"
+      - "docs/architecture/architecture.html"
   workflow_dispatch:
 
 concurrency:
@@ -50,7 +52,7 @@ jobs:
       - name: Evaluate + regenerate + verify + Draft-only publish capability
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSISTENT_AUTO_REFRESH_TRIGGER: workflow_dispatch
+          PERSISTENT_AUTO_REFRESH_TRIGGER: ${{ github.event_name }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: npm run auto-refresh:persistent -- --publish
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -20,6 +20,7 @@ Unknowns and assumptions are retained explicitly; they must not be upgraded to
 confirmed facts without repository evidence.
 
 AUTO-REFRESH-V1 is **designed**; a **manual** pilot exists
-(`npm run auto-refresh:pilot`). Persistent AUTO-REFRESH has a **DISABLED-MODE**
-workflow (`workflow_dispatch` only) and remains **NOT ENABLED** (no push-to-main
-automation) — see [`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md).
+(`npm run auto-refresh:pilot`). Persistent AUTO-REFRESH is **ENABLED** via
+`.github/workflows/architecture-auto-refresh.yml` (`push` to `main` +
+`workflow_dispatch`) and still stops at Draft PR — see
+[`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md).

--- a/docs/architecture/auto-refresh-v1.md
+++ b/docs/architecture/auto-refresh-v1.md
@@ -14,9 +14,9 @@ It does **not** enable cron, push triggers, Ready, Merge, Action Gateway, or
 Agent execution.
 
 Persistent AUTO-REFRESH is designed separately in
-[`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md). A
-**DISABLED-MODE** workflow exists (`workflow_dispatch` only) and Persistent
-AUTO-REFRESH remains **NOT ENABLED** (no push-to-main automatic publication).
+[`persistent-auto-refresh-v1.md`](./persistent-auto-refresh-v1.md). The
+workflow (`.github/workflows/architecture-auto-refresh.yml`) uses `push` to
+`main` plus `workflow_dispatch` and remains Draft-only (no Ready/Merge).
 
 ---
 

--- a/docs/architecture/persistent-auto-refresh-v1.md
+++ b/docs/architecture/persistent-auto-refresh-v1.md
@@ -1,19 +1,19 @@
 # PERSISTENT-AUTO-REFRESH-V1
 
-**Status: DISABLED-MODE IMPLEMENTED · NOT ENABLED · NO PUSH TRIGGER · NO SCHEDULER**
+**Status: ENABLED (push to main + workflow_dispatch) · Draft-only · NO SCHEDULER**
 
 This document designs and tracks the **persistent** Architecture Snapshot
 refresh mechanism. It builds on:
 
 - `docs/architecture/auto-refresh-v1.md` (eligibility / anti-loop / identity)
 - AUTO-REFRESH-PILOT-V1 (`npm run auto-refresh:pilot`) — manual proof path
-- DISABLED-MODE runner: `npm run auto-refresh:persistent`
-- DISABLED-MODE workflow: `.github/workflows/architecture-auto-refresh.yml`
-  (`workflow_dispatch` only)
+- Persistent runner: `npm run auto-refresh:persistent`
+- Workflow: `.github/workflows/architecture-auto-refresh.yml`
+  (`push` to `main` + `workflow_dispatch`)
 
-**Persistent AUTO-REFRESH is NOT ENABLED.** Push-to-main automatic publication
-is absent. A later Human-authorized enablement slice may add the `push:`
-trigger without redesigning jobs/steps.
+**Enablement:** when the enabled workflow is present on the default branch,
+Persistent AUTO-REFRESH is **ENABLED** for push-to-main. Publication still
+stops at Draft PR. Ready/Merge remain Human.
 
 Companion pure helpers: `src/domain/persistentAutoRefreshContract.ts`  
 Example (historical) workflow sketch:
@@ -61,15 +61,16 @@ Human **Ready** and Human **Merge** remain unchanged.
 - Always apply repository-native contract evaluation when the workflow runs.
   Generic HEAD change alone is never sufficient for publication.
 
-### Explicit non-enablement
+### Explicit non-enablement of cron / Ready / Merge
 
-Until an accepted **enablement** slice lands:
+Until a separate Human-authorized expansion lands:
 
-- `.github/workflows/architecture-auto-refresh.yml` may exist only in
-  **DISABLED-MODE** (`workflow_dispatch` only; no `push`, no cron)
-- Persistent AUTO-REFRESH remains **NOT ENABLED** (no automatic push-to-main)
+- cron / schedule remains **NOT** selected for V1
+- Ready / Merge / auto-merge / PR close remain unauthorized
 - platform `pull-requests: write` is broader than intended Draft-only
   capability; publisher guards keep Ready/Merge/close unauthorized
+
+Push-to-main + `workflow_dispatch` are the accepted V1 triggers.
 
 ---
 
@@ -310,22 +311,18 @@ above.
 
 ---
 
-## Proposed implementation artifacts (future enablement)
+## Proposed implementation artifacts
 
 | Artifact | Role |
 |---|---|
-| `.github/workflows/architecture-auto-refresh.yml` | DISABLED-MODE workflow (`workflow_dispatch` only); enablement adds `push` |
-| `docs/architecture/persistent-auto-refresh-workflow.example.yml` | Historical example with commented push shape |
-| `scripts/run-persistent-auto-refresh.ts` | DISABLED-MODE runner (`npm run auto-refresh:persistent`) |
+| `.github/workflows/architecture-auto-refresh.yml` | ENABLED workflow (`push` to `main` + `workflow_dispatch`) |
+| `docs/architecture/persistent-auto-refresh-workflow.example.yml` | Historical example |
+| `scripts/run-persistent-auto-refresh.ts` | Persistent runner (`npm run auto-refresh:persistent`) |
 | `scripts/run-auto-refresh-pilot.ts` | Manual pilot runner |
 | `src/domain/autoRefreshContract.ts` | Eligibility / anti-loop / identity |
 | `src/domain/autoRefreshPilot.ts` | Publication decision helpers |
 | `src/domain/autoRefreshPublisher.ts` | Draft-only publisher caps |
 | `src/domain/persistentAutoRefreshContract.ts` | Concurrency / failure / draft disposition / workflow inspection |
-
-Enablement requires a **separate Human-authorized** PR that adds `push:` to
-the DISABLED-MODE workflow (with designed filters) while keeping Draft-only
-publisher guards.
 
 ---
 
@@ -335,10 +332,9 @@ publisher guards.
 |---|---|
 | Persistent design | this document |
 | Pure contract helpers + tests | present |
-| DISABLED-MODE workflow | `.github/workflows/architecture-auto-refresh.yml` (`workflow_dispatch` only) |
-| DISABLED-MODE runner | `npm run auto-refresh:persistent` |
-| Example workflow YAML | docs only (non-triggering historical sketch) |
-| Active push-to-main AUTO-REFRESH | **NOT ENABLED** |
+| ENABLED workflow | `.github/workflows/architecture-auto-refresh.yml` |
+| Persistent runner | `npm run auto-refresh:persistent` |
+| Active push-to-main AUTO-REFRESH | **ENABLED** (after this enablement merges) |
 | cron / webhook mutation | **NOT ENABLED** |
 | Ready / Merge automation | **NOT ENABLED** |
 | Action Gateway / Agent execution | **NOT IMPLEMENTED** |

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -65,10 +65,9 @@ HANDOFF-V1 does not regenerate the Architecture Snapshot.
 
 AUTO-REFRESH-V1 is **designed** with a **manual** pilot
 (`npm run auto-refresh:pilot`) that may open a Draft refresh PR only.
-Persistent AUTO-REFRESH has a **DISABLED-MODE** implementation
-(`docs/architecture/persistent-auto-refresh-v1.md`,
-`.github/workflows/architecture-auto-refresh.yml` with `workflow_dispatch` only)
-and remains **NOT ENABLED** (no push-to-main automation). Snapshot staleness is
+Persistent AUTO-REFRESH is **ENABLED** for push-to-main via
+`.github/workflows/architecture-auto-refresh.yml` (`docs/architecture/persistent-auto-refresh-v1.md`)
+and still stops at Draft PR (no Ready/Merge automation). Snapshot staleness is
 maintenance evidence only and must never be upgraded into HANDOFF / Approval
 Ledger `ACTION_REQUIRED`.
 

--- a/scripts/run-persistent-auto-refresh.ts
+++ b/scripts/run-persistent-auto-refresh.ts
@@ -30,12 +30,13 @@ import {
 } from "../src/domain/autoRefreshPublisher";
 import {
   assertGeneratedFromMatchesSourceMain,
-  assertPersistentAutoRefreshNotEnabled,
+  assertPersistentAutoRefreshEnabled,
   assertPersistentPublisherCannotReadyOrMerge,
   classifyPersistentDraftDisposition,
   classifyPersistentFailure,
   decidePersistentPublication,
   mayRetryPublication,
+  PERSISTENT_AUTO_REFRESH_ENABLED,
   PERSISTENT_AUTO_REFRESH_MODE,
   type PersistentAutoRefreshRunReport,
   type PersistentFailureClass,
@@ -128,7 +129,7 @@ function mapExistingPulls(
 }
 
 async function main(): Promise<void> {
-  assertPersistentAutoRefreshNotEnabled();
+  assertPersistentAutoRefreshEnabled();
   assertPersistentPublisherCannotReadyOrMerge();
 
   const args = parseArgs(process.argv.slice(2));
@@ -137,7 +138,9 @@ async function main(): Promise<void> {
   const trigger =
     triggerEnv === "workflow_dispatch"
       ? ("workflow_dispatch" as const)
-      : ("manual_cli" as const);
+      : triggerEnv === "push"
+        ? ("push_main" as const)
+        : ("manual_cli" as const);
   const runId = process.env.GITHUB_RUN_ID ?? null;
 
   const raw = JSON.parse(readFileSync(snapshotPath, "utf8"));
@@ -242,7 +245,7 @@ async function main(): Promise<void> {
     },
     failureClass,
     approvalActionRequired: false,
-    persistentAutoRefreshEnabled: false,
+    persistentAutoRefreshEnabled: PERSISTENT_AUTO_REFRESH_ENABLED,
     evaluatedAt,
   };
 

--- a/src/domain/persistentAutoRefreshContract.ts
+++ b/src/domain/persistentAutoRefreshContract.ts
@@ -1,10 +1,10 @@
 /**
  * PERSISTENT-AUTO-REFRESH-V1 contract helpers.
  *
- * DISABLED-MODE IMPLEMENTATION · NOT ENABLED (no push-to-main automatic execution)
+ * ENABLED · push to main + workflow_dispatch · Draft-only publication
  *
  * Concurrency, failure, Draft disposition, workflow static inspection, and
- * publication decision logic. Does not enable cron or push triggers.
+ * publication decision logic. Cron/schedule remains not selected for V1.
  */
 
 import {
@@ -20,10 +20,10 @@ import {
 import type { MainRecheckResult } from "./autoRefreshPilot";
 
 export const PERSISTENT_AUTO_REFRESH_DESIGN = "PERSISTENT-AUTO-REFRESH-DESIGN-V1" as const;
-export const PERSISTENT_AUTO_REFRESH_MODE = "DISABLED_MODE" as const;
+export const PERSISTENT_AUTO_REFRESH_MODE = "ENABLED" as const;
 
-/** Push-to-main / scheduled persistent automation remains off. */
-export const PERSISTENT_AUTO_REFRESH_ENABLED = false as const;
+/** Push-to-main persistent automation is enabled (cron still absent). */
+export const PERSISTENT_AUTO_REFRESH_ENABLED = true as const;
 
 export const PERSISTENT_CONCURRENCY_GROUP = "architecture-auto-refresh-main" as const;
 export const PERSISTENT_CONCURRENCY_GROUP_EXPRESSION =
@@ -33,8 +33,8 @@ export const PERSISTENT_CANCEL_IN_PROGRESS = true as const;
 export const PERSISTENT_WORKFLOW_PATH =
   ".github/workflows/architecture-auto-refresh.yml" as const;
 
-/** Active triggers in DISABLED-MODE (push/cron must remain absent). */
-export const PERSISTENT_ACTIVE_TRIGGERS = ["workflow_dispatch"] as const;
+/** Active triggers when ENABLED (cron/schedule must remain absent). */
+export const PERSISTENT_ACTIVE_TRIGGERS = ["push_main", "workflow_dispatch"] as const;
 
 /**
  * Designed preference for a future enablement slice.
@@ -106,6 +106,9 @@ export interface PersistentWorkflowInspection {
   path: typeof PERSISTENT_WORKFLOW_PATH;
   hasWorkflowDispatch: boolean;
   hasPushTrigger: boolean;
+  hasPushMainOnly: boolean;
+  hasPullRequestTrigger: boolean;
+  hasRepositoryDispatch: boolean;
   hasScheduleCron: boolean;
   concurrencyGroupExpression: string | null;
   cancelInProgress: boolean | null;
@@ -124,7 +127,7 @@ export interface PersistentWorkflowInspection {
 export interface PersistentAutoRefreshRunReport {
   schemaVersion: "1.0";
   mode: typeof PERSISTENT_AUTO_REFRESH_MODE;
-  trigger: "workflow_dispatch" | "manual_cli" | "unknown";
+  trigger: "workflow_dispatch" | "push_main" | "manual_cli" | "unknown";
   repository: string;
   runId: string | null;
   observedMain: string | null;
@@ -156,14 +159,14 @@ export interface PersistentAutoRefreshRunReport {
   };
   failureClass: PersistentFailureClass | null;
   approvalActionRequired: false;
-  persistentAutoRefreshEnabled: false;
+  persistentAutoRefreshEnabled: typeof PERSISTENT_AUTO_REFRESH_ENABLED;
   evaluatedAt: string;
 }
 
-export function assertPersistentAutoRefreshNotEnabled(): void {
-  if (PERSISTENT_AUTO_REFRESH_ENABLED) {
+export function assertPersistentAutoRefreshEnabled(): void {
+  if (!PERSISTENT_AUTO_REFRESH_ENABLED) {
     throw new Error(
-      "PERSISTENT-AUTO-REFRESH-V1 must remain NOT ENABLED (no push-to-main automatic execution)",
+      "PERSISTENT-AUTO-REFRESH-V1 must be ENABLED (push-to-main + workflow_dispatch)",
     );
   }
 }
@@ -407,7 +410,7 @@ export function persistentConcurrencyPolicy(): {
 }
 
 /**
- * Static inspection of the DISABLED-MODE workflow YAML text.
+ * Static inspection of the persistent workflow YAML text.
  * Uses conservative string checks (no YAML dependency).
  */
 export function inspectPersistentWorkflowYaml(yaml: string): PersistentWorkflowInspection {
@@ -419,8 +422,22 @@ export function inspectPersistentWorkflowYaml(yaml: string): PersistentWorkflowI
   const hasWorkflowDispatch = /^\s*workflow_dispatch\s*:/m.test(withoutComments);
   // Active push trigger only if an uncommented `push:` appears under `on:`.
   const hasPushTrigger = /^\s*push\s*:/m.test(withoutComments);
+  const hasPullRequestTrigger = /^\s*pull_request\s*:/m.test(withoutComments);
+  const hasRepositoryDispatch = /^\s*repository_dispatch\s*:/m.test(withoutComments);
   const hasScheduleCron =
     /^\s*schedule\s*:/m.test(withoutComments) || /^\s*-\s*cron\s*:/m.test(withoutComments);
+
+  const pushMainInline = /push:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+branches:\s*\[\s*main\s*\]/.test(
+    withoutComments,
+  );
+  const pushMainList = /push:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+branches:\s*\n[ \t]+-\s*main\b/.test(
+    withoutComments,
+  );
+  const pushOtherBranchList =
+    /push:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+branches:\s*\n(?:[ \t]+-\s*(?!main\b)\S+\s*\n)+/.test(
+      withoutComments,
+    );
+  const hasPushMainOnly = hasPushTrigger && (pushMainInline || pushMainList) && !pushOtherBranchList;
 
   const concurrencyMatch = withoutComments.match(
     /concurrency:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+group:\s*([^\n]+)/,
@@ -448,6 +465,9 @@ export function inspectPersistentWorkflowYaml(yaml: string): PersistentWorkflowI
     path: PERSISTENT_WORKFLOW_PATH,
     hasWorkflowDispatch,
     hasPushTrigger,
+    hasPushMainOnly,
+    hasPullRequestTrigger,
+    hasRepositoryDispatch,
     hasScheduleCron,
     concurrencyGroupExpression,
     cancelInProgress,
@@ -464,6 +484,53 @@ export function inspectPersistentWorkflowYaml(yaml: string): PersistentWorkflowI
   };
 }
 
+/** Assert ENABLED workflow shape: push(main) + workflow_dispatch, no cron/extra scopes. */
+export function assertEnabledModeWorkflow(inspection: PersistentWorkflowInspection): void {
+  if (!inspection.hasWorkflowDispatch) {
+    throw new Error("ENABLED workflow must include workflow_dispatch");
+  }
+  if (!inspection.hasPushTrigger || !inspection.hasPushMainOnly) {
+    throw new Error("ENABLED workflow must include push trigger for main only");
+  }
+  if (inspection.hasPullRequestTrigger) {
+    throw new Error("ENABLED workflow must not include pull_request trigger");
+  }
+  if (inspection.hasRepositoryDispatch) {
+    throw new Error("ENABLED workflow must not include repository_dispatch");
+  }
+  if (inspection.hasScheduleCron) {
+    throw new Error("ENABLED workflow must not include cron/schedule");
+  }
+  if (!inspection.persistentEnabled) {
+    throw new Error("ENABLED mode requires PERSISTENT_AUTO_REFRESH_ENABLED=true");
+  }
+  if (inspection.concurrencyGroupExpression !== PERSISTENT_CONCURRENCY_GROUP_EXPRESSION) {
+    throw new Error("ENABLED workflow concurrency group mismatch");
+  }
+  if (inspection.cancelInProgress !== true) {
+    throw new Error("ENABLED workflow must set cancel-in-progress: true");
+  }
+  if (inspection.permissionsContents !== "write") {
+    throw new Error("ENABLED workflow contents permission must be write");
+  }
+  if (inspection.permissionsPullRequests !== "write") {
+    throw new Error("ENABLED workflow pull-requests permission must be write");
+  }
+  if (
+    inspection.grantsIssuesWrite ||
+    inspection.grantsActionsWrite ||
+    inspection.grantsDeploymentsWrite ||
+    inspection.grantsIdTokenWrite ||
+    inspection.grantsPackagesWrite
+  ) {
+    throw new Error("ENABLED workflow grants excess permissions");
+  }
+  if (inspection.invokesReadyOrMerge) {
+    throw new Error("ENABLED workflow must not Ready/Merge/auto-merge");
+  }
+}
+
+/** @deprecated Retained for negative-path tests of pre-enablement YAML. */
 export function assertDisabledModeWorkflow(inspection: PersistentWorkflowInspection): void {
   if (!inspection.hasWorkflowDispatch) {
     throw new Error("DISABLED-MODE workflow must include workflow_dispatch");

--- a/test/persistentAutoRefreshContract.test.ts
+++ b/test/persistentAutoRefreshContract.test.ts
@@ -4,7 +4,7 @@ import {
   filterSourceArchitectureRelevantPaths,
 } from "../src/domain/autoRefreshContract";
 import {
-  assertPersistentAutoRefreshNotEnabled,
+  assertPersistentAutoRefreshEnabled,
   assertPersistentPublisherCannotReadyOrMerge,
   classifyPersistentDraftDisposition,
   classifyPersistentFailure,
@@ -26,9 +26,9 @@ const mainA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const mainB = "cccccccccccccccccccccccccccccccccccccccc";
 
 describe("PERSISTENT-AUTO-REFRESH-V1 design contract", () => {
-  it("remains NOT ENABLED and prefers push_main then workflow_dispatch", () => {
-    expect(PERSISTENT_AUTO_REFRESH_ENABLED).toBe(false);
-    expect(() => assertPersistentAutoRefreshNotEnabled()).not.toThrow();
+  it("is ENABLED and prefers push_main then workflow_dispatch", () => {
+    expect(PERSISTENT_AUTO_REFRESH_ENABLED).toBe(true);
+    expect(() => assertPersistentAutoRefreshEnabled()).not.toThrow();
     expect(PERSISTENT_TRIGGER_PREFERENCE).toEqual(["push_main", "workflow_dispatch"]);
     expect(PERSISTENT_TRIGGER_PREFERENCE).not.toContain("schedule");
   });

--- a/test/persistentAutoRefreshDisabledMode.test.ts
+++ b/test/persistentAutoRefreshDisabledMode.test.ts
@@ -9,8 +9,9 @@ import {
 import { AUTO_REFRESH_PILOT_PUBLISHER } from "../src/domain/autoRefreshPublisher";
 import {
   assertDisabledModeWorkflow,
+  assertEnabledModeWorkflow,
   assertGeneratedFromMatchesSourceMain,
-  assertPersistentAutoRefreshNotEnabled,
+  assertPersistentAutoRefreshEnabled,
   assertPersistentPublisherCannotReadyOrMerge,
   classifyPersistentDraftDisposition,
   classifyPersistentFailure,
@@ -41,23 +42,25 @@ const workflowYaml = readFileSync(
   "utf8",
 );
 
-describe("PERSISTENT-AUTO-REFRESH-V1 DISABLED-MODE", () => {
-  it("remains NOT ENABLED in DISABLED_MODE with workflow_dispatch-only active triggers", () => {
-    expect(PERSISTENT_AUTO_REFRESH_ENABLED).toBe(false);
-    expect(PERSISTENT_AUTO_REFRESH_MODE).toBe("DISABLED_MODE");
-    expect(PERSISTENT_ACTIVE_TRIGGERS).toEqual(["workflow_dispatch"]);
-    expect(PERSISTENT_ACTIVE_TRIGGERS).not.toContain("push_main");
+describe("PERSISTENT-AUTO-REFRESH-V1 ENABLEMENT", () => {
+  it("is ENABLED with push_main + workflow_dispatch active triggers", () => {
+    expect(PERSISTENT_AUTO_REFRESH_ENABLED).toBe(true);
+    expect(PERSISTENT_AUTO_REFRESH_MODE).toBe("ENABLED");
+    expect(PERSISTENT_ACTIVE_TRIGGERS).toEqual(["push_main", "workflow_dispatch"]);
     expect(PERSISTENT_ACTIVE_TRIGGERS).not.toContain("schedule");
-    expect(() => assertPersistentAutoRefreshNotEnabled()).not.toThrow();
+    expect(() => assertPersistentAutoRefreshEnabled()).not.toThrow();
   });
 
-  it("workflow only has workflow_dispatch; no push; no cron", () => {
+  it("workflow has push(main) + workflow_dispatch; no cron; no pull_request", () => {
     const inspection = inspectPersistentWorkflowYaml(workflowYaml);
     expect(inspection.path).toBe(PERSISTENT_WORKFLOW_PATH);
     expect(inspection.hasWorkflowDispatch).toBe(true);
-    expect(inspection.hasPushTrigger).toBe(false);
+    expect(inspection.hasPushTrigger).toBe(true);
+    expect(inspection.hasPushMainOnly).toBe(true);
+    expect(inspection.hasPullRequestTrigger).toBe(false);
+    expect(inspection.hasRepositoryDispatch).toBe(false);
     expect(inspection.hasScheduleCron).toBe(false);
-    expect(() => assertDisabledModeWorkflow(inspection)).not.toThrow();
+    expect(() => assertEnabledModeWorkflow(inspection)).not.toThrow();
   });
 
   it("permissions are expected minimum and concurrency group exists", () => {
@@ -261,17 +264,19 @@ describe("PERSISTENT-AUTO-REFRESH-V1 DISABLED-MODE", () => {
     expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canMerge).toBe(false);
     expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canInvokeActionGateway).toBe(false);
     expect(PERSISTENT_AUTO_REFRESH_PUBLISHER.canExecuteAgent).toBe(false);
-    // Run report type always pins approvalActionRequired: false at the contract layer.
     const approvalActionRequired = false as const;
     expect(approvalActionRequired).toBe(false);
   });
 
-  it("rejects a push-triggered workflow YAML in DISABLED-MODE inspection", () => {
+  it("rejects cron-enabled workflow YAML in ENABLED inspection", () => {
     const bad = [
       "on:",
       "  push:",
-      "    branches: [main]",
+      "    branches:",
+      "      - main",
       "  workflow_dispatch:",
+      "  schedule:",
+      "    - cron: '0 * * * *'",
       "concurrency:",
       `  group: ${PERSISTENT_CONCURRENCY_GROUP_EXPRESSION}`,
       "  cancel-in-progress: true",
@@ -280,7 +285,25 @@ describe("PERSISTENT-AUTO-REFRESH-V1 DISABLED-MODE", () => {
       "  pull-requests: write",
     ].join("\n");
     const inspection = inspectPersistentWorkflowYaml(bad);
-    expect(inspection.hasPushTrigger).toBe(true);
-    expect(() => assertDisabledModeWorkflow(inspection)).toThrow(/must not include push/);
+    expect(inspection.hasScheduleCron).toBe(true);
+    expect(() => assertEnabledModeWorkflow(inspection)).toThrow(/cron/);
+  });
+
+  it("dispatch-only YAML is not ENABLED shape", () => {
+    const disabled = [
+      "on:",
+      "  workflow_dispatch:",
+      "concurrency:",
+      `  group: ${PERSISTENT_CONCURRENCY_GROUP_EXPRESSION}`,
+      "  cancel-in-progress: true",
+      "permissions:",
+      "  contents: write",
+      "  pull-requests: write",
+    ].join("\n");
+    const inspection = inspectPersistentWorkflowYaml(disabled);
+    expect(inspection.hasPushTrigger).toBe(false);
+    // Contract constant is ENABLED=true on this branch, so DISABLED assert fails closed on enabled flag.
+    expect(() => assertDisabledModeWorkflow(inspection)).toThrow(/PERSISTENT_AUTO_REFRESH_ENABLED=false/);
+    expect(() => assertEnabledModeWorkflow(inspection)).toThrow(/push trigger/);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Persistent AUTO-REFRESH will become ENABLED only after this PR is merged.**

This slice activates the reviewed `push` to `main` trigger on the existing `.github/workflows/architecture-auto-refresh.yml`. No capability expansion beyond the accepted design.

## Smoke evidence (pre-enablement)

- Run `31561500637` — SUCCESS — `REFRESH_NOT_REQUIRED` — `NO_PUBLICATION`
- Run `31561520227` — SUCCESS — `REFRESH_NOT_REQUIRED` — `NO_PUBLICATION`
- Actor: `yasutakesougo` via `workflow_dispatch`
- Head SHA: `d0100a1626ca5b6bf2078b2af257a857bfbbca3a`

## Trigger change

| Before | After (this PR on main) |
|---|---|
| `workflow_dispatch` only | `push` to `main` + `workflow_dispatch` |

Also retains designed `paths-ignore` for generated Snapshot artifacts.

**Not added:** cron, schedule, `pull_request`, `repository_dispatch`, webhook.

## Unchanged

- **Permissions:** `contents: write`, `pull-requests: write` only
- **Concurrency:** `architecture-auto-refresh-${{ github.repository }}-main` + `cancel-in-progress: true`
- **Mutation boundary:** Draft-only (`canMarkReady/canMerge/canClose*=false`)
- **Anti-loop / main movement / duplicate / failure semantics:** unchanged

## Tests / verification

- `npm run verify` — **PASS** (**195/195** tests)
- Static workflow inspection — ENABLED shape PASS

## Expected behavior immediately after merge

- Actions **will run** once (merge push to `main` activates the new trigger)
- Changed files in this PR are **not** architecture-relevant under accepted rules → expected evaluation **REFRESH_NOT_REQUIRED** / **NO_PUBLICATION**
- Persistent AUTO-REFRESH becomes **ENABLED** for subsequent architecture-relevant main pushes

## Human gate

Draft PR review only. Do not mark Ready / Merge here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff3bd-613c-7d0a-b59d-d9615a722c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff3bd-613c-7d0a-b59d-d9615a722c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

