### PR TITLE
feat(status): add STATUS-OVERLAY-V1 read-only GitHub observer

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,7 +29,7 @@ HISTORY-V1 is **designed** (append-only Snapshot/refresh audit) and **not
 implemented** — see [`../history/history-v1.md`](../history/history-v1.md).
 No persistence writer is enabled.
 
-STATUS-OVERLAY-V1 is **designed**; pure Runtime Generator is **implemented**
-(`src/domain/statusOverlayGenerator.ts`) — see
+STATUS-OVERLAY-V1 is **designed**; Runtime Generator and read-only GitHub /
+workflow observer are **implemented** — see
 [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
-UI / observer / Action Gateway binding remain not implemented.
+UI / repository writer / Action Gateway binding remain not implemented.

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -76,11 +76,11 @@ implemented** — see [`../history/history-v1.md`](../history/history-v1.md).
 Historical events must not change HANDOFF decision semantics or manufacture
 `ACTION_REQUIRED`.
 
-STATUS-OVERLAY-V1 (current-state projection) is **designed**; pure Runtime
-Generator is **implemented** — see
+STATUS-OVERLAY-V1 (current-state projection) is **designed**; Runtime Generator
+and read-only GitHub/workflow observer are **implemented** — see
 [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
 Overlay consumes HANDOFF output and must not redefine HANDOFF rules.
-UI / observer remain not implemented.
+UI / repository writer remain not implemented.
 
 ## Next action
 

--- a/docs/status/status-overlay-v1.md
+++ b/docs/status/status-overlay-v1.md
@@ -1,6 +1,6 @@
 # STATUS-OVERLAY-V1
 
-**Status: DESIGNED · runtime generator IMPLEMENTED · UI NOT IMPLEMENTED**
+**Status: DESIGNED · runtime generator IMPLEMENTED · GitHub/workflow observer IMPLEMENTED · UI NOT IMPLEMENTED**
 
 This document designs **STATUS-OVERLAY-V1**: a replaceable **current-state
 projection** that answers:
@@ -15,12 +15,21 @@ Companion modules:
 
 - Contract helpers: `src/domain/statusOverlayContract.ts`
 - Runtime generator (pure): `src/domain/statusOverlayGenerator.ts`
+- Read-only observer: `src/observer/statusOverlayGithubObserver.ts`
 
 STATUS-OVERLAY is **decision-support only**. It does **not** authorize
 mutation, Ready, Merge, Action Gateway, Agent execution, or Ledger writes.
 
-Observation remains separate: callers supply explicit observed inputs. No
-GitHub observer, repository-file writer, or UI is implemented in this slice.
+Observation flow:
+
+```
+read-only GitHub/workflow observer
+  → explicit StatusOverlayGeneratorInput
+  → generateStatusOverlay()
+  → StatusOverlayDocument
+```
+
+No repository-file writer / HISTORY writer / UI in this slice.
 
 ---
 
@@ -385,8 +394,9 @@ No decorative metric strips. Markdown/HTML renderer is **NOT IMPLEMENTED**.
 |---|---|
 | STATUS-OVERLAY-V1 | **DESIGNED** |
 | Runtime generator | **IMPLEMENTED** (`statusOverlayGenerator.ts`) |
-| GitHub / workflow observer | **NOT IMPLEMENTED** |
+| GitHub / workflow observer | **IMPLEMENTED** (`statusOverlayGithubObserver.ts`, read-only) |
 | Repository-file writer | **NOT IMPLEMENTED** |
+| HISTORY writer | **NOT IMPLEMENTED** |
 | UI | **NOT IMPLEMENTED** |
 | Action Gateway binding | **NOT IMPLEMENTED** |
 | Approval Ledger / Agent execution | **NOT IMPLEMENTED** |

--- a/src/domain/statusOverlayContract.ts
+++ b/src/domain/statusOverlayContract.ts
@@ -126,6 +126,11 @@ export interface StatusOverlayDocument {
 export interface SelectNextActionInput {
   /** Live evidence incomplete for a required decision. */
   liveObservationFailed?: boolean;
+  /**
+   * Workflow/Actions observation could not be read.
+   * This is observation UNKNOWN — not automation OUTCOME_UNKNOWN.
+   */
+  workflowObservationFailed?: boolean;
   outcomeUnknown?: boolean;
   safetyHold?: boolean;
   holdReason?: string | null;
@@ -245,6 +250,7 @@ export function isUncoveredArchitectureStale(input: SelectNextActionInput): bool
  */
 export function classifyOverlayGateKind(input: SelectNextActionInput): StatusOverlayGateKind {
   if (input.liveObservationFailed) return "Unknown";
+  if (input.workflowObservationFailed) return "Unknown";
   if (input.outcomeUnknown || input.safetyHold) return "HumanActionRequired";
   if (input.handoffActionRequired) return "HumanActionRequired";
   if (input.automationFailed) return "HumanActionRequired";
@@ -288,6 +294,18 @@ export function selectRecommendedNextAction(
       status: "UNKNOWN",
       gateKind: "Unknown",
       summary: "Live observation failed; cannot recommend a safe next action",
+      ...denyAuth,
+    };
+  }
+
+  // Workflow API/read failure is observation UNKNOWN, not automation OUTCOME_UNKNOWN.
+  if (input.workflowObservationFailed) {
+    return {
+      code: "UNKNOWN",
+      status: "UNKNOWN",
+      gateKind: "Unknown",
+      summary:
+        "Workflow observation unavailable; cannot recommend a safe next action from missing automation evidence",
       ...denyAuth,
     };
   }

--- a/src/domain/statusOverlayGenerator.ts
+++ b/src/domain/statusOverlayGenerator.ts
@@ -58,6 +58,8 @@ export interface StatusOverlayGeneratorInput {
   holds?: string[];
   unknowns?: string[];
   liveObservationFailed?: boolean;
+  /** Workflow/Actions read failed — observation UNKNOWN, not OUTCOME_UNKNOWN. */
+  workflowObservationFailed?: boolean;
   outcomeUnknown?: boolean;
   safetyHold?: boolean;
   holdReason?: string | null;
@@ -209,6 +211,7 @@ export function generateStatusOverlay(
 
   const architectureAffectingStale = isArchitectureAffectingStale(input);
   const liveObservationFailed = input.liveObservationFailed === true;
+  const workflowObservationFailed = input.workflowObservationFailed === true;
   const { activeRefreshPr, overrideRejected } = resolveActiveRefreshPr({
     openPullRequests,
     override: input.autoRefresh.activeRefreshPr,
@@ -217,13 +220,14 @@ export function generateStatusOverlay(
     architectureAffectingStale,
     autoRefreshEnabled: input.autoRefresh.enabled,
     activeRefreshPr,
-    liveObservationFailed,
+    liveObservationFailed: liveObservationFailed || workflowObservationFailed,
     openPullRequests,
   });
 
   const handoffActionRequired = input.handoff.nextActionStatus === "ACTION_REQUIRED";
   const decisionInput = {
     liveObservationFailed,
+    workflowObservationFailed,
     outcomeUnknown: input.outcomeUnknown === true,
     safetyHold: input.safetyHold === true,
     holdReason: input.holdReason ?? null,
@@ -248,6 +252,9 @@ export function generateStatusOverlay(
   const unknowns = [...(input.unknowns ?? [])];
   if (liveObservationFailed && !unknowns.includes("live_observation_failed")) {
     unknowns.push("live_observation_failed");
+  }
+  if (workflowObservationFailed && !unknowns.includes("workflow_state_UNKNOWN")) {
+    unknowns.push("workflow_state_UNKNOWN");
   }
   if (overrideRejected && !unknowns.includes("activeRefreshPr_override_rejected")) {
     unknowns.push("activeRefreshPr_override_rejected");

--- a/src/observer/statusOverlayGithubObserver.ts
+++ b/src/observer/statusOverlayGithubObserver.ts
@@ -200,6 +200,7 @@ export async function observeStatusOverlayGithub(
     holds,
     unknowns,
     liveObservationFailed: false,
+    workflowObservationFailed: false,
     historicalDraftOpen: params.local.historicalDraftOpen === true,
     historyWriter: { writerImplemented: false },
   };
@@ -207,6 +208,7 @@ export async function observeStatusOverlayGithub(
   let currentMain: string | null = null;
   let openPullRequests: StatusOverlayPullRequest[] = [];
   let workflowRuns: StatusOverlayObservedWorkflowRun[] = [];
+  let workflowObservationFailed = false;
 
   try {
     const tip = await params.client.getDefaultBranchTip(params.repository);
@@ -222,8 +224,11 @@ export async function observeStatusOverlayGithub(
         workflowFileName,
       );
     } catch {
-      unknowns.push("workflow_state_UNKNOWN");
-      base.outcomeUnknown = true;
+      // Observation UNKNOWN — not automation OUTCOME_UNKNOWN.
+      workflowObservationFailed = true;
+      if (!unknowns.includes("workflow_state_UNKNOWN")) {
+        unknowns.push("workflow_state_UNKNOWN");
+      }
     }
   } catch {
     return {
@@ -248,10 +253,15 @@ export async function observeStatusOverlayGithub(
   let lastRunConclusion: string | null = null;
   let lastEvaluation: string | null = null;
   let lastPublicationOutcome: string | null = null;
-  let outcomeUnknown = base.outcomeUnknown === true;
+  let outcomeUnknown = false;
   let automationFailed = false;
 
-  if (!latestRun) {
+  if (workflowObservationFailed) {
+    // Workflow API unreadable: observation UNKNOWN fields only.
+    lastRunConclusion = "UNKNOWN";
+    lastEvaluation = "UNKNOWN";
+    lastPublicationOutcome = "UNKNOWN";
+  } else if (!latestRun) {
     if (!unknowns.includes("workflow_state_UNKNOWN")) {
       unknowns.push("workflow_state_UNKNOWN");
     }
@@ -262,11 +272,10 @@ export async function observeStatusOverlayGithub(
     lastRunId = latestRun.id;
     lastRunConclusion = latestRun.conclusion ?? "UNKNOWN";
     if (latestRun.conclusion == null || latestRun.conclusion === "") {
+      lastRunConclusion = "UNKNOWN";
+      // Completed run with missing conclusion → automation OUTCOME_UNKNOWN.
       if (latestRun.status === "completed") {
         outcomeUnknown = true;
-        lastRunConclusion = "UNKNOWN";
-      } else {
-        lastRunConclusion = "UNKNOWN";
       }
     }
     if (latestRun.conclusion === "failure" || latestRun.conclusion === "timed_out") {
@@ -321,6 +330,7 @@ export async function observeStatusOverlayGithub(
     openPullRequests,
     unknowns,
     holds,
+    workflowObservationFailed,
     outcomeUnknown,
     automationFailed,
     autoRefresh: {

--- a/src/observer/statusOverlayGithubObserver.ts
+++ b/src/observer/statusOverlayGithubObserver.ts
@@ -1,0 +1,490 @@
+/**
+ * STATUS-OVERLAY-V1 GitHub / workflow observer (read-only).
+ *
+ * Flow:
+ *   read-only client + local metadata
+ *     → StatusOverlayGeneratorInput
+ *     → generateStatusOverlay() (caller)
+ *
+ * Does not mutate GitHub, write repository files, write HISTORY, invoke
+ * Action Gateway / Ledger / Agents, or implement UI.
+ */
+
+import {
+  inspectPersistentWorkflowYaml,
+  PERSISTENT_AUTO_REFRESH_ENABLED,
+  PERSISTENT_WORKFLOW_PATH,
+} from "../domain/persistentAutoRefreshContract";
+import type { StatusOverlayPullRequest } from "../domain/statusOverlayContract";
+import type { StatusOverlayGeneratorInput } from "../domain/statusOverlayGenerator";
+import { resolveActiveRefreshPr } from "../domain/statusOverlayGenerator";
+import {
+  STATUS_OVERLAY_AUTO_REFRESH_WORKFLOW,
+  STATUS_OVERLAY_OBSERVER_IMPLEMENTED,
+  type StatusOverlayObserveParams,
+  type StatusOverlayObservedPull,
+  type StatusOverlayObservedWorkflowRun,
+  type StatusOverlayReadonlyGithubClient,
+} from "./statusOverlayObservationTypes";
+
+export {
+  STATUS_OVERLAY_AUTO_REFRESH_WORKFLOW,
+  STATUS_OVERLAY_OBSERVER_IMPLEMENTED,
+};
+export type {
+  StatusOverlayLocalObservation,
+  StatusOverlayObserveParams,
+  StatusOverlayObservedPull,
+  StatusOverlayObservedWorkflowRun,
+  StatusOverlayReadonlyGithubClient,
+} from "./statusOverlayObservationTypes";
+
+/** Keys that must never appear on a read-only observer client. */
+export const STATUS_OVERLAY_OBSERVER_FORBIDDEN_CLIENT_METHODS = [
+  "createPullRequest",
+  "updatePullRequest",
+  "mergePullRequest",
+  "closePullRequest",
+  "createIssue",
+  "updateIssue",
+  "createCommit",
+  "push",
+  "deleteRef",
+  "requestReview",
+  "submitReview",
+  "dispatchWorkflow",
+  "cancelWorkflow",
+  "writeFile",
+  "putFile",
+] as const;
+
+/**
+ * Deterministic PR classification for overlay projections.
+ * REFRESH_DRAFT requires draft === true plus refresh-oriented title/branch/body.
+ */
+export function classifyOverlayPullRequest(pr: {
+  draft: boolean;
+  title: string;
+  headRef?: string | null;
+  body?: string | null;
+}): StatusOverlayPullRequest["classification"] {
+  const title = pr.title;
+  const head = pr.headRef ?? "";
+  const body = pr.body ?? "";
+
+  const looksRefresh =
+    /refresh\s+Snapshot/i.test(title) ||
+    /auto-refresh\s+Snapshot/i.test(title) ||
+    /architecture\):\s*refresh\b/i.test(title) ||
+    /architecture\):\s*auto-refresh\b/i.test(title) ||
+    (/auto-refresh/i.test(head) &&
+      (/snapshot/i.test(title) || /ARCH-SNAPSHOT-GEN-V1/.test(body) || /generatedFrom/i.test(body))) ||
+    /refreshIdentity\s*[:=]/i.test(body) ||
+    (/ARCH-SNAPSHOT-GEN-V1/.test(body) && /snapshot/i.test(title));
+
+  if (pr.draft && looksRefresh) return "REFRESH_DRAFT";
+
+  const looksDesign =
+    /\bdesign\b/i.test(title) ||
+    /-design-/i.test(head) ||
+    /\bDESIGNED\b/.test(body) ||
+    /Status:\s*DESIGNED/i.test(body);
+
+  if (looksDesign) return "DESIGN";
+  return "OTHER";
+}
+
+function humanActionFor(
+  draft: boolean,
+  classification: StatusOverlayPullRequest["classification"],
+): StatusOverlayPullRequest["humanAction"] {
+  if (draft) return "REVIEW_DRAFT";
+  if (classification === "OTHER" || classification === "DESIGN") return "DECIDE_MERGE";
+  return "DECIDE_MERGE";
+}
+
+function unknownOr(value: string | null | undefined): string | "UNKNOWN" {
+  if (value == null || value === "") return "UNKNOWN";
+  return value;
+}
+
+export function projectObservedPull(
+  pr: StatusOverlayObservedPull,
+): StatusOverlayPullRequest {
+  const classification = classifyOverlayPullRequest(pr);
+  return {
+    number: pr.number,
+    title: pr.title,
+    draft: pr.draft === true,
+    mergeable:
+      pr.mergeable === true || pr.mergeable === false ? pr.mergeable : "UNKNOWN",
+    head: pr.headSha ?? null,
+    base: pr.baseRef ?? null,
+    reviewState: unknownOr(pr.reviewState),
+    ciState: unknownOr(pr.ciState),
+    classification,
+    humanAction: humanActionFor(pr.draft === true, classification),
+  };
+}
+
+function buildTriggerLabel(yaml: string | null | undefined): string | null {
+  if (yaml == null || yaml === "") return null;
+  const inspection = inspectPersistentWorkflowYaml(yaml);
+  const parts: string[] = [];
+  if (inspection.hasPushMainOnly) parts.push("push_main");
+  if (inspection.hasWorkflowDispatch) parts.push("workflow_dispatch");
+  if (parts.length === 0) return "UNKNOWN";
+  return parts.join("+");
+}
+
+function isAutoRefreshEnabled(yaml: string | null | undefined): boolean {
+  if (yaml == null || yaml === "") return PERSISTENT_AUTO_REFRESH_ENABLED;
+  const inspection = inspectPersistentWorkflowYaml(yaml);
+  return (
+    PERSISTENT_AUTO_REFRESH_ENABLED &&
+    inspection.hasPushMainOnly &&
+    inspection.hasWorkflowDispatch &&
+    !inspection.hasScheduleCron
+  );
+}
+
+function selectLatestWorkflowRun(
+  runs: readonly StatusOverlayObservedWorkflowRun[],
+): StatusOverlayObservedWorkflowRun | null {
+  if (runs.length === 0) return null;
+  // Caller/client should return newest-first; still pick first completed-or-latest.
+  return runs[0] ?? null;
+}
+
+/**
+ * Observe live GitHub/workflow evidence into explicit generator input.
+ * Produces `observedAt` once via `now()` and never invents PASS/READY.
+ */
+export async function observeStatusOverlayGithub(
+  params: StatusOverlayObserveParams,
+): Promise<StatusOverlayGeneratorInput> {
+  const observedAt = params.now();
+  const workflowFileName =
+    params.workflowFileName ?? STATUS_OVERLAY_AUTO_REFRESH_WORKFLOW;
+  const unknowns = [...(params.local.unknowns ?? [])];
+  const holds = [...(params.local.holds ?? [])];
+
+  const base: StatusOverlayGeneratorInput = {
+    repository: params.repository,
+    observedAt,
+    currentMain: null,
+    snapshot: {
+      generatedFrom: params.local.snapshotGeneratedFrom,
+      stale: params.local.snapshotStale,
+      staleClassification: params.local.snapshotStaleClassification,
+      architectureRelevantChanges: [
+        ...(params.local.architectureRelevantChanges ?? []),
+      ],
+    },
+    handoff: {
+      nextActionStatus: params.local.handoffNextActionStatus,
+      staleClassification:
+        params.local.handoffStaleClassification ??
+        params.local.snapshotStaleClassification,
+    },
+    autoRefresh: {
+      enabled: isAutoRefreshEnabled(params.local.persistentWorkflowYaml),
+      trigger: buildTriggerLabel(params.local.persistentWorkflowYaml),
+      lastRunId: null,
+      lastRunConclusion: null,
+      lastEvaluation: null,
+      lastPublicationOutcome: null,
+      activeRefreshPr: null,
+    },
+    openPullRequests: [],
+    holds,
+    unknowns,
+    liveObservationFailed: false,
+    historicalDraftOpen: params.local.historicalDraftOpen === true,
+    historyWriter: { writerImplemented: false },
+  };
+
+  let currentMain: string | null = null;
+  let openPullRequests: StatusOverlayPullRequest[] = [];
+  let workflowRuns: StatusOverlayObservedWorkflowRun[] = [];
+
+  try {
+    const tip = await params.client.getDefaultBranchTip(params.repository);
+    currentMain = tip.sha;
+    const rawPulls = await params.client.listOpenPullRequests(params.repository);
+    openPullRequests = [...rawPulls]
+      .map(projectObservedPull)
+      .sort((a, b) => a.number - b.number);
+
+    try {
+      workflowRuns = await params.client.listWorkflowRuns(
+        params.repository,
+        workflowFileName,
+      );
+    } catch {
+      unknowns.push("workflow_state_UNKNOWN");
+      base.outcomeUnknown = true;
+    }
+  } catch {
+    return {
+      ...base,
+      currentMain: null,
+      openPullRequests: [],
+      liveObservationFailed: true,
+      unknowns: unknowns.includes("live_observation_failed")
+        ? unknowns
+        : [...unknowns, "live_observation_failed"],
+      autoRefresh: {
+        ...base.autoRefresh,
+        lastRunConclusion: "UNKNOWN",
+        lastEvaluation: "UNKNOWN",
+        lastPublicationOutcome: "UNKNOWN",
+      },
+    };
+  }
+
+  const latestRun = selectLatestWorkflowRun(workflowRuns);
+  let lastRunId: string | null = null;
+  let lastRunConclusion: string | null = null;
+  let lastEvaluation: string | null = null;
+  let lastPublicationOutcome: string | null = null;
+  let outcomeUnknown = base.outcomeUnknown === true;
+  let automationFailed = false;
+
+  if (!latestRun) {
+    if (!unknowns.includes("workflow_state_UNKNOWN")) {
+      unknowns.push("workflow_state_UNKNOWN");
+    }
+    lastRunConclusion = "UNKNOWN";
+    lastEvaluation = "UNKNOWN";
+    lastPublicationOutcome = "UNKNOWN";
+  } else {
+    lastRunId = latestRun.id;
+    lastRunConclusion = latestRun.conclusion ?? "UNKNOWN";
+    if (latestRun.conclusion == null || latestRun.conclusion === "") {
+      if (latestRun.status === "completed") {
+        outcomeUnknown = true;
+        lastRunConclusion = "UNKNOWN";
+      } else {
+        lastRunConclusion = "UNKNOWN";
+      }
+    }
+    if (latestRun.conclusion === "failure" || latestRun.conclusion === "timed_out") {
+      automationFailed = true;
+    }
+
+    const runOnCurrentMain =
+      !!currentMain && !!latestRun.headSha && latestRun.headSha === currentMain;
+
+    if (!runOnCurrentMain) {
+      // Older successful runs must not prove current freshness.
+      unknowns.push("workflow_run_not_on_current_main");
+      lastEvaluation = latestRun.lastEvaluation ?? null;
+      lastPublicationOutcome = latestRun.lastPublicationOutcome ?? null;
+      // Do not invent CURRENT / NOT_REQUIRED from a stale-SHA success.
+    } else {
+      lastEvaluation = latestRun.lastEvaluation ?? null;
+      lastPublicationOutcome = latestRun.lastPublicationOutcome ?? null;
+    }
+
+    if (lastRunConclusion === "UNKNOWN" && latestRun.status === "completed") {
+      outcomeUnknown = true;
+    }
+  }
+
+  // activeRefreshPr only from live REFRESH_DRAFT; historical override validated.
+  const { activeRefreshPr, overrideRejected } = resolveActiveRefreshPr({
+    openPullRequests,
+    override:
+      params.local.historicalActiveRefreshPr !== undefined
+        ? params.local.historicalActiveRefreshPr
+        : undefined,
+  });
+  if (overrideRejected && !unknowns.includes("activeRefreshPr_override_rejected")) {
+    unknowns.push("activeRefreshPr_override_rejected");
+  }
+
+  for (const pr of openPullRequests) {
+    if (pr.ciState === "UNKNOWN") {
+      const key = `pr_${pr.number}_ciState_UNKNOWN`;
+      if (!unknowns.includes(key)) unknowns.push(key);
+    }
+    if (pr.reviewState === "UNKNOWN") {
+      const key = `pr_${pr.number}_reviewState_UNKNOWN`;
+      if (!unknowns.includes(key)) unknowns.push(key);
+    }
+  }
+
+  return {
+    ...base,
+    currentMain,
+    openPullRequests,
+    unknowns,
+    holds,
+    outcomeUnknown,
+    automationFailed,
+    autoRefresh: {
+      enabled: base.autoRefresh.enabled,
+      trigger: base.autoRefresh.trigger,
+      lastRunId,
+      lastRunConclusion,
+      lastEvaluation,
+      lastPublicationOutcome,
+      activeRefreshPr,
+    },
+  };
+}
+
+/**
+ * Optional HTTP adapter — GET-only. Not used by unit tests.
+ * Mutation helpers are intentionally absent.
+ */
+export function createStatusOverlayGithubHttpClient(env: {
+  GITHUB_TOKEN?: string;
+}): StatusOverlayReadonlyGithubClient {
+  const API = "https://api.github.com";
+
+  async function githubGet<T>(path: string): Promise<T> {
+    const headers = new Headers({
+      Accept: "application/vnd.github+json",
+      "User-Agent": "ai-development-control-center-status-overlay-observer-v1",
+    });
+    if (env.GITHUB_TOKEN) headers.set("Authorization", `Bearer ${env.GITHUB_TOKEN}`);
+    const response = await fetch(`${API}${path}`, { method: "GET", headers });
+    if (!response.ok) {
+      throw new Error(`GitHub GET ${path} failed: ${response.status}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  return {
+    async getDefaultBranchTip(repository) {
+      const repo = await githubGet<{ default_branch?: string }>(`/repos/${repository}`);
+      if (!repo.default_branch) throw new Error("default branch missing");
+      const commit = await githubGet<{ sha?: string }>(
+        `/repos/${repository}/commits/${encodeURIComponent(repo.default_branch)}`,
+      );
+      if (!commit.sha) throw new Error("main commit SHA missing");
+      return { defaultBranch: repo.default_branch, sha: commit.sha };
+    },
+
+    async listOpenPullRequests(repository) {
+      type Pull = {
+        number: number;
+        title: string;
+        draft?: boolean;
+        body?: string | null;
+        mergeable?: boolean | null;
+        head?: { sha?: string; ref?: string };
+        base?: { ref?: string };
+      };
+      const pulls = await githubGet<Pull[]>(
+        `/repos/${repository}/pulls?state=open&per_page=50`,
+      );
+      const out: StatusOverlayObservedPull[] = [];
+      for (const pull of pulls) {
+        const detail = await githubGet<Pull>(`/repos/${repository}/pulls/${pull.number}`);
+        const headSha = detail.head?.sha ?? pull.head?.sha ?? null;
+        let ciState: string | null = null;
+        let reviewState: string | null = null;
+        if (headSha) {
+          try {
+            const [status, checks] = await Promise.all([
+              githubGet<{ state?: string; total_count?: number }>(
+                `/repos/${repository}/commits/${headSha}/status`,
+              ),
+              githubGet<{
+                check_runs?: Array<{ status?: string; conclusion?: string | null }>;
+              }>(`/repos/${repository}/commits/${headSha}/check-runs`),
+            ]);
+            ciState = normalizeCiFromGithub(status, checks);
+          } catch {
+            ciState = null;
+          }
+        }
+        try {
+          const reviews = await githubGet<Array<{ state?: string }>>(
+            `/repos/${repository}/pulls/${pull.number}/reviews`,
+          );
+          reviewState = normalizeReviewFromGithub(reviews);
+        } catch {
+          reviewState = null;
+        }
+        out.push({
+          number: pull.number,
+          title: detail.title ?? pull.title,
+          draft: detail.draft === true || pull.draft === true,
+          mergeable: detail.mergeable ?? pull.mergeable ?? null,
+          headSha,
+          baseRef: detail.base?.ref ?? pull.base?.ref ?? null,
+          headRef: detail.head?.ref ?? pull.head?.ref ?? null,
+          body: detail.body ?? pull.body ?? null,
+          ciState,
+          reviewState,
+        });
+      }
+      return out;
+    },
+
+    async listWorkflowRuns(repository, workflowFileName) {
+      type Run = {
+        id: number;
+        status?: string;
+        conclusion?: string | null;
+        head_sha?: string;
+        event?: string;
+      };
+      const payload = await githubGet<{ workflow_runs?: Run[] }>(
+        `/repos/${repository}/actions/workflows/${encodeURIComponent(workflowFileName)}/runs?per_page=10`,
+      );
+      return (payload.workflow_runs ?? []).map((run) => ({
+        id: String(run.id),
+        status: run.status ?? "UNKNOWN",
+        conclusion: run.conclusion ?? null,
+        headSha: run.head_sha ?? null,
+        event: run.event ?? null,
+      }));
+    },
+  };
+}
+
+function normalizeCiFromGithub(
+  status: { state?: string; total_count?: number },
+  checks: { check_runs?: Array<{ status?: string; conclusion?: string | null }> },
+): string {
+  const runs = checks.check_runs ?? [];
+  if (runs.some((run) => run.status && run.status !== "completed")) return "PENDING";
+  if (runs.some((run) => run.conclusion === "failure" || run.conclusion === "timed_out")) {
+    return "FAIL";
+  }
+  if (
+    runs.length > 0 &&
+    runs.every(
+      (run) =>
+        run.conclusion === "success" ||
+        run.conclusion === "neutral" ||
+        run.conclusion === "skipped",
+    )
+  ) {
+    return "PASS";
+  }
+  if (!status.state || status.total_count === 0) return "UNKNOWN";
+  if (status.state === "pending") return "PENDING";
+  if (status.state === "failure" || status.state === "error") return "FAIL";
+  if (status.state === "success") return "PASS";
+  return "UNKNOWN";
+}
+
+function normalizeReviewFromGithub(reviews: Array<{ state?: string }>): string {
+  if (reviews.length === 0) return "UNKNOWN";
+  if (reviews.some((review) => review.state === "CHANGES_REQUESTED")) {
+    return "CHANGES_REQUESTED";
+  }
+  if (reviews.some((review) => review.state === "APPROVED")) return "PASS";
+  return "PENDING";
+}
+
+/** Documented workflow path constant for callers assembling local YAML. */
+export function statusOverlayPersistentWorkflowPath(): typeof PERSISTENT_WORKFLOW_PATH {
+  return PERSISTENT_WORKFLOW_PATH;
+}

--- a/src/observer/statusOverlayObservationTypes.ts
+++ b/src/observer/statusOverlayObservationTypes.ts
@@ -1,0 +1,88 @@
+/**
+ * STATUS-OVERLAY-V1 observation types.
+ *
+ * Read-only evidence shapes for the GitHub / workflow observer.
+ * No mutation capabilities are defined on these interfaces.
+ */
+
+import type { StatusOverlayGeneratorInput } from "../domain/statusOverlayGenerator";
+
+export const STATUS_OVERLAY_OBSERVER_IMPLEMENTED = true as const;
+export const STATUS_OVERLAY_OBSERVER_DESIGN = "STATUS-OVERLAY-OBSERVER-V1" as const;
+
+export const STATUS_OVERLAY_AUTO_REFRESH_WORKFLOW =
+  "architecture-auto-refresh.yml" as const;
+
+/** Raw open-PR evidence from a read-only GitHub adapter. */
+export interface StatusOverlayObservedPull {
+  number: number;
+  title: string;
+  draft: boolean;
+  /** null/undefined → UNKNOWN in generator input */
+  mergeable?: boolean | null;
+  headSha?: string | null;
+  baseRef?: string | null;
+  headRef?: string | null;
+  body?: string | null;
+  /** null/undefined/empty → UNKNOWN */
+  reviewState?: string | null;
+  /** null/undefined/empty → UNKNOWN */
+  ciState?: string | null;
+}
+
+/** Raw workflow-run evidence from a read-only Actions adapter. */
+export interface StatusOverlayObservedWorkflowRun {
+  id: string;
+  status: string;
+  conclusion?: string | null;
+  headSha?: string | null;
+  event?: string | null;
+  /** Optional parsed fields when available from run metadata/logs */
+  lastEvaluation?: string | null;
+  lastPublicationOutcome?: string | null;
+}
+
+/**
+ * Narrow read-only GitHub/Actions client.
+ * Implementations must use GET-only APIs and must not expose mutation methods.
+ */
+export interface StatusOverlayReadonlyGithubClient {
+  getDefaultBranchTip(repository: string): Promise<{ defaultBranch: string; sha: string }>;
+  listOpenPullRequests(repository: string): Promise<StatusOverlayObservedPull[]>;
+  listWorkflowRuns(
+    repository: string,
+    workflowFileName: string,
+  ): Promise<StatusOverlayObservedWorkflowRun[]>;
+}
+
+/** Repository-native metadata supplied by the caller (not fetched by the client). */
+export interface StatusOverlayLocalObservation {
+  snapshotGeneratedFrom: string | null;
+  snapshotStale: boolean | null;
+  snapshotStaleClassification: string | null;
+  architectureRelevantChanges?: string[];
+  handoffNextActionStatus: "NO_ACTION" | "ACTION_REQUIRED" | "UNKNOWN" | null;
+  handoffStaleClassification?: string | null;
+  /** Persistent AUTO-REFRESH workflow YAML text for trigger/enablement inspection. */
+  persistentWorkflowYaml?: string | null;
+  /** Historical claim only — never overrides live open PRs. */
+  historicalDraftOpen?: boolean;
+  /** Historical active refresh PR number — ignored unless it matches live REFRESH_DRAFT. */
+  historicalActiveRefreshPr?: number | null;
+  holds?: string[];
+  unknowns?: string[];
+}
+
+export interface StatusOverlayObserveParams {
+  repository: string;
+  client: StatusOverlayReadonlyGithubClient;
+  local: StatusOverlayLocalObservation;
+  /**
+   * Clock injection for `observedAt`. Called once per observation.
+   * Production callers may pass `() => new Date().toISOString()`.
+   */
+  now: () => string;
+  workflowFileName?: string;
+}
+
+export type StatusOverlayObservationResult = StatusOverlayGeneratorInput;

--- a/test/statusOverlayGithubObserver.test.ts
+++ b/test/statusOverlayGithubObserver.test.ts
@@ -1,0 +1,427 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { generateStatusOverlay } from "../src/domain/statusOverlayGenerator";
+import {
+  STATUS_OVERLAY_OBSERVER_FORBIDDEN_CLIENT_METHODS,
+  STATUS_OVERLAY_OBSERVER_IMPLEMENTED,
+  classifyOverlayPullRequest,
+  createStatusOverlayGithubHttpClient,
+  observeStatusOverlayGithub,
+  projectObservedPull,
+  type StatusOverlayLocalObservation,
+  type StatusOverlayObservedPull,
+  type StatusOverlayObservedWorkflowRun,
+  type StatusOverlayReadonlyGithubClient,
+} from "../src/observer/statusOverlayGithubObserver";
+
+const repo = "yasutakesougo/ai-development-control-center";
+const main = "9877e5e89ec1fdc8d0e79bd89a108d5e24f834ed";
+const from = "78a72b13965d7b4fc4ce021d0aaa08a40eb17aa0";
+const observedAt = "2026-08-12T04:50:00.000Z";
+
+const enabledWorkflowYaml = `
+name: architecture-auto-refresh
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+concurrency:
+  group: architecture-auto-refresh-\${{ github.repository }}-main
+  cancel-in-progress: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps: []
+`;
+
+function local(
+  partial: Partial<StatusOverlayLocalObservation> = {},
+): StatusOverlayLocalObservation {
+  return {
+    snapshotGeneratedFrom: from,
+    snapshotStale: false,
+    snapshotStaleClassification: "current",
+    architectureRelevantChanges: [],
+    handoffNextActionStatus: "NO_ACTION",
+    handoffStaleClassification: "current",
+    persistentWorkflowYaml: enabledWorkflowYaml,
+    ...partial,
+  };
+}
+
+function fakeClient(input: {
+  mainSha?: string;
+  pulls?: StatusOverlayObservedPull[];
+  runs?: StatusOverlayObservedWorkflowRun[];
+  failTip?: boolean;
+  failRuns?: boolean;
+}): StatusOverlayReadonlyGithubClient {
+  return {
+    async getDefaultBranchTip() {
+      if (input.failTip) throw new Error("tip failed");
+      return { defaultBranch: "main", sha: input.mainSha ?? main };
+    },
+    async listOpenPullRequests() {
+      return [...(input.pulls ?? [])];
+    },
+    async listWorkflowRuns() {
+      if (input.failRuns) throw new Error("runs failed");
+      return [...(input.runs ?? [])];
+    },
+  };
+}
+
+describe("STATUS-OVERLAY-V1 GitHub / workflow observer", () => {
+  it("marks observer implemented", () => {
+    expect(STATUS_OVERLAY_OBSERVER_IMPLEMENTED).toBe(true);
+  });
+
+  it("observes current main", async () => {
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({ mainSha: main }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(input.currentMain).toBe(main);
+    expect(input.observedAt).toBe(observedAt);
+    expect(input.liveObservationFailed).toBe(false);
+  });
+
+  it("projects Draft and Ready PRs with deterministic ordering", async () => {
+    const pulls: StatusOverlayObservedPull[] = [
+      {
+        number: 40,
+        title: "feat: ready work",
+        draft: false,
+        mergeable: true,
+        headSha: "r1",
+        baseRef: "main",
+        headRef: "feat/ready",
+        ciState: "PASS",
+        reviewState: "PASS",
+      },
+      {
+        number: 30,
+        title: "docs(status): design STATUS-OVERLAY-V1",
+        draft: true,
+        headSha: "d1",
+        baseRef: "main",
+        headRef: "cursor/status-overlay-v1-design-2c83",
+      },
+    ];
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({ pulls }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(input.openPullRequests?.map((p) => p.number)).toEqual([30, 40]);
+    expect(input.openPullRequests?.[0].draft).toBe(true);
+    expect(input.openPullRequests?.[1].draft).toBe(false);
+  });
+
+  it("classifies REFRESH_DRAFT vs DESIGN vs OTHER", () => {
+    expect(
+      classifyOverlayPullRequest({
+        draft: true,
+        title: "docs(architecture): refresh Snapshot after enablement",
+        headRef: "cursor/auto-refresh-followup-2c83",
+      }),
+    ).toBe("REFRESH_DRAFT");
+    expect(
+      classifyOverlayPullRequest({
+        draft: true,
+        title: "docs(status): design STATUS-OVERLAY-V1",
+        headRef: "cursor/status-overlay-v1-design-2c83",
+      }),
+    ).toBe("DESIGN");
+    expect(
+      classifyOverlayPullRequest({
+        draft: false,
+        title: "chore: bump deps",
+        headRef: "chore/deps",
+      }),
+    ).toBe("OTHER");
+  });
+
+  it("missing CI and review become UNKNOWN", () => {
+    const projected = projectObservedPull({
+      number: 9,
+      title: "docs(status): design X",
+      draft: true,
+      headRef: "cursor/x-design-2c83",
+      ciState: null,
+      reviewState: undefined,
+    });
+    expect(projected.ciState).toBe("UNKNOWN");
+    expect(projected.reviewState).toBe("UNKNOWN");
+  });
+
+  it("workflow state unavailable → UNKNOWN fields", async () => {
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({ failRuns: true }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(input.unknowns).toContain("workflow_state_UNKNOWN");
+    expect(input.autoRefresh.lastRunConclusion).toBe("UNKNOWN");
+    expect(input.outcomeUnknown).toBe(true);
+  });
+
+  it("old successful workflow run does not prove freshness after main moves", async () => {
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({
+        mainSha: main,
+        runs: [
+          {
+            id: "111",
+            status: "completed",
+            conclusion: "success",
+            headSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            lastEvaluation: "NOT_REQUIRED",
+            lastPublicationOutcome: "NO_PUBLICATION",
+          },
+        ],
+      }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(input.autoRefresh.lastRunId).toBe("111");
+    expect(input.autoRefresh.lastRunConclusion).toBe("success");
+    expect(input.unknowns).toContain("workflow_run_not_on_current_main");
+    // Still surface observed evaluation strings, but generator freshness helper
+    // and unknowns make clear the run is not current-main proof.
+    const doc = generateStatusOverlay(input);
+    expect(doc.recommendedNextAction.authorizesMutation).toBe(false);
+  });
+
+  it("identifies valid active refresh Draft and rejects stale historical reference", async () => {
+    const pulls: StatusOverlayObservedPull[] = [
+      {
+        number: 44,
+        title: "docs(architecture): refresh Snapshot",
+        draft: true,
+        headRef: "cursor/auto-refresh-followup-2c83",
+        headSha: "bbbb",
+        baseRef: "main",
+      },
+      {
+        number: 30,
+        title: "docs(status): design STATUS-OVERLAY-V1",
+        draft: true,
+        headRef: "cursor/status-overlay-v1-design-2c83",
+        headSha: "cccc",
+        baseRef: "main",
+      },
+    ];
+    const valid = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({ pulls }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(valid.autoRefresh.activeRefreshPr).toBe(44);
+
+    const rejected = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({ pulls }),
+      local: local({ historicalActiveRefreshPr: 999 }),
+      now: () => observedAt,
+    });
+    expect(rejected.autoRefresh.activeRefreshPr).toBe(44);
+    expect(rejected.unknowns).toContain("activeRefreshPr_override_rejected");
+  });
+
+  it("observer read failure → liveObservationFailed=true and UNKNOWN overlay", async () => {
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({ failTip: true }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(input.liveObservationFailed).toBe(true);
+    expect(input.unknowns).toContain("live_observation_failed");
+    const doc = generateStatusOverlay(input);
+    expect(doc.recommendedNextAction.code).toBe("UNKNOWN");
+    expect(doc.recommendedNextAction.gateKind).toBe("Unknown");
+  });
+
+  it("generated input → expected Runtime Generator outputs", async () => {
+    const currentInput = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({
+        runs: [
+          {
+            id: "200",
+            status: "completed",
+            conclusion: "success",
+            headSha: main,
+            lastEvaluation: "NOT_REQUIRED",
+            lastPublicationOutcome: "NO_PUBLICATION",
+          },
+        ],
+      }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(generateStatusOverlay(currentInput).recommendedNextAction.code).toBe("NO_ACTION");
+
+    const draftInput = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({
+        pulls: [
+          {
+            number: 41,
+            title: "docs(status): design STATUS-OVERLAY-V1",
+            draft: true,
+            headRef: "cursor/status-overlay-v1-design-2c83",
+          },
+        ],
+      }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(generateStatusOverlay(draftInput).recommendedNextAction.code).toBe(
+      "REVIEW_DRAFT_PR",
+    );
+
+    const staleInput = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({
+        pulls: [
+          {
+            number: 41,
+            title: "docs(status): design STATUS-OVERLAY-V1",
+            draft: true,
+            headRef: "cursor/status-overlay-v1-design-2c83",
+          },
+        ],
+      }),
+      local: local({
+        snapshotStale: true,
+        snapshotStaleClassification: "stale_architecture_affecting",
+        architectureRelevantChanges: ["package.json"],
+        handoffStaleClassification: "stale_architecture_affecting",
+        persistentWorkflowYaml: "name: x\non:\n  workflow_dispatch:\n",
+      }),
+      now: () => observedAt,
+    });
+    // workflow yaml without push_main → enabled false via inspection
+    expect(staleInput.autoRefresh.enabled).toBe(false);
+    expect(generateStatusOverlay(staleInput).recommendedNextAction.code).toBe(
+      "MAINTAIN_STALE_SNAPSHOT",
+    );
+  });
+
+  it("preserves observedAt exactly across generator", async () => {
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({}),
+      local: local(),
+      now: () => "2026-02-03T04:05:06.789Z",
+    });
+    expect(generateStatusOverlay(input).observedAt).toBe("2026-02-03T04:05:06.789Z");
+  });
+
+  it("recommendation never authorizes mutation", async () => {
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({
+        pulls: [
+          {
+            number: 1,
+            title: "docs(architecture): refresh Snapshot",
+            draft: true,
+            headRef: "cursor/auto-refresh-x-2c83",
+          },
+        ],
+      }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(generateStatusOverlay(input).recommendedNextAction.authorizesMutation).toBe(
+      false,
+    );
+  });
+
+  it("observer path has no mutation methods on client interface / HTTP factory", () => {
+    const source = readFileSync(
+      new URL("../src/observer/statusOverlayGithubObserver.ts", import.meta.url),
+      "utf8",
+    );
+    const types = readFileSync(
+      new URL("../src/observer/statusOverlayObservationTypes.ts", import.meta.url),
+      "utf8",
+    );
+    // Interface surface is GET-only.
+    expect(types).toMatch(/getDefaultBranchTip/);
+    expect(types).toMatch(/listOpenPullRequests/);
+    expect(types).toMatch(/listWorkflowRuns/);
+    for (const method of STATUS_OVERLAY_OBSERVER_FORBIDDEN_CLIENT_METHODS) {
+      expect(types).not.toMatch(new RegExp(`\\b${method}\\s*\\(`));
+      expect(source).not.toMatch(new RegExp(`\\basync\\s+${method}\\s*\\(`));
+      expect(source).not.toMatch(new RegExp(`\\b${method}\\s*:\\s*async\\b`));
+    }
+    expect(source).toMatch(/method:\s*["']GET["']/);
+    expect(source).not.toMatch(/method:\s*["']POST["']/);
+    expect(source).not.toMatch(/method:\s*["']PATCH["']/);
+    expect(source).not.toMatch(/method:\s*["']PUT["']/);
+    expect(source).not.toMatch(/method:\s*["']DELETE["']/);
+
+    const client = createStatusOverlayGithubHttpClient({});
+    expect(Object.keys(client).sort()).toEqual([
+      "getDefaultBranchTip",
+      "listOpenPullRequests",
+      "listWorkflowRuns",
+    ].sort());
+    const clientRecord = client as unknown as Record<string, unknown>;
+    for (const method of STATUS_OVERLAY_OBSERVER_FORBIDDEN_CLIENT_METHODS) {
+      expect(typeof clientRecord[method]).not.toBe("function");
+    }
+  });
+
+  it("repeated observation is equivalent except observedAt", async () => {
+    const client = fakeClient({
+      pulls: [
+        {
+          number: 5,
+          title: "docs(status): design X",
+          draft: true,
+          headRef: "cursor/x-design-2c83",
+        },
+      ],
+      runs: [
+        {
+          id: "9",
+          status: "completed",
+          conclusion: "success",
+          headSha: main,
+          lastEvaluation: "NOT_REQUIRED",
+        },
+      ],
+    });
+    const a = await observeStatusOverlayGithub({
+      repository: repo,
+      client,
+      local: local(),
+      now: () => "2026-08-12T04:50:00.000Z",
+    });
+    const b = await observeStatusOverlayGithub({
+      repository: repo,
+      client,
+      local: local(),
+      now: () => "2026-08-12T04:51:00.000Z",
+    });
+    const { observedAt: _a, ...restA } = a;
+    const { observedAt: _b, ...restB } = b;
+    expect(restA).toEqual(restB);
+    expect(_a).not.toBe(_b);
+  });
+});

--- a/test/statusOverlayGithubObserver.test.ts
+++ b/test/statusOverlayGithubObserver.test.ts
@@ -162,16 +162,63 @@ describe("STATUS-OVERLAY-V1 GitHub / workflow observer", () => {
     expect(projected.reviewState).toBe("UNKNOWN");
   });
 
-  it("workflow state unavailable → UNKNOWN fields", async () => {
+  it("workflow API read failure → observation UNKNOWN, not OUTCOME_UNKNOWN", async () => {
     const input = await observeStatusOverlayGithub({
       repository: repo,
-      client: fakeClient({ failRuns: true }),
+      client: fakeClient({
+        failRuns: true,
+        pulls: [
+          {
+            number: 30,
+            title: "docs(status): design STATUS-OVERLAY-V1",
+            draft: true,
+            headRef: "cursor/status-overlay-v1-design-2c83",
+          },
+        ],
+      }),
       local: local(),
       now: () => observedAt,
     });
     expect(input.unknowns).toContain("workflow_state_UNKNOWN");
+    expect(input.workflowObservationFailed).toBe(true);
+    expect(input.outcomeUnknown).toBeFalsy();
     expect(input.autoRefresh.lastRunConclusion).toBe("UNKNOWN");
+
+    const doc = generateStatusOverlay(input);
+    expect(doc.recommendedNextAction.code).toBe("UNKNOWN");
+    expect(doc.recommendedNextAction.code).not.toBe("RESOLVE_OUTCOME_UNKNOWN");
+    expect(doc.recommendedNextAction.status).toBe("UNKNOWN");
+    expect(doc.recommendedNextAction.gateKind).toBe("Unknown");
+    // Must not upgrade to Draft review / NO_ACTION while workflow evidence is unavailable.
+    expect(doc.recommendedNextAction.code).not.toBe("REVIEW_DRAFT_PR");
+    expect(doc.recommendedNextAction.code).not.toBe("NO_ACTION");
+  });
+
+  it("completed run with missing conclusion → OUTCOME_UNKNOWN", async () => {
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client: fakeClient({
+        mainSha: main,
+        runs: [
+          {
+            id: "31569999999",
+            status: "completed",
+            conclusion: null,
+            headSha: main,
+          },
+        ],
+      }),
+      local: local(),
+      now: () => observedAt,
+    });
+    expect(input.workflowObservationFailed).toBeFalsy();
     expect(input.outcomeUnknown).toBe(true);
+    expect(input.autoRefresh.lastRunId).toBe("31569999999");
+    expect(input.autoRefresh.lastRunConclusion).toBe("UNKNOWN");
+
+    const doc = generateStatusOverlay(input);
+    expect(doc.recommendedNextAction.code).toBe("RESOLVE_OUTCOME_UNKNOWN");
+    expect(doc.recommendedNextAction.status).toBe("OUTCOME_UNKNOWN");
   });
 
   it("old successful workflow run does not prove freshness after main moves", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the read-only **STATUS-OVERLAY-V1 GitHub / Workflow Observer** authorized by Issue #33.

```
read-only GitHub/workflow observer
  → StatusOverlayGeneratorInput
  → generateStatusOverlay()
  → StatusOverlayDocument
```

Closes #33

---

## P2 follow-up (review 4913128669)

Separated workflow observation failure from automation OUTCOME_UNKNOWN:

| Case | Signal | Next action |
|---|---|---|
| `listWorkflowRuns()` throws | `workflowObservationFailed` + `workflow_state_UNKNOWN` | `UNKNOWN` (observation) |
| Completed run, conclusion missing | `outcomeUnknown=true` | `RESOLVE_OUTCOME_UNKNOWN` |

Workflow read failure no longer manufactures `RESOLVE_OUTCOME_UNKNOWN`, and does not upgrade to `NO_ACTION` / Draft review while automation evidence is unavailable.

---

## Baseline

| Item | Value |
|---|---|
| Expected main | `9877e5e89ec1fdc8d0e79bd89a108d5e24f834ed` |
| Branch | `cursor/status-overlay-observer-2c83` |

---

## Verification

```
npm run verify
→ typecheck PASS
→ 257 tests PASS (21 files)
→ build PASS
```

---

## Explicit non-goals (still NOT IMPLEMENTED)

| Item | Status |
|---|---|
| UI | NOT IMPLEMENTED |
| Repository-file writer | NOT IMPLEMENTED |
| HISTORY writer | NOT IMPLEMENTED |
| Action Gateway | NOT IMPLEMENTED |
| Approval Ledger write | NOT IMPLEMENTED |
| Agent execution | NOT IMPLEMENTED |

**Stop at Draft.** Fresh Review on new HEAD. Do not mark Ready. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff3bd-613c-7d0a-b59d-d9615a722c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff3bd-613c-7d0a-b59d-d9615a722c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

