### PR TITLE
feat(status): implement STATUS-OVERLAY-V1 runtime generator

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,6 +29,7 @@ HISTORY-V1 is **designed** (append-only Snapshot/refresh audit) and **not
 implemented** — see [`../history/history-v1.md`](../history/history-v1.md).
 No persistence writer is enabled.
 
-STATUS-OVERLAY-V1 is **designed** (current-state projection) and **not
-implemented** — see [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
-Runtime generator and UI are not enabled.
+STATUS-OVERLAY-V1 is **designed**; pure Runtime Generator is **implemented**
+(`src/domain/statusOverlayGenerator.ts`) — see
+[`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
+UI / observer / Action Gateway binding remain not implemented.

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -76,9 +76,11 @@ implemented** — see [`../history/history-v1.md`](../history/history-v1.md).
 Historical events must not change HANDOFF decision semantics or manufacture
 `ACTION_REQUIRED`.
 
-STATUS-OVERLAY-V1 (current-state projection) is **designed** and **not
-implemented** — see [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
+STATUS-OVERLAY-V1 (current-state projection) is **designed**; pure Runtime
+Generator is **implemented** — see
+[`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
 Overlay consumes HANDOFF output and must not redefine HANDOFF rules.
+UI / observer remain not implemented.
 
 ## Next action
 

--- a/docs/status/status-overlay-v1.md
+++ b/docs/status/status-overlay-v1.md
@@ -1,6 +1,6 @@
 # STATUS-OVERLAY-V1
 
-**Status: DESIGNED · runtime generator NOT IMPLEMENTED · UI NOT IMPLEMENTED**
+**Status: DESIGNED · runtime generator IMPLEMENTED · UI NOT IMPLEMENTED**
 
 This document designs **STATUS-OVERLAY-V1**: a replaceable **current-state
 projection** that answers:
@@ -11,11 +11,16 @@ projection** that answers:
 - What is waiting on Human?
 - What is safe to do next?
 
-Companion pure helpers (design contract only):
-`src/domain/statusOverlayContract.ts`
+Companion modules:
+
+- Contract helpers: `src/domain/statusOverlayContract.ts`
+- Runtime generator (pure): `src/domain/statusOverlayGenerator.ts`
 
 STATUS-OVERLAY is **decision-support only**. It does **not** authorize
 mutation, Ready, Merge, Action Gateway, Agent execution, or Ledger writes.
+
+Observation remains separate: callers supply explicit observed inputs. No
+GitHub observer, repository-file writer, or UI is implemented in this slice.
 
 ---
 
@@ -298,9 +303,16 @@ the decision depends on that evidence.
 }
 ```
 
-Runtime generation of this document is **NOT IMPLEMENTED** in this slice.
-Pure contract helpers exist for precedence, gate classification, and
-next-action selection only.
+Runtime generation is implemented as a pure function:
+
+```ts
+generateStatusOverlay(input) → StatusOverlayDocument
+```
+
+The generator accepts already-observed inputs, preserves caller-supplied
+`observedAt` exactly, and reuses contract helpers for coverage / gates /
+next-action selection. It does **not** observe GitHub, write files, or
+create timestamps.
 
 ---
 
@@ -350,8 +362,9 @@ No decorative metric strips. Markdown/HTML renderer is **NOT IMPLEMENTED**.
 
 ## Storage / runtime
 
+- Pure in-memory generator: `generateStatusOverlay`.
 - No new Cloudflare / SharePoint persistence.
-- No production writer for overlay artifacts in this slice.
+- No production repository-file writer for overlay artifacts in this slice.
 - Future optional emit path (not implemented): e.g. `docs/status/status-overlay.json`
   generated on demand (replaceable), never treated as authorization.
 
@@ -371,6 +384,9 @@ No decorative metric strips. Markdown/HTML renderer is **NOT IMPLEMENTED**.
 | Item | Status |
 |---|---|
 | STATUS-OVERLAY-V1 | **DESIGNED** |
-| Runtime generator | **NOT IMPLEMENTED** |
+| Runtime generator | **IMPLEMENTED** (`statusOverlayGenerator.ts`) |
+| GitHub / workflow observer | **NOT IMPLEMENTED** |
+| Repository-file writer | **NOT IMPLEMENTED** |
 | UI | **NOT IMPLEMENTED** |
 | Action Gateway binding | **NOT IMPLEMENTED** |
+| Approval Ledger / Agent execution | **NOT IMPLEMENTED** |

--- a/src/domain/statusOverlayContract.ts
+++ b/src/domain/statusOverlayContract.ts
@@ -1,19 +1,20 @@
 /**
  * STATUS-OVERLAY-V1 design contract helpers.
  *
- * DESIGNED · runtime generator NOT IMPLEMENTED · UI NOT IMPLEMENTED
+ * DESIGNED · runtime generator IMPLEMENTED · UI NOT IMPLEMENTED
  *
  * Pure live-state precedence, Human-gate classification, and deterministic
  * next-action selection. Does not observe GitHub, write files, or authorize
- * mutation.
+ * mutation. Projection assembly lives in `statusOverlayGenerator.ts`.
  */
 
 export const STATUS_OVERLAY_SCHEMA_VERSION = "STATUS-OVERLAY-V1" as const;
 export const STATUS_OVERLAY_DESIGN = "STATUS-OVERLAY-DESIGN-V1" as const;
 
-/** Runtime projection generator remains unimplemented in this design-only slice. */
-export const STATUS_OVERLAY_GENERATOR_IMPLEMENTED = false as const;
+/** Pure runtime projection generator is implemented (no observer/UI/writer). */
+export const STATUS_OVERLAY_GENERATOR_IMPLEMENTED = true as const;
 export const STATUS_OVERLAY_UI_IMPLEMENTED = false as const;
+/** Full product (observer + UI + emit) remains incomplete. */
 export const STATUS_OVERLAY_IMPLEMENTED = false as const;
 
 /** Stable status vocabulary — no synonyms. */
@@ -139,14 +140,19 @@ export interface SelectNextActionInput {
   historicalDraftOpen?: boolean;
 }
 
+/** UI / observer / writer / Gateway binding remain forbidden in this slice. */
+export function assertStatusOverlayUiNotImplemented(): void {
+  if (STATUS_OVERLAY_UI_IMPLEMENTED) {
+    throw new Error("STATUS-OVERLAY-V1 UI must remain NOT IMPLEMENTED");
+  }
+}
+
+/** @deprecated Use assertStatusOverlayUiNotImplemented — generator is now implemented. */
 export function assertStatusOverlayNotImplemented(): void {
-  if (
-    STATUS_OVERLAY_IMPLEMENTED ||
-    STATUS_OVERLAY_GENERATOR_IMPLEMENTED ||
-    STATUS_OVERLAY_UI_IMPLEMENTED
-  ) {
+  assertStatusOverlayUiNotImplemented();
+  if (STATUS_OVERLAY_IMPLEMENTED) {
     throw new Error(
-      "STATUS-OVERLAY-V1 runtime generator/UI must remain NOT IMPLEMENTED in design-only state",
+      "STATUS-OVERLAY-V1 full product (observer/UI/writer) must remain NOT IMPLEMENTED",
     );
   }
 }

--- a/src/domain/statusOverlayContract.ts
+++ b/src/domain/statusOverlayContract.ts
@@ -138,6 +138,11 @@ export interface SelectNextActionInput {
   openPullRequests?: StatusOverlayPullRequest[];
   /** Historical claim that a Draft is open — ignored when live PRs are supplied. */
   historicalDraftOpen?: boolean;
+  /**
+   * Resolved live REFRESH_DRAFT number (already validated). When set and present
+   * in openPullRequests as REFRESH_DRAFT, preferred for covered Draft review.
+   */
+  activeRefreshPr?: number | null;
 }
 
 /** UI / observer / writer / Gateway binding remain forbidden in this slice. */
@@ -330,7 +335,16 @@ export function selectRecommendedNextAction(
 
   const prs = input.openPullRequests ?? [];
   // Live open PRs only — historicalDraftOpen must not invent a current Draft.
-  const refreshDraft = pickActiveRefreshDraft(prs);
+  const preferredRefresh =
+    input.activeRefreshPr != null
+      ? prs.find(
+          (p) =>
+            p.number === input.activeRefreshPr &&
+            p.draft &&
+            p.classification === "REFRESH_DRAFT",
+        ) ?? null
+      : null;
+  const refreshDraft = preferredRefresh ?? pickActiveRefreshDraft(prs);
   const draft = pickPrimaryPr(prs.filter((p) => p.draft));
   const ready = pickPrimaryPr(prs.filter((p) => !p.draft));
   const coverage = input.autoRefreshCoverage ?? "UNKNOWN";

--- a/src/domain/statusOverlayGenerator.ts
+++ b/src/domain/statusOverlayGenerator.ts
@@ -46,8 +46,11 @@ export interface StatusOverlayGeneratorInput {
     lastEvaluation?: string | null;
     lastPublicationOutcome?: string | null;
     /**
-     * Optional override. When omitted, derived from the lowest-number live
-     * open Draft with classification REFRESH_DRAFT.
+     * Optional override. Counts only when that exact live open PR is
+     * `draft === true` and `classification === "REFRESH_DRAFT"`.
+     * Invalid/stale overrides are rejected; generator falls back to the
+     * lowest-number live REFRESH_DRAFT (or null) so coverage fields stay
+     * consistent.
      */
     activeRefreshPr?: number | null;
   };
@@ -89,15 +92,52 @@ function normalizePullRequest(pr: StatusOverlayPullRequest): StatusOverlayPullRe
   };
 }
 
-function deriveActiveRefreshPr(
+function isLiveRefreshDraft(
   prs: readonly StatusOverlayPullRequest[],
-  override: number | null | undefined,
+  prNumber: number | null,
+): boolean {
+  if (prNumber == null) return false;
+  return prs.some(
+    (p) => p.number === prNumber && p.draft && p.classification === "REFRESH_DRAFT",
+  );
+}
+
+function lowestLiveRefreshDraftNumber(
+  prs: readonly StatusOverlayPullRequest[],
 ): number | null {
-  if (override !== undefined) return override;
   const refreshDrafts = prs
     .filter((p) => p.draft && p.classification === "REFRESH_DRAFT")
     .sort((a, b) => a.number - b.number);
   return refreshDrafts[0]?.number ?? null;
+}
+
+/**
+ * Resolve activeRefreshPr from live evidence.
+ *
+ * Rules:
+ * - omitted override → lowest-number live REFRESH_DRAFT (or null)
+ * - override === null → null (explicit none)
+ * - override number valid only if that exact live PR is draft + REFRESH_DRAFT
+ * - invalid/stale override → ignored; fall back to live-derived REFRESH_DRAFT
+ *   (documented fail-closed consistency: never emit contradictory activeRefreshPr)
+ */
+export function resolveActiveRefreshPr(input: {
+  openPullRequests: readonly StatusOverlayPullRequest[];
+  override?: number | null;
+}): { activeRefreshPr: number | null; overrideRejected: boolean } {
+  const liveDerived = lowestLiveRefreshDraftNumber(input.openPullRequests);
+
+  if (input.override === undefined) {
+    return { activeRefreshPr: liveDerived, overrideRejected: false };
+  }
+  if (input.override === null) {
+    return { activeRefreshPr: null, overrideRejected: false };
+  }
+  if (isLiveRefreshDraft(input.openPullRequests, input.override)) {
+    return { activeRefreshPr: input.override, overrideRejected: false };
+  }
+  // Invalid override must not stick; fall back to live-derived state.
+  return { activeRefreshPr: liveDerived, overrideRejected: true };
 }
 
 function deriveCoverage(input: {
@@ -107,22 +147,21 @@ function deriveCoverage(input: {
   liveObservationFailed: boolean;
   openPullRequests: StatusOverlayPullRequest[];
 }): AutoRefreshCoverage {
+  // Only the resolved activeRefreshPr that matches a live REFRESH_DRAFT covers.
+  const coveredByMatchedDraft = isLiveRefreshDraft(
+    input.openPullRequests,
+    input.activeRefreshPr,
+  );
   const base = classifyAutoRefreshCoverage({
     architectureAffectingStale: input.architectureAffectingStale,
     autoRefreshEnabled: input.autoRefreshEnabled,
-    activeRefreshPr: input.activeRefreshPr,
+    activeRefreshPr: coveredByMatchedDraft ? input.activeRefreshPr : null,
     livePrObservationFailed: input.liveObservationFailed,
   });
-  // COVERED_BY_DRAFT only when a live REFRESH_DRAFT exists.
-  if (base === "COVERED_BY_DRAFT") {
-    const hasRefreshDraft = input.openPullRequests.some(
-      (p) => p.draft && p.classification === "REFRESH_DRAFT",
-    );
-    if (!hasRefreshDraft) {
-      return input.autoRefreshEnabled
-        ? "COVERED_BY_ENABLED_AUTOMATION_IDLE"
-        : "NOT_COVERED";
-    }
+  if (base === "COVERED_BY_DRAFT" && !coveredByMatchedDraft) {
+    return input.autoRefreshEnabled
+      ? "COVERED_BY_ENABLED_AUTOMATION_IDLE"
+      : "NOT_COVERED";
   }
   return base;
 }
@@ -170,10 +209,10 @@ export function generateStatusOverlay(
 
   const architectureAffectingStale = isArchitectureAffectingStale(input);
   const liveObservationFailed = input.liveObservationFailed === true;
-  const activeRefreshPr = deriveActiveRefreshPr(
+  const { activeRefreshPr, overrideRejected } = resolveActiveRefreshPr({
     openPullRequests,
-    input.autoRefresh.activeRefreshPr,
-  );
+    override: input.autoRefresh.activeRefreshPr,
+  });
   const autoRefreshCoverage = deriveCoverage({
     architectureAffectingStale,
     autoRefreshEnabled: input.autoRefresh.enabled,
@@ -194,6 +233,7 @@ export function generateStatusOverlay(
     autoRefreshCoverage,
     openPullRequests,
     historicalDraftOpen: input.historicalDraftOpen === true,
+    activeRefreshPr,
   };
 
   const recommendedNextAction = selectRecommendedNextAction(decisionInput);
@@ -208,6 +248,9 @@ export function generateStatusOverlay(
   const unknowns = [...(input.unknowns ?? [])];
   if (liveObservationFailed && !unknowns.includes("live_observation_failed")) {
     unknowns.push("live_observation_failed");
+  }
+  if (overrideRejected && !unknowns.includes("activeRefreshPr_override_rejected")) {
+    unknowns.push("activeRefreshPr_override_rejected");
   }
   for (const pr of openPullRequests) {
     if (pr.ciState === "UNKNOWN") {

--- a/src/domain/statusOverlayGenerator.ts
+++ b/src/domain/statusOverlayGenerator.ts
@@ -1,0 +1,263 @@
+/**
+ * STATUS-OVERLAY-V1 runtime generator.
+ *
+ * Pure projection: explicit observed inputs → StatusOverlayDocument.
+ * Does not call network/APIs, read env/secrets, touch the filesystem, or
+ * manufacture observation timestamps.
+ */
+
+import {
+  STATUS_OVERLAY_GENERATOR_IMPLEMENTED,
+  STATUS_OVERLAY_SCHEMA_VERSION,
+  classifyAutoRefreshCoverage,
+  classifyOverlayGateKind,
+  normalizeCiState,
+  projectHistoryForOverlay,
+  resolveLivePrStateOverHistory,
+  selectRecommendedNextAction,
+  type AutoRefreshCoverage,
+  type StatusOverlayDocument,
+  type StatusOverlayGateKind,
+  type StatusOverlayPullRequest,
+} from "./statusOverlayContract";
+
+export { STATUS_OVERLAY_GENERATOR_IMPLEMENTED };
+
+export interface StatusOverlayGeneratorInput {
+  repository: string;
+  /** Caller-supplied observation time — preserved exactly; never replaced. */
+  observedAt: string;
+  currentMain: string | null;
+  snapshot: {
+    generatedFrom: string | null;
+    stale: boolean | null;
+    staleClassification: string | null;
+    architectureRelevantChanges?: string[];
+  };
+  handoff: {
+    nextActionStatus: "NO_ACTION" | "ACTION_REQUIRED" | "UNKNOWN" | null;
+    staleClassification?: string | null;
+  };
+  autoRefresh: {
+    enabled: boolean;
+    trigger?: string | null;
+    lastRunId?: string | null;
+    lastRunConclusion?: string | null;
+    lastEvaluation?: string | null;
+    lastPublicationOutcome?: string | null;
+    /**
+     * Optional override. When omitted, derived from the lowest-number live
+     * open Draft with classification REFRESH_DRAFT.
+     */
+    activeRefreshPr?: number | null;
+  };
+  openPullRequests?: StatusOverlayPullRequest[];
+  holds?: string[];
+  unknowns?: string[];
+  liveObservationFailed?: boolean;
+  outcomeUnknown?: boolean;
+  safetyHold?: boolean;
+  holdReason?: string | null;
+  automationFailed?: boolean;
+  /** Historical claim only — never overrides live openPullRequests. */
+  historicalDraftOpen?: boolean;
+  historyWriter?: {
+    writerImplemented?: boolean;
+    lastEvent?: string | null;
+    lastConvergedAt?: string | null;
+    refreshLifecycleSummary?: string | null;
+  };
+}
+
+function isArchitectureAffectingStale(input: StatusOverlayGeneratorInput): boolean {
+  const classification =
+    input.snapshot.staleClassification ?? input.handoff.staleClassification ?? null;
+  if (classification === "stale_architecture_affecting") return true;
+  if (classification === "stale_no_architecture_impact" || classification === "current") {
+    return false;
+  }
+  const changes = input.snapshot.architectureRelevantChanges ?? [];
+  return input.snapshot.stale === true && changes.length > 0;
+}
+
+function normalizePullRequest(pr: StatusOverlayPullRequest): StatusOverlayPullRequest {
+  return {
+    ...pr,
+    mergeable: pr.mergeable === true || pr.mergeable === false ? pr.mergeable : "UNKNOWN",
+    reviewState: normalizeCiState(pr.reviewState),
+    ciState: normalizeCiState(pr.ciState),
+  };
+}
+
+function deriveActiveRefreshPr(
+  prs: readonly StatusOverlayPullRequest[],
+  override: number | null | undefined,
+): number | null {
+  if (override !== undefined) return override;
+  const refreshDrafts = prs
+    .filter((p) => p.draft && p.classification === "REFRESH_DRAFT")
+    .sort((a, b) => a.number - b.number);
+  return refreshDrafts[0]?.number ?? null;
+}
+
+function deriveCoverage(input: {
+  architectureAffectingStale: boolean;
+  autoRefreshEnabled: boolean;
+  activeRefreshPr: number | null;
+  liveObservationFailed: boolean;
+  openPullRequests: StatusOverlayPullRequest[];
+}): AutoRefreshCoverage {
+  const base = classifyAutoRefreshCoverage({
+    architectureAffectingStale: input.architectureAffectingStale,
+    autoRefreshEnabled: input.autoRefreshEnabled,
+    activeRefreshPr: input.activeRefreshPr,
+    livePrObservationFailed: input.liveObservationFailed,
+  });
+  // COVERED_BY_DRAFT only when a live REFRESH_DRAFT exists.
+  if (base === "COVERED_BY_DRAFT") {
+    const hasRefreshDraft = input.openPullRequests.some(
+      (p) => p.draft && p.classification === "REFRESH_DRAFT",
+    );
+    if (!hasRefreshDraft) {
+      return input.autoRefreshEnabled
+        ? "COVERED_BY_ENABLED_AUTOMATION_IDLE"
+        : "NOT_COVERED";
+    }
+  }
+  return base;
+}
+
+function buildHumanGates(input: {
+  gateKind: StatusOverlayGateKind;
+  recommendedSummary: string;
+  handoffActionRequired: boolean;
+  architectureAffectingStale: boolean;
+  openPullRequests: StatusOverlayPullRequest[];
+}): Array<{ kind: StatusOverlayGateKind; summary: string }> {
+  const gates: Array<{ kind: StatusOverlayGateKind; summary: string }> = [
+    { kind: input.gateKind, summary: input.recommendedSummary },
+  ];
+  if (input.handoffActionRequired && input.gateKind !== "HumanActionRequired") {
+    gates.push({
+      kind: "HumanActionRequired",
+      summary: "HANDOFF nextAction is ACTION_REQUIRED",
+    });
+  }
+  return gates;
+}
+
+/**
+ * Build a JSON-serializable STATUS-OVERLAY document from explicit observations.
+ * Deterministic for identical inputs. Does not invent timestamps.
+ */
+export function generateStatusOverlay(
+  input: StatusOverlayGeneratorInput,
+): StatusOverlayDocument {
+  const openPullRequests = [...(input.openPullRequests ?? [])]
+    .map(normalizePullRequest)
+    .sort((a, b) => a.number - b.number);
+
+  // Live open PRs win; historicalDraftOpen is context only.
+  void resolveLivePrStateOverHistory({
+    historicalState: input.historicalDraftOpen ? "OPEN_DRAFT" : "MISSING",
+    liveState:
+      openPullRequests.length === 0
+        ? "MISSING"
+        : openPullRequests.some((p) => p.draft)
+          ? "OPEN_DRAFT"
+          : "OPEN_READY",
+  });
+
+  const architectureAffectingStale = isArchitectureAffectingStale(input);
+  const liveObservationFailed = input.liveObservationFailed === true;
+  const activeRefreshPr = deriveActiveRefreshPr(
+    openPullRequests,
+    input.autoRefresh.activeRefreshPr,
+  );
+  const autoRefreshCoverage = deriveCoverage({
+    architectureAffectingStale,
+    autoRefreshEnabled: input.autoRefresh.enabled,
+    activeRefreshPr,
+    liveObservationFailed,
+    openPullRequests,
+  });
+
+  const handoffActionRequired = input.handoff.nextActionStatus === "ACTION_REQUIRED";
+  const decisionInput = {
+    liveObservationFailed,
+    outcomeUnknown: input.outcomeUnknown === true,
+    safetyHold: input.safetyHold === true,
+    holdReason: input.holdReason ?? null,
+    handoffActionRequired,
+    automationFailed: input.automationFailed === true,
+    architectureAffectingStale,
+    autoRefreshCoverage,
+    openPullRequests,
+    historicalDraftOpen: input.historicalDraftOpen === true,
+  };
+
+  const recommendedNextAction = selectRecommendedNextAction(decisionInput);
+  const gateKind = classifyOverlayGateKind(decisionInput);
+  const history = projectHistoryForOverlay(input.historyWriter);
+
+  const holds = [...(input.holds ?? [])];
+  if (input.safetyHold && input.holdReason && !holds.includes(input.holdReason)) {
+    holds.push(input.holdReason);
+  }
+
+  const unknowns = [...(input.unknowns ?? [])];
+  if (liveObservationFailed && !unknowns.includes("live_observation_failed")) {
+    unknowns.push("live_observation_failed");
+  }
+  for (const pr of openPullRequests) {
+    if (pr.ciState === "UNKNOWN") {
+      const key = `pr_${pr.number}_ciState_UNKNOWN`;
+      if (!unknowns.includes(key)) unknowns.push(key);
+    }
+    if (pr.reviewState === "UNKNOWN") {
+      const key = `pr_${pr.number}_reviewState_UNKNOWN`;
+      if (!unknowns.includes(key)) unknowns.push(key);
+    }
+  }
+
+  return {
+    schemaVersion: STATUS_OVERLAY_SCHEMA_VERSION,
+    repository: input.repository,
+    observedAt: input.observedAt,
+    main: { sha: input.currentMain },
+    snapshot: {
+      generatedFrom: input.snapshot.generatedFrom,
+      currentMain: input.currentMain,
+      stale: input.snapshot.stale,
+      staleClassification: input.snapshot.staleClassification,
+      architectureRelevantChanges: [...(input.snapshot.architectureRelevantChanges ?? [])],
+      autoRefreshCoverage,
+    },
+    handoff: {
+      nextActionStatus: input.handoff.nextActionStatus,
+      staleClassification:
+        input.handoff.staleClassification ?? input.snapshot.staleClassification,
+    },
+    autoRefresh: {
+      enabled: input.autoRefresh.enabled,
+      trigger: input.autoRefresh.trigger ?? null,
+      lastRunId: input.autoRefresh.lastRunId ?? null,
+      lastRunConclusion: input.autoRefresh.lastRunConclusion ?? null,
+      lastEvaluation: input.autoRefresh.lastEvaluation ?? null,
+      lastPublicationOutcome: input.autoRefresh.lastPublicationOutcome ?? null,
+      activeRefreshPr,
+    },
+    history,
+    pullRequests: openPullRequests,
+    humanGates: buildHumanGates({
+      gateKind,
+      recommendedSummary: recommendedNextAction.summary,
+      handoffActionRequired,
+      architectureAffectingStale,
+      openPullRequests,
+    }),
+    holds,
+    unknowns,
+    recommendedNextAction,
+  };
+}

--- a/test/statusOverlayContract.test.ts
+++ b/test/statusOverlayContract.test.ts
@@ -50,11 +50,11 @@ function readyPr(n: number): StatusOverlayPullRequest {
 }
 
 describe("STATUS-OVERLAY-V1 design contract", () => {
-  it("remains DESIGNED with no runtime generator or UI", () => {
+  it("marks runtime generator implemented while UI/full product stay off", () => {
     expect(STATUS_OVERLAY_SCHEMA_VERSION).toBe("STATUS-OVERLAY-V1");
-    expect(STATUS_OVERLAY_IMPLEMENTED).toBe(false);
-    expect(STATUS_OVERLAY_GENERATOR_IMPLEMENTED).toBe(false);
+    expect(STATUS_OVERLAY_GENERATOR_IMPLEMENTED).toBe(true);
     expect(STATUS_OVERLAY_UI_IMPLEMENTED).toBe(false);
+    expect(STATUS_OVERLAY_IMPLEMENTED).toBe(false);
     expect(() => assertStatusOverlayNotImplemented()).not.toThrow();
     expect(proposedStatusOverlayStoragePath()).toBe("docs/status/status-overlay.json");
     expect(STATUS_OVERLAY_MARKDOWN_SECTIONS).toEqual([

--- a/test/statusOverlayGenerator.test.ts
+++ b/test/statusOverlayGenerator.test.ts
@@ -1,0 +1,310 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  STATUS_OVERLAY_GENERATOR_IMPLEMENTED,
+  STATUS_OVERLAY_SCHEMA_VERSION,
+  STATUS_OVERLAY_UI_IMPLEMENTED,
+  type StatusOverlayPullRequest,
+} from "../src/domain/statusOverlayContract";
+import {
+  generateStatusOverlay,
+  type StatusOverlayGeneratorInput,
+} from "../src/domain/statusOverlayGenerator";
+
+const repo = "yasutakesougo/ai-development-control-center";
+const observedAt = "2026-08-12T04:40:00.000Z";
+const main = "752691defeb09508137c3db9238bf9260c07dbc6";
+const from = "78a72b13965d7b4fc4ce021d0aaa08a40eb17aa0";
+
+function baseInput(
+  partial: Partial<StatusOverlayGeneratorInput> = {},
+): StatusOverlayGeneratorInput {
+  return {
+    repository: repo,
+    observedAt,
+    currentMain: main,
+    snapshot: {
+      generatedFrom: from,
+      stale: false,
+      staleClassification: "current",
+      architectureRelevantChanges: [],
+    },
+    handoff: {
+      nextActionStatus: "NO_ACTION",
+      staleClassification: "current",
+    },
+    autoRefresh: {
+      enabled: true,
+      trigger: "push_main+workflow_dispatch",
+      lastRunId: "31562991156",
+      lastRunConclusion: "success",
+      lastEvaluation: "NOT_REQUIRED",
+      lastPublicationOutcome: "NO_PUBLICATION",
+    },
+    openPullRequests: [],
+    ...partial,
+  };
+}
+
+function designDraft(n: number): StatusOverlayPullRequest {
+  return {
+    number: n,
+    title: "docs(status): design",
+    draft: true,
+    mergeable: "UNKNOWN",
+    head: "aaa",
+    base: "main",
+    reviewState: "UNKNOWN",
+    ciState: "UNKNOWN",
+    classification: "DESIGN",
+    humanAction: "REVIEW_DRAFT",
+  };
+}
+
+function refreshDraft(n: number): StatusOverlayPullRequest {
+  return {
+    number: n,
+    title: "docs(architecture): refresh Snapshot",
+    draft: true,
+    mergeable: "UNKNOWN",
+    head: "bbb",
+    base: "main",
+    reviewState: "UNKNOWN",
+    ciState: "UNKNOWN",
+    classification: "REFRESH_DRAFT",
+    humanAction: "REVIEW_DRAFT",
+  };
+}
+
+function readyPr(n: number): StatusOverlayPullRequest {
+  return {
+    number: n,
+    title: "ready",
+    draft: false,
+    mergeable: true,
+    head: "ccc",
+    base: "main",
+    reviewState: "UNKNOWN",
+    ciState: "UNKNOWN",
+    classification: "OTHER",
+    humanAction: "DECIDE_MERGE",
+  };
+}
+
+describe("STATUS-OVERLAY-V1 runtime generator", () => {
+  it("marks generator implemented and UI not implemented", () => {
+    expect(STATUS_OVERLAY_GENERATOR_IMPLEMENTED).toBe(true);
+    expect(STATUS_OVERLAY_UI_IMPLEMENTED).toBe(false);
+  });
+
+  it("produces a deterministic full document for identical inputs", () => {
+    const input = baseInput({
+      openPullRequests: [readyPr(32), designDraft(30)],
+    });
+    const a = generateStatusOverlay(input);
+    const b = generateStatusOverlay(input);
+    expect(a).toEqual(b);
+    expect(JSON.parse(JSON.stringify(a))).toEqual(a);
+    expect(a.schemaVersion).toBe(STATUS_OVERLAY_SCHEMA_VERSION);
+    expect(a.pullRequests.map((p) => p.number)).toEqual([30, 32]);
+  });
+
+  it("preserves caller-supplied observedAt exactly", () => {
+    const custom = "2026-01-02T03:04:05.678Z";
+    const doc = generateStatusOverlay(baseInput({ observedAt: custom }));
+    expect(doc.observedAt).toBe(custom);
+  });
+
+  it("current / no-action projection", () => {
+    const doc = generateStatusOverlay(baseInput());
+    expect(doc.recommendedNextAction.code).toBe("NO_ACTION");
+    expect(doc.recommendedNextAction.gateKind).toBe("NoAction");
+    expect(doc.snapshot.autoRefreshCoverage).toBe("COVERED_BY_ENABLED_AUTOMATION_IDLE");
+    expect(doc.history.status).toBe("DESIGNED_NOT_IMPLEMENTED");
+  });
+
+  it("Draft review projection", () => {
+    const doc = generateStatusOverlay(
+      baseInput({ openPullRequests: [designDraft(41), designDraft(40)] }),
+    );
+    expect(doc.recommendedNextAction.code).toBe("REVIEW_DRAFT_PR");
+    expect(doc.recommendedNextAction.targets?.pullRequest).toBe(40);
+    expect(doc.recommendedNextAction.gateKind).toBe("HumanActionRequired");
+  });
+
+  it("Ready merge-decision projection", () => {
+    const doc = generateStatusOverlay(baseInput({ openPullRequests: [readyPr(55)] }));
+    expect(doc.recommendedNextAction.code).toBe("DECIDE_MERGE_READY_PR");
+    expect(doc.recommendedNextAction.status).toBe("READY");
+    expect(doc.recommendedNextAction.targets?.pullRequest).toBe(55);
+  });
+
+  it("uncovered architecture stale + unrelated DESIGN Draft → maintenance", () => {
+    const doc = generateStatusOverlay(
+      baseInput({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        handoff: {
+          nextActionStatus: "NO_ACTION",
+          staleClassification: "stale_architecture_affecting",
+        },
+        autoRefresh: {
+          enabled: false,
+          trigger: null,
+        },
+        openPullRequests: [designDraft(30)],
+        historicalDraftOpen: true,
+      }),
+    );
+    expect(doc.recommendedNextAction.code).toBe("MAINTAIN_STALE_SNAPSHOT");
+    expect(doc.recommendedNextAction.gateKind).toBe("SystemMaintenanceRequired");
+    expect(doc.snapshot.autoRefreshCoverage).toBe("NOT_COVERED");
+    expect(doc.autoRefresh.activeRefreshPr).toBeNull();
+  });
+
+  it("covered stale + live REFRESH_DRAFT → review Draft (not duplicate refresh)", () => {
+    const doc = generateStatusOverlay(
+      baseInput({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        handoff: {
+          nextActionStatus: "NO_ACTION",
+          staleClassification: "stale_architecture_affecting",
+        },
+        autoRefresh: {
+          enabled: true,
+          trigger: "push_main+workflow_dispatch",
+          lastEvaluation: "ELIGIBLE",
+          lastPublicationOutcome: "DRAFT_CREATED",
+        },
+        openPullRequests: [designDraft(30), refreshDraft(44)],
+      }),
+    );
+    expect(doc.snapshot.autoRefreshCoverage).toBe("COVERED_BY_DRAFT");
+    expect(doc.autoRefresh.activeRefreshPr).toBe(44);
+    expect(doc.recommendedNextAction.code).toBe("REVIEW_DRAFT_PR");
+    expect(doc.recommendedNextAction.targets?.pullRequest).toBe(44);
+    expect(
+      doc.recommendedNextAction.secondaryContext?.some((s) => s.includes("duplicate refresh")),
+    ).toBe(true);
+  });
+
+  it("OUTCOME_UNKNOWN priority", () => {
+    const doc = generateStatusOverlay(
+      baseInput({
+        outcomeUnknown: true,
+        openPullRequests: [refreshDraft(10), readyPr(11)],
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        autoRefresh: { enabled: false },
+      }),
+    );
+    expect(doc.recommendedNextAction.code).toBe("RESOLVE_OUTCOME_UNKNOWN");
+  });
+
+  it("safety HOLD priority", () => {
+    const doc = generateStatusOverlay(
+      baseInput({
+        safetyHold: true,
+        holdReason: "token scope HOLD",
+        openPullRequests: [refreshDraft(12)],
+      }),
+    );
+    expect(doc.recommendedNextAction.code).toBe("RESOLVE_HOLD");
+    expect(doc.holds).toContain("token scope HOLD");
+  });
+
+  it("UNKNOWN / live-observation failure", () => {
+    const doc = generateStatusOverlay(
+      baseInput({
+        liveObservationFailed: true,
+        openPullRequests: [readyPr(13)],
+      }),
+    );
+    expect(doc.recommendedNextAction.code).toBe("UNKNOWN");
+    expect(doc.recommendedNextAction.gateKind).toBe("Unknown");
+    expect(doc.snapshot.autoRefreshCoverage).toBe("UNKNOWN");
+    expect(doc.unknowns).toContain("live_observation_failed");
+  });
+
+  it("HISTORY writer absent projects DESIGNED_NOT_IMPLEMENTED", () => {
+    const doc = generateStatusOverlay(baseInput());
+    expect(doc.history).toEqual({
+      status: "DESIGNED_NOT_IMPLEMENTED",
+      writerImplemented: false,
+      lastEvent: null,
+      lastConvergedAt: null,
+      refreshLifecycleSummary: null,
+    });
+  });
+
+  it("authorizesMutation is always false", () => {
+    const cases = [
+      baseInput(),
+      baseInput({ openPullRequests: [designDraft(1)] }),
+      baseInput({ openPullRequests: [readyPr(2)] }),
+      baseInput({ outcomeUnknown: true }),
+      baseInput({
+        safetyHold: true,
+        holdReason: "hold",
+      }),
+      baseInput({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        autoRefresh: { enabled: false },
+        openPullRequests: [designDraft(3)],
+      }),
+    ];
+    for (const input of cases) {
+      expect(generateStatusOverlay(input).recommendedNextAction.authorizesMutation).toBe(false);
+    }
+  });
+
+  it("does not invent PASS for missing CI/review evidence", () => {
+    const doc = generateStatusOverlay(
+      baseInput({
+        openPullRequests: [
+          {
+            ...designDraft(9),
+            ciState: "",
+            reviewState: undefined as unknown as string,
+          },
+        ],
+      }),
+    );
+    expect(doc.pullRequests[0].ciState).toBe("UNKNOWN");
+    expect(doc.pullRequests[0].reviewState).toBe("UNKNOWN");
+    expect(doc.unknowns).toContain("pr_9_ciState_UNKNOWN");
+    expect(doc.unknowns).toContain("pr_9_reviewState_UNKNOWN");
+  });
+
+  it("generator module has no network/filesystem/Date side-effect calls", () => {
+    const source = readFileSync(
+      new URL("../src/domain/statusOverlayGenerator.ts", import.meta.url),
+      "utf8",
+    );
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+    expect(source).not.toMatch(/\bDate\.now\s*\(/);
+    expect(source).not.toMatch(/new\s+Date\s*\(/);
+    expect(source).not.toMatch(/from ["']node:fs["']/);
+    expect(source).not.toMatch(/from ["']fs["']/);
+    expect(source).not.toMatch(/process\.env/);
+    expect(source).not.toMatch(/@octokit|octokit/);
+  });
+});

--- a/test/statusOverlayGenerator.test.ts
+++ b/test/statusOverlayGenerator.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/domain/statusOverlayContract";
 import {
   generateStatusOverlay,
+  resolveActiveRefreshPr,
   type StatusOverlayGeneratorInput,
 } from "../src/domain/statusOverlayGenerator";
 
@@ -306,5 +307,88 @@ describe("STATUS-OVERLAY-V1 runtime generator", () => {
     expect(source).not.toMatch(/from ["']fs["']/);
     expect(source).not.toMatch(/process\.env/);
     expect(source).not.toMatch(/@octokit|octokit/);
+  });
+
+  it("rejects nonexistent activeRefreshPr override and falls back to live REFRESH_DRAFT", () => {
+    const prs = [refreshDraft(44)];
+    expect(
+      resolveActiveRefreshPr({ openPullRequests: prs, override: 999 }),
+    ).toEqual({ activeRefreshPr: 44, overrideRejected: true });
+
+    const doc = generateStatusOverlay(
+      baseInput({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        autoRefresh: {
+          enabled: true,
+          activeRefreshPr: 999,
+        },
+        openPullRequests: prs,
+      }),
+    );
+    expect(doc.autoRefresh.activeRefreshPr).toBe(44);
+    expect(doc.snapshot.autoRefreshCoverage).toBe("COVERED_BY_DRAFT");
+    expect(doc.recommendedNextAction.code).toBe("REVIEW_DRAFT_PR");
+    expect(doc.recommendedNextAction.targets?.pullRequest).toBe(44);
+    expect(doc.unknowns).toContain("activeRefreshPr_override_rejected");
+  });
+
+  it("rejects DESIGN/OTHER Draft override while live REFRESH_DRAFT exists", () => {
+    const prs = [designDraft(30), refreshDraft(44)];
+    expect(
+      resolveActiveRefreshPr({ openPullRequests: prs, override: 30 }),
+    ).toEqual({ activeRefreshPr: 44, overrideRejected: true });
+
+    const doc = generateStatusOverlay(
+      baseInput({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        autoRefresh: {
+          enabled: true,
+          activeRefreshPr: 30,
+        },
+        openPullRequests: prs,
+      }),
+    );
+    expect(doc.autoRefresh.activeRefreshPr).toBe(44);
+    expect(doc.snapshot.autoRefreshCoverage).toBe("COVERED_BY_DRAFT");
+    expect(doc.recommendedNextAction.targets?.pullRequest).toBe(44);
+    expect(doc.unknowns).toContain("activeRefreshPr_override_rejected");
+  });
+
+  it("accepts valid activeRefreshPr override pointing to live REFRESH_DRAFT", () => {
+    const prs = [refreshDraft(44), refreshDraft(50)];
+    expect(
+      resolveActiveRefreshPr({ openPullRequests: prs, override: 50 }),
+    ).toEqual({ activeRefreshPr: 50, overrideRejected: false });
+
+    const doc = generateStatusOverlay(
+      baseInput({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        autoRefresh: {
+          enabled: true,
+          activeRefreshPr: 50,
+        },
+        openPullRequests: prs,
+      }),
+    );
+    expect(doc.autoRefresh.activeRefreshPr).toBe(50);
+    expect(doc.snapshot.autoRefreshCoverage).toBe("COVERED_BY_DRAFT");
+    expect(doc.recommendedNextAction.code).toBe("REVIEW_DRAFT_PR");
+    expect(doc.recommendedNextAction.targets?.pullRequest).toBe(50);
+    expect(doc.unknowns).not.toContain("activeRefreshPr_override_rejected");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the pure **STATUS-OVERLAY-V1 Runtime Generator** authorized by Issue #31.

`generateStatusOverlay(input) → StatusOverlayDocument`

Closes #31

---

## P2 follow-up (Fresh Review)

Fixed `activeRefreshPr` override validation:

- Override counts only when that exact live PR is `draft === true` and `classification === "REFRESH_DRAFT"`
- Invalid/stale override → rejected; fall back to lowest-number live `REFRESH_DRAFT` (or null)
- Coverage / `activeRefreshPr` / next-action targets stay consistent
- Rejected override recorded as unknown `activeRefreshPr_override_rejected`

Regression tests added for nonexistent override, DESIGN override, and valid override.

---

## Baseline

| Item | Value |
|---|---|
| Expected main | `752691defeb09508137c3db9238bf9260c07dbc6` |
| Observed main before implementation | `752691defeb09508137c3db9238bf9260c07dbc6` (MATCH) |
| Branch | `cursor/status-overlay-runtime-2c83` |

---

## Changed files

- `src/domain/statusOverlayGenerator.ts`
- `src/domain/statusOverlayContract.ts`
- `test/statusOverlayGenerator.test.ts`
- `test/statusOverlayContract.test.ts`
- `docs/status/status-overlay-v1.md` (+ architecture/handoff pointers)

---

## Verification

```
npm run verify
→ typecheck PASS
→ 242 tests PASS (20 files)
→ build PASS
```

---

## Explicit non-goals (still NOT IMPLEMENTED)

| Item | Status |
|---|---|
| UI | NOT IMPLEMENTED |
| GitHub / workflow observer | NOT IMPLEMENTED |
| Repository-file writer | NOT IMPLEMENTED |
| Action Gateway | NOT IMPLEMENTED |
| Approval Ledger write | NOT IMPLEMENTED |
| Agent execution | NOT IMPLEMENTED |

**Stop at Draft.** Fresh Review on new HEAD. Do not mark Ready. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff3bd-613c-7d0a-b59d-d9615a722c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff3bd-613c-7d0a-b59d-d9615a722c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

