### PR TITLE
feat(status): add STATUS-OVERLAY-V1 read-only UI projection

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,7 +29,7 @@ HISTORY-V1 is **designed** (append-only Snapshot/refresh audit) and **not
 implemented** — see [`../history/history-v1.md`](../history/history-v1.md).
 No persistence writer is enabled.
 
-STATUS-OVERLAY-V1 is **designed**; Runtime Generator and read-only GitHub /
-workflow observer are **implemented** — see
+STATUS-OVERLAY-V1 is **designed**; Runtime Generator, read-only GitHub /
+workflow observer, and read-only UI projection are **implemented** — see
 [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
-UI / repository writer / Action Gateway binding remain not implemented.
+Repository writer / Action Gateway binding remain not implemented.

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -76,11 +76,12 @@ implemented** — see [`../history/history-v1.md`](../history/history-v1.md).
 Historical events must not change HANDOFF decision semantics or manufacture
 `ACTION_REQUIRED`.
 
-STATUS-OVERLAY-V1 (current-state projection) is **designed**; Runtime Generator
-and read-only GitHub/workflow observer are **implemented** — see
+STATUS-OVERLAY-V1 (current-state projection) is **designed**; Runtime Generator,
+read-only GitHub/workflow observer, and read-only UI projection are
+**implemented** — see
 [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
 Overlay consumes HANDOFF output and must not redefine HANDOFF rules.
-UI / repository writer remain not implemented.
+Repository writer remains not implemented.
 
 ## Next action
 

--- a/docs/status/status-overlay-v1.md
+++ b/docs/status/status-overlay-v1.md
@@ -1,6 +1,6 @@
 # STATUS-OVERLAY-V1
 
-**Status: DESIGNED · runtime generator IMPLEMENTED · GitHub/workflow observer IMPLEMENTED · UI NOT IMPLEMENTED**
+**Status: DESIGNED · runtime generator IMPLEMENTED · GitHub/workflow observer IMPLEMENTED · UI IMPLEMENTED (read-only)**
 
 This document designs **STATUS-OVERLAY-V1**: a replaceable **current-state
 projection** that answers:
@@ -16,20 +16,23 @@ Companion modules:
 - Contract helpers: `src/domain/statusOverlayContract.ts`
 - Runtime generator (pure): `src/domain/statusOverlayGenerator.ts`
 - Read-only observer: `src/observer/statusOverlayGithubObserver.ts`
+- Read-only UI: `src/ui/statusOverlayViewModel.ts`, `src/ui/StatusOverlayPanel.tsx`
 
 STATUS-OVERLAY is **decision-support only**. It does **not** authorize
 mutation, Ready, Merge, Action Gateway, Agent execution, or Ledger writes.
 
-Observation flow:
+Observation / projection flow:
 
 ```
 read-only GitHub/workflow observer
   → explicit StatusOverlayGeneratorInput
   → generateStatusOverlay()
   → StatusOverlayDocument
+  → UI projection (read-only)
 ```
 
-No repository-file writer / HISTORY writer / UI in this slice.
+No repository-file writer / HISTORY writer in this slice. UI never observes
+GitHub itself and never exposes mutation controls.
 
 ---
 
@@ -325,20 +328,26 @@ create timestamps.
 
 ---
 
-## Human-readable rendering (optional)
+## Human-readable rendering
 
-Compact sections only:
+Compact sections (UI projection):
 
 ```
 CURRENT
 GATE
+NEXT
 AUTOMATION
 HOLDS
-UNKNOWN
-NEXT
+UNKNOWNS
+PRS
 ```
 
-No decorative metric strips. Markdown/HTML renderer is **NOT IMPLEMENTED**.
+Pure view-model: `buildStatusOverlayViewModel(document)`  
+Deterministic Markdown: `renderStatusOverlayMarkdown(document)`  
+React panel: `<StatusOverlayPanel document={document} />`
+
+No decorative metric strips. No write buttons. `authorizesMutation` remains
+false and is shown explicitly.
 
 ---
 
@@ -397,6 +406,6 @@ No decorative metric strips. Markdown/HTML renderer is **NOT IMPLEMENTED**.
 | GitHub / workflow observer | **IMPLEMENTED** (`statusOverlayGithubObserver.ts`, read-only) |
 | Repository-file writer | **NOT IMPLEMENTED** |
 | HISTORY writer | **NOT IMPLEMENTED** |
-| UI | **NOT IMPLEMENTED** |
+| UI | **IMPLEMENTED** (read-only view-model + panel) |
 | Action Gateway binding | **NOT IMPLEMENTED** |
 | Approval Ledger / Agent execution | **NOT IMPLEMENTED** |

--- a/src/domain/statusOverlayContract.ts
+++ b/src/domain/statusOverlayContract.ts
@@ -1,7 +1,7 @@
 /**
  * STATUS-OVERLAY-V1 design contract helpers.
  *
- * DESIGNED · runtime generator IMPLEMENTED · UI NOT IMPLEMENTED
+ * DESIGNED · runtime generator IMPLEMENTED · UI IMPLEMENTED (read-only)
  *
  * Pure live-state precedence, Human-gate classification, and deterministic
  * next-action selection. Does not observe GitHub, write files, or authorize
@@ -11,10 +11,11 @@
 export const STATUS_OVERLAY_SCHEMA_VERSION = "STATUS-OVERLAY-V1" as const;
 export const STATUS_OVERLAY_DESIGN = "STATUS-OVERLAY-DESIGN-V1" as const;
 
-/** Pure runtime projection generator is implemented (no observer/UI/writer). */
+/** Pure runtime projection generator is implemented (no writer). */
 export const STATUS_OVERLAY_GENERATOR_IMPLEMENTED = true as const;
-export const STATUS_OVERLAY_UI_IMPLEMENTED = false as const;
-/** Full product (observer + UI + emit) remains incomplete. */
+/** Read-only UI projection is implemented (no mutation controls). */
+export const STATUS_OVERLAY_UI_IMPLEMENTED = true as const;
+/** Full product (writer / Gateway binding) remains incomplete. */
 export const STATUS_OVERLAY_IMPLEMENTED = false as const;
 
 /** Stable status vocabulary — no synonyms. */
@@ -150,21 +151,23 @@ export interface SelectNextActionInput {
   activeRefreshPr?: number | null;
 }
 
-/** UI / observer / writer / Gateway binding remain forbidden in this slice. */
-export function assertStatusOverlayUiNotImplemented(): void {
-  if (STATUS_OVERLAY_UI_IMPLEMENTED) {
-    throw new Error("STATUS-OVERLAY-V1 UI must remain NOT IMPLEMENTED");
+/** Writer / Gateway / Ledger binding remain forbidden. */
+export function assertStatusOverlayWriterNotImplemented(): void {
+  if (STATUS_OVERLAY_IMPLEMENTED) {
+    throw new Error(
+      "STATUS-OVERLAY-V1 full product (writer/Gateway binding) must remain NOT IMPLEMENTED",
+    );
   }
 }
 
-/** @deprecated Use assertStatusOverlayUiNotImplemented — generator is now implemented. */
+/** @deprecated Prefer assertStatusOverlayWriterNotImplemented — UI projection is implemented. */
 export function assertStatusOverlayNotImplemented(): void {
-  assertStatusOverlayUiNotImplemented();
-  if (STATUS_OVERLAY_IMPLEMENTED) {
-    throw new Error(
-      "STATUS-OVERLAY-V1 full product (observer/UI/writer) must remain NOT IMPLEMENTED",
-    );
-  }
+  assertStatusOverlayWriterNotImplemented();
+}
+
+/** @deprecated UI projection is implemented; use assertStatusOverlayWriterNotImplemented. */
+export function assertStatusOverlayUiNotImplemented(): void {
+  assertStatusOverlayWriterNotImplemented();
 }
 
 /**
@@ -449,14 +452,15 @@ export function proposedStatusOverlayStoragePath(): "docs/status/status-overlay.
   return "docs/status/status-overlay.json";
 }
 
-/** Compact Markdown section order for a future renderer (not implemented). */
+/** Compact human-facing section order (UI projection). */
 export const STATUS_OVERLAY_MARKDOWN_SECTIONS = [
   "CURRENT",
   "GATE",
+  "NEXT",
   "AUTOMATION",
   "HOLDS",
-  "UNKNOWN",
-  "NEXT",
+  "UNKNOWNS",
+  "PRS",
 ] as const;
 
 /**

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -15,10 +15,12 @@ import {
   type LedgerSubmissionAttempt,
   type LedgerSubmissionState,
 } from "../domain/ledgerSubmission";
+import type { StatusOverlayDocument } from "../domain/statusOverlayContract";
 import { ApprovalIntentPanel } from "./ApprovalIntentPanel";
 import { fetchLedgerHistory, postLedgerRecord, type LedgerHistoryResult } from "./ledgerApi";
 import { LedgerHistoryPanel } from "./LedgerHistoryPanel";
 import { LedgerRecordControls } from "./LedgerRecordControls";
+import { StatusOverlayPanel } from "./StatusOverlayPanel";
 
 type PrEvidence = {
   pr: number;
@@ -53,7 +55,15 @@ const fallback: HumanAction = {
   sourceRefs: [],
 };
 
-export function App() {
+export interface AppProps {
+  /**
+   * Optional STATUS-OVERLAY document for read-only display.
+   * The UI never observes GitHub/workflow itself — callers supply the document.
+   */
+  statusOverlay?: StatusOverlayDocument | null;
+}
+
+export function App({ statusOverlay = null }: AppProps = {}) {
   const [data, setData] = useState<StatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [intentDraft, setIntentDraft] = useState<ApprovalIntentDraft | null>(null);
@@ -156,6 +166,8 @@ export function App() {
           <div><dt>observedAt</dt><dd>{data?.observedAt ?? "確認中"}</dd></div>
         </dl>
       </section>
+
+      {statusOverlay && <StatusOverlayPanel document={statusOverlay} />}
 
       {!loading && approvalAllowed && data && (
         <ApprovalIntentPanel

--- a/src/ui/StatusOverlayPanel.tsx
+++ b/src/ui/StatusOverlayPanel.tsx
@@ -1,0 +1,184 @@
+/**
+ * STATUS-OVERLAY-V1 read-only React panel.
+ *
+ * Renders a StatusOverlayDocument only. No observe/fetch/Date.now/mutation controls.
+ */
+
+import type { StatusOverlayDocument } from "../domain/statusOverlayContract";
+import { buildStatusOverlayViewModel } from "./statusOverlayViewModel";
+
+export interface StatusOverlayPanelProps {
+  document: StatusOverlayDocument;
+}
+
+export function StatusOverlayPanel({ document }: StatusOverlayPanelProps) {
+  const vm = buildStatusOverlayViewModel(document);
+
+  return (
+    <section
+      className="status-overlay-card"
+      data-testid="status-overlay-panel"
+      aria-label="STATUS-OVERLAY"
+    >
+      <header className="status-overlay-header">
+        <p className="eyebrow">STATUS-OVERLAY-V1</p>
+        <h2>Repository status</h2>
+        <p className="status-overlay-note">
+          Read-only projection. Recommendations do not authorize mutation.
+        </p>
+      </header>
+
+      <section className={`status-overlay-section tone-${vm.current.tone}`} data-section="CURRENT">
+        <h3>CURRENT</h3>
+        <dl>
+          <div><dt>Repository</dt><dd>{vm.current.repository}</dd></div>
+          <div><dt>Main</dt><dd>{vm.current.mainSha}</dd></div>
+          <div><dt>observedAt</dt><dd>{vm.current.observedAt}</dd></div>
+          <div>
+            <dt>Snapshot</dt>
+            <dd>
+              <span className={`status-overlay-badge tone-${vm.current.tone}`}>
+                {vm.current.snapshotLabel}
+              </span>{" "}
+              {vm.current.snapshotClassification}
+            </dd>
+          </div>
+          <div><dt>Coverage</dt><dd>{vm.current.coverage}</dd></div>
+        </dl>
+      </section>
+
+      <section className={`status-overlay-section tone-${vm.gate.tone}`} data-section="GATE">
+        <h3>GATE</h3>
+        <p>
+          <span className={`status-overlay-badge tone-${vm.gate.tone}`}>{vm.gate.kind}</span>
+          {" — "}
+          {vm.gate.kindLabel}
+        </p>
+        <p className="status-overlay-summary">{vm.gate.summary}</p>
+      </section>
+
+      <section className={`status-overlay-section tone-${vm.next.tone}`} data-section="NEXT">
+        <h3>NEXT</h3>
+        <p>
+          <span className={`status-overlay-badge tone-${vm.next.tone}`}>{vm.next.code}</span>
+          {" / "}
+          <span className={`status-overlay-badge tone-${vm.next.tone}`}>{vm.next.status}</span>
+        </p>
+        <p className="status-overlay-summary">{vm.next.summary}</p>
+        {vm.next.targetPr != null && vm.next.targetPrUrl && (
+          <p>
+            Target PR:{" "}
+            <a href={vm.next.targetPrUrl} rel="noreferrer">
+              #{vm.next.targetPr}
+            </a>
+          </p>
+        )}
+        <p className="status-overlay-auth" data-testid="status-overlay-no-auth">
+          authorizesMutation: false — {vm.next.authorizationNote}
+        </p>
+        {vm.next.secondaryContext.length > 0 && (
+          <ul className="status-overlay-secondary">
+            {vm.next.secondaryContext.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section
+        className={`status-overlay-section tone-${vm.automation.tone}`}
+        data-section="AUTOMATION"
+      >
+        <h3>AUTOMATION</h3>
+        <dl>
+          <div><dt>Enabled</dt><dd>{vm.automation.enabledLabel}</dd></div>
+          <div><dt>Trigger</dt><dd>{vm.automation.trigger}</dd></div>
+          <div><dt>Last run</dt><dd>{vm.automation.lastRunId}</dd></div>
+          <div>
+            <dt>Conclusion</dt>
+            <dd>
+              <span className={`status-overlay-badge tone-${vm.automation.tone}`}>
+                {vm.automation.lastRunConclusion}
+              </span>
+            </dd>
+          </div>
+          <div><dt>Evaluation</dt><dd>{vm.automation.lastEvaluation}</dd></div>
+          <div><dt>Publication</dt><dd>{vm.automation.lastPublicationOutcome}</dd></div>
+          <div>
+            <dt>Active refresh PR</dt>
+            <dd>
+              {vm.automation.activeRefreshPr != null && vm.automation.activeRefreshPrUrl ? (
+                <a href={vm.automation.activeRefreshPrUrl} rel="noreferrer">
+                  #{vm.automation.activeRefreshPr}
+                </a>
+              ) : (
+                "none"
+              )}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className={`status-overlay-section tone-${vm.holds.tone}`} data-section="HOLDS">
+        <h3>HOLDS</h3>
+        {vm.holds.empty ? (
+          <p className="status-overlay-empty">{vm.holds.emptyLabel}</p>
+        ) : (
+          <ul>
+            {vm.holds.items.map((item) => (
+              <li key={item}>
+                <span className="status-overlay-badge tone-hold">HOLD</span> {item}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section
+        className={`status-overlay-section tone-${vm.unknowns.tone}`}
+        data-section="UNKNOWNS"
+      >
+        <h3>UNKNOWNS</h3>
+        {vm.unknowns.empty ? (
+          <p className="status-overlay-empty">{vm.unknowns.emptyLabel}</p>
+        ) : (
+          <ul>
+            {vm.unknowns.items.map((item) => (
+              <li key={item}>
+                <span className="status-overlay-badge tone-unknown">UNKNOWN</span> {item}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="status-overlay-section tone-neutral" data-section="PRS">
+        <h3>PRS</h3>
+        {vm.pullRequests.length === 0 ? (
+          <p className="status-overlay-empty">none</p>
+        ) : (
+          <ul className="status-overlay-pr-list">
+            {vm.pullRequests.map((pr) => (
+              <li key={pr.number}>
+                <a href={pr.url} rel="noreferrer">
+                  #{pr.number}
+                </a>{" "}
+                <span className="status-overlay-badge tone-neutral">
+                  {pr.draft ? "DRAFT" : "READY"}
+                </span>{" "}
+                <span className="status-overlay-badge tone-neutral">{pr.classification}</span>
+                {pr.isActiveRefresh && (
+                  <span className="status-overlay-badge tone-action">activeRefresh</span>
+                )}{" "}
+                {pr.title}
+                <div className="status-overlay-pr-meta">
+                  CI={pr.ciState} · Review={pr.reviewState}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/src/ui/statusOverlayViewModel.ts
+++ b/src/ui/statusOverlayViewModel.ts
@@ -1,0 +1,343 @@
+/**
+ * STATUS-OVERLAY-V1 UI view-model (read-only presentation).
+ *
+ * Consumes only StatusOverlayDocument. Does not observe GitHub, mutate state,
+ * invent timestamps, or authorize mutation.
+ */
+
+import type {
+  StatusOverlayDocument,
+  StatusOverlayGateKind,
+  StatusOverlayStatus,
+} from "../domain/statusOverlayContract";
+
+export const STATUS_OVERLAY_UI_PROJECTION = "STATUS-OVERLAY-UI-V1" as const;
+
+/** Visual tone — never maps UNKNOWN/HOLD/FAILED/OUTCOME_UNKNOWN to success. */
+export type StatusOverlayTone =
+  | "current"
+  | "action"
+  | "maintenance"
+  | "ready"
+  | "stale"
+  | "hold"
+  | "failed"
+  | "outcome-unknown"
+  | "unknown"
+  | "neutral";
+
+export interface StatusOverlayPrView {
+  number: number;
+  title: string;
+  draft: boolean;
+  classification: string;
+  ciState: string;
+  reviewState: string;
+  url: string;
+  isActiveRefresh: boolean;
+}
+
+export interface StatusOverlayViewModel {
+  schemaVersion: typeof STATUS_OVERLAY_UI_PROJECTION;
+  sectionOrder: readonly [
+    "CURRENT",
+    "GATE",
+    "NEXT",
+    "AUTOMATION",
+    "HOLDS",
+    "UNKNOWNS",
+    "PRS",
+  ];
+  current: {
+    repository: string;
+    mainSha: string;
+    observedAt: string;
+    snapshotLabel: string;
+    snapshotClassification: string;
+    coverage: string;
+    tone: StatusOverlayTone;
+  };
+  gate: {
+    kind: StatusOverlayGateKind;
+    kindLabel: string;
+    summary: string;
+    tone: StatusOverlayTone;
+  };
+  next: {
+    code: string;
+    status: StatusOverlayStatus;
+    summary: string;
+    targetPr: number | null;
+    targetPrUrl: string | null;
+    authorizesMutation: false;
+    authorizationNote: string;
+    secondaryContext: string[];
+    tone: StatusOverlayTone;
+  };
+  automation: {
+    enabledLabel: string;
+    trigger: string;
+    lastRunId: string;
+    lastRunConclusion: string;
+    lastEvaluation: string;
+    lastPublicationOutcome: string;
+    activeRefreshPr: number | null;
+    activeRefreshPrUrl: string | null;
+    tone: StatusOverlayTone;
+  };
+  holds: {
+    items: string[];
+    empty: boolean;
+    emptyLabel: "none";
+    tone: StatusOverlayTone;
+  };
+  unknowns: {
+    items: string[];
+    empty: boolean;
+    emptyLabel: "none";
+    tone: StatusOverlayTone;
+  };
+  pullRequests: StatusOverlayPrView[];
+}
+
+function githubPrUrl(repository: string, number: number): string {
+  return `https://github.com/${repository}/pull/${number}`;
+}
+
+function shortSha(sha: string | null | undefined): string {
+  if (!sha) return "UNKNOWN";
+  return sha.length > 12 ? `${sha.slice(0, 12)}…` : sha;
+}
+
+function gateKindLabel(kind: StatusOverlayGateKind): string {
+  switch (kind) {
+    case "HumanActionRequired":
+      return "Human action required";
+    case "SystemMaintenanceRequired":
+      return "System maintenance required";
+    case "NoAction":
+      return "No action";
+    case "Unknown":
+      return "Unknown";
+  }
+}
+
+function toneForStatus(status: StatusOverlayStatus): StatusOverlayTone {
+  switch (status) {
+    case "CURRENT":
+    case "NO_ACTION":
+      return "current";
+    case "READY":
+      return "ready";
+    case "STALE":
+      return "stale";
+    case "HOLD":
+      return "hold";
+    case "FAILED":
+      return "failed";
+    case "OUTCOME_UNKNOWN":
+      return "outcome-unknown";
+    case "UNKNOWN":
+      return "unknown";
+    case "ACTION_REQUIRED":
+      return "action";
+  }
+}
+
+function toneForGate(kind: StatusOverlayGateKind): StatusOverlayTone {
+  switch (kind) {
+    case "HumanActionRequired":
+      return "action";
+    case "SystemMaintenanceRequired":
+      return "maintenance";
+    case "NoAction":
+      return "current";
+    case "Unknown":
+      return "unknown";
+  }
+}
+
+function snapshotLabel(doc: StatusOverlayDocument): string {
+  if (doc.snapshot.stale === false) return "CURRENT";
+  if (doc.snapshot.stale === true) return "STALE";
+  return "UNKNOWN";
+}
+
+function primaryGate(doc: StatusOverlayDocument): {
+  kind: StatusOverlayGateKind;
+  summary: string;
+} {
+  const fromNext = doc.recommendedNextAction.gateKind;
+  const match = doc.humanGates.find((g) => g.kind === fromNext);
+  return {
+    kind: fromNext,
+    summary: match?.summary ?? doc.recommendedNextAction.summary,
+  };
+}
+
+/**
+ * Build a deterministic read-only view-model from a StatusOverlayDocument.
+ */
+export function buildStatusOverlayViewModel(
+  document: StatusOverlayDocument,
+): StatusOverlayViewModel {
+  const gate = primaryGate(document);
+  const next = document.recommendedNextAction;
+  const targetPr = next.targets?.pullRequest ?? null;
+  const activeRefreshPr = document.autoRefresh.activeRefreshPr;
+
+  const holds = [...document.holds];
+  const unknowns = [...document.unknowns];
+
+  return {
+    schemaVersion: STATUS_OVERLAY_UI_PROJECTION,
+    sectionOrder: ["CURRENT", "GATE", "NEXT", "AUTOMATION", "HOLDS", "UNKNOWNS", "PRS"],
+    current: {
+      repository: document.repository,
+      mainSha: shortSha(document.main.sha),
+      observedAt: document.observedAt,
+      snapshotLabel: snapshotLabel(document),
+      snapshotClassification: document.snapshot.staleClassification ?? "UNKNOWN",
+      coverage: document.snapshot.autoRefreshCoverage,
+      tone:
+        document.snapshot.stale === null
+          ? "unknown"
+          : document.snapshot.stale
+            ? "stale"
+            : "current",
+    },
+    gate: {
+      kind: gate.kind,
+      kindLabel: gateKindLabel(gate.kind),
+      summary: gate.summary,
+      tone: toneForGate(gate.kind),
+    },
+    next: {
+      code: next.code,
+      status: next.status,
+      summary: next.summary,
+      targetPr,
+      targetPrUrl:
+        targetPr != null ? githubPrUrl(document.repository, targetPr) : null,
+      authorizesMutation: false,
+      authorizationNote: "Recommendation does not authorize mutation",
+      secondaryContext: [...(next.secondaryContext ?? [])],
+      tone: toneForStatus(next.status),
+    },
+    automation: {
+      enabledLabel: document.autoRefresh.enabled ? "ENABLED" : "DISABLED",
+      trigger: document.autoRefresh.trigger ?? "UNKNOWN",
+      lastRunId: document.autoRefresh.lastRunId ?? "none",
+      lastRunConclusion: document.autoRefresh.lastRunConclusion ?? "UNKNOWN",
+      lastEvaluation: document.autoRefresh.lastEvaluation ?? "UNKNOWN",
+      lastPublicationOutcome: document.autoRefresh.lastPublicationOutcome ?? "UNKNOWN",
+      activeRefreshPr,
+      activeRefreshPrUrl:
+        activeRefreshPr != null
+          ? githubPrUrl(document.repository, activeRefreshPr)
+          : null,
+      tone:
+        document.autoRefresh.lastRunConclusion === "failure" ||
+        document.autoRefresh.lastRunConclusion === "FAILED"
+          ? "failed"
+          : document.autoRefresh.lastRunConclusion === "UNKNOWN"
+            ? "unknown"
+            : "neutral",
+    },
+    holds: {
+      items: holds,
+      empty: holds.length === 0,
+      emptyLabel: "none",
+      tone: holds.length > 0 ? "hold" : "neutral",
+    },
+    unknowns: {
+      items: unknowns,
+      empty: unknowns.length === 0,
+      emptyLabel: "none",
+      tone: unknowns.length > 0 ? "unknown" : "neutral",
+    },
+    pullRequests: document.pullRequests.map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      draft: pr.draft,
+      classification: pr.classification,
+      ciState: pr.ciState,
+      reviewState: pr.reviewState,
+      url: githubPrUrl(document.repository, pr.number),
+      isActiveRefresh: activeRefreshPr === pr.number,
+    })),
+  };
+}
+
+/**
+ * Deterministic compact Markdown projection (no Date.now / network).
+ * Section order matches Issue #35 UI contract.
+ */
+export function renderStatusOverlayMarkdown(document: StatusOverlayDocument): string {
+  const vm = buildStatusOverlayViewModel(document);
+  const lines: string[] = [
+    "# STATUS-OVERLAY",
+    "",
+    "## CURRENT",
+    `- repository: ${vm.current.repository}`,
+    `- main: ${vm.current.mainSha}`,
+    `- observedAt: ${vm.current.observedAt}`,
+    `- snapshot: ${vm.current.snapshotLabel} (${vm.current.snapshotClassification})`,
+    `- autoRefreshCoverage: ${vm.current.coverage}`,
+    "",
+    "## GATE",
+    `- kind: ${vm.gate.kind}`,
+    `- label: ${vm.gate.kindLabel}`,
+    `- summary: ${vm.gate.summary}`,
+    "",
+    "## NEXT",
+    `- code: ${vm.next.code}`,
+    `- status: ${vm.next.status}`,
+    `- summary: ${vm.next.summary}`,
+    `- targetPr: ${vm.next.targetPr ?? "none"}`,
+    `- authorizesMutation: false`,
+    `- note: ${vm.next.authorizationNote}`,
+  ];
+  if (vm.next.secondaryContext.length > 0) {
+    lines.push("- secondary:");
+    for (const item of vm.next.secondaryContext) {
+      lines.push(`  - ${item}`);
+    }
+  }
+  lines.push(
+    "",
+    "## AUTOMATION",
+    `- enabled: ${vm.automation.enabledLabel}`,
+    `- trigger: ${vm.automation.trigger}`,
+    `- lastRunId: ${vm.automation.lastRunId}`,
+    `- lastRunConclusion: ${vm.automation.lastRunConclusion}`,
+    `- lastEvaluation: ${vm.automation.lastEvaluation}`,
+    `- lastPublicationOutcome: ${vm.automation.lastPublicationOutcome}`,
+    `- activeRefreshPr: ${vm.automation.activeRefreshPr ?? "none"}`,
+    "",
+    "## HOLDS",
+  );
+  if (vm.holds.empty) {
+    lines.push(`- ${vm.holds.emptyLabel}`);
+  } else {
+    for (const item of vm.holds.items) lines.push(`- ${item}`);
+  }
+  lines.push("", "## UNKNOWNS");
+  if (vm.unknowns.empty) {
+    lines.push(`- ${vm.unknowns.emptyLabel}`);
+  } else {
+    for (const item of vm.unknowns.items) lines.push(`- ${item}`);
+  }
+  lines.push("", "## PRS");
+  if (vm.pullRequests.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const pr of vm.pullRequests) {
+      lines.push(
+        `- #${pr.number} [${pr.draft ? "DRAFT" : "READY"}|${pr.classification}] ${pr.title} (CI=${pr.ciState}, Review=${pr.reviewState}${pr.isActiveRefresh ? ", activeRefresh" : ""})`,
+      );
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -8,7 +8,7 @@ body { margin: 0; min-width: 320px; min-height: 100vh; }
 button, input, textarea, select { font: inherit; }
 .shell { width: min(100%, 720px); margin: 0 auto; padding: 20px 16px 48px; }
 .action-card, .status-card, .details-card, .approval-intent-card,
-.ledger-record-card, .ledger-history-card {
+.ledger-record-card, .ledger-history-card, .status-overlay-card {
   background: #fff;
   border: 1px solid #dfe5dc;
   border-radius: 20px;
@@ -119,3 +119,53 @@ summary { cursor: pointer; font-weight: 700; }
   .shell { padding-top: 40px; }
   .action-card { padding: 32px; }
 }
+
+/* STATUS-OVERLAY-V1 read-only projection */
+.status-overlay-card { margin-top: 16px; padding: 20px; }
+.status-overlay-header { margin-bottom: 12px; }
+.status-overlay-note { margin: 0; color: #5f675f; line-height: 1.55; }
+.status-overlay-section { margin-top: 16px; padding-top: 14px; border-top: 1px solid #edf0eb; }
+.status-overlay-section h3 { margin: 0 0 10px; font-size: 0.95rem; letter-spacing: 0.04em; }
+.status-overlay-summary { margin: 8px 0 0; line-height: 1.55; }
+.status-overlay-auth { margin: 10px 0 0; font-size: 0.9rem; color: #5f675f; }
+.status-overlay-secondary { margin: 10px 0 0; padding-left: 18px; color: #5f675f; }
+.status-overlay-empty { margin: 0; color: #657066; font-style: italic; }
+.status-overlay-pr-list { list-style: none; margin: 0; padding: 0; }
+.status-overlay-pr-list li { padding: 10px 0; border-top: 1px solid #edf0eb; }
+.status-overlay-pr-list li:first-child { border-top: 0; }
+.status-overlay-pr-meta { margin-top: 4px; color: #657066; font-size: 0.85rem; }
+.status-overlay-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+.tone-current .status-overlay-badge,
+.status-overlay-badge.tone-current { background: #e7efe6; border-color: #355d3a; color: #27462b; }
+.tone-action .status-overlay-badge,
+.status-overlay-badge.tone-action { background: #e8eef8; border-color: #35557a; color: #243852; }
+.tone-maintenance .status-overlay-badge,
+.status-overlay-badge.tone-maintenance { background: #f3eee6; border-color: #8a6a3a; color: #5a4320; }
+.tone-ready .status-overlay-badge,
+.status-overlay-badge.tone-ready { background: #e7efe6; border-color: #355d3a; color: #27462b; }
+.tone-stale .status-overlay-badge,
+.status-overlay-badge.tone-stale { background: #fff3e0; border-color: #b36b00; color: #6b4200; }
+.tone-hold .status-overlay-badge,
+.status-overlay-badge.tone-hold { background: #fff9eb; border-color: #8a722a; color: #5c4a14; }
+.tone-failed .status-overlay-badge,
+.status-overlay-badge.tone-failed { background: #fdf1f0; border-color: #a25050; color: #6d2d2d; }
+.tone-outcome-unknown .status-overlay-badge,
+.status-overlay-badge.tone-outcome-unknown { background: #f5eef8; border-color: #6b4f7a; color: #3f2d4a; }
+.tone-unknown .status-overlay-badge,
+.status-overlay-badge.tone-unknown { background: #eef1ec; border-color: #758078; color: #3f463f; }
+.tone-neutral .status-overlay-badge,
+.status-overlay-badge.tone-neutral { background: #f8faf6; border-color: #c9d2c6; color: #3c463d; }
+.status-overlay-section.tone-unknown { border-left: 4px solid #758078; padding-left: 12px; }
+.status-overlay-section.tone-hold { border-left: 4px solid #8a722a; padding-left: 12px; }
+.status-overlay-section.tone-failed { border-left: 4px solid #a25050; padding-left: 12px; }
+.status-overlay-section.tone-outcome-unknown { border-left: 4px solid #6b4f7a; padding-left: 12px; }
+.status-overlay-section.tone-maintenance { border-left: 4px solid #8a6a3a; padding-left: 12px; }
+.status-overlay-section.tone-action { border-left: 4px solid #35557a; padding-left: 12px; }
+.status-overlay-section.tone-current { border-left: 4px solid #355d3a; padding-left: 12px; }

--- a/test/statusOverlayContract.test.ts
+++ b/test/statusOverlayContract.test.ts
@@ -50,20 +50,21 @@ function readyPr(n: number): StatusOverlayPullRequest {
 }
 
 describe("STATUS-OVERLAY-V1 design contract", () => {
-  it("marks runtime generator implemented while UI/full product stay off", () => {
+  it("marks generator and UI implemented while full product/writer stay off", () => {
     expect(STATUS_OVERLAY_SCHEMA_VERSION).toBe("STATUS-OVERLAY-V1");
     expect(STATUS_OVERLAY_GENERATOR_IMPLEMENTED).toBe(true);
-    expect(STATUS_OVERLAY_UI_IMPLEMENTED).toBe(false);
+    expect(STATUS_OVERLAY_UI_IMPLEMENTED).toBe(true);
     expect(STATUS_OVERLAY_IMPLEMENTED).toBe(false);
     expect(() => assertStatusOverlayNotImplemented()).not.toThrow();
     expect(proposedStatusOverlayStoragePath()).toBe("docs/status/status-overlay.json");
     expect(STATUS_OVERLAY_MARKDOWN_SECTIONS).toEqual([
       "CURRENT",
       "GATE",
+      "NEXT",
       "AUTOMATION",
       "HOLDS",
-      "UNKNOWN",
-      "NEXT",
+      "UNKNOWNS",
+      "PRS",
     ]);
   });
 

--- a/test/statusOverlayGenerator.test.ts
+++ b/test/statusOverlayGenerator.test.ts
@@ -93,9 +93,9 @@ function readyPr(n: number): StatusOverlayPullRequest {
 }
 
 describe("STATUS-OVERLAY-V1 runtime generator", () => {
-  it("marks generator implemented and UI not implemented", () => {
+  it("marks generator implemented (UI projection is separate)", () => {
     expect(STATUS_OVERLAY_GENERATOR_IMPLEMENTED).toBe(true);
-    expect(STATUS_OVERLAY_UI_IMPLEMENTED).toBe(false);
+    expect(STATUS_OVERLAY_UI_IMPLEMENTED).toBe(true);
   });
 
   it("produces a deterministic full document for identical inputs", () => {

--- a/test/statusOverlayViewModel.test.ts
+++ b/test/statusOverlayViewModel.test.ts
@@ -1,0 +1,291 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  STATUS_OVERLAY_MARKDOWN_SECTIONS,
+  STATUS_OVERLAY_UI_IMPLEMENTED,
+  type StatusOverlayDocument,
+  type StatusOverlayPullRequest,
+} from "../src/domain/statusOverlayContract";
+import {
+  generateStatusOverlay,
+  type StatusOverlayGeneratorInput,
+} from "../src/domain/statusOverlayGenerator";
+import {
+  buildStatusOverlayViewModel,
+  renderStatusOverlayMarkdown,
+} from "../src/ui/statusOverlayViewModel";
+
+const repo = "yasutakesougo/ai-development-control-center";
+const observedAt = "2026-08-12T05:00:00.000Z";
+const main = "58064f0fa7c99a6f9f6492095db4ef87c9cab553";
+const from = "78a72b13965d7b4fc4ce021d0aaa08a40eb17aa0";
+
+function designDraft(n: number): StatusOverlayPullRequest {
+  return {
+    number: n,
+    title: "docs(status): design STATUS-OVERLAY-V1",
+    draft: true,
+    mergeable: "UNKNOWN",
+    head: "aaa",
+    base: "main",
+    reviewState: "UNKNOWN",
+    ciState: "UNKNOWN",
+    classification: "DESIGN",
+    humanAction: "REVIEW_DRAFT",
+  };
+}
+
+function refreshDraft(n: number): StatusOverlayPullRequest {
+  return {
+    number: n,
+    title: "docs(architecture): refresh Snapshot",
+    draft: true,
+    mergeable: "UNKNOWN",
+    head: "bbb",
+    base: "main",
+    reviewState: "UNKNOWN",
+    ciState: "UNKNOWN",
+    classification: "REFRESH_DRAFT",
+    humanAction: "REVIEW_DRAFT",
+  };
+}
+
+function readyPr(n: number): StatusOverlayPullRequest {
+  return {
+    number: n,
+    title: "ready work",
+    draft: false,
+    mergeable: true,
+    head: "ccc",
+    base: "main",
+    reviewState: "UNKNOWN",
+    ciState: "UNKNOWN",
+    classification: "OTHER",
+    humanAction: "DECIDE_MERGE",
+  };
+}
+
+function docFrom(partial: Partial<StatusOverlayGeneratorInput> = {}): StatusOverlayDocument {
+  return generateStatusOverlay({
+    repository: repo,
+    observedAt,
+    currentMain: main,
+    snapshot: {
+      generatedFrom: from,
+      stale: false,
+      staleClassification: "current",
+      architectureRelevantChanges: [],
+    },
+    handoff: { nextActionStatus: "NO_ACTION", staleClassification: "current" },
+    autoRefresh: {
+      enabled: true,
+      trigger: "push_main+workflow_dispatch",
+      lastRunId: "1",
+      lastRunConclusion: "success",
+      lastEvaluation: "NOT_REQUIRED",
+      lastPublicationOutcome: "NO_PUBLICATION",
+    },
+    openPullRequests: [],
+    ...partial,
+  });
+}
+
+describe("STATUS-OVERLAY-V1 UI projection", () => {
+  it("marks UI implemented", () => {
+    expect(STATUS_OVERLAY_UI_IMPLEMENTED).toBe(true);
+    expect(STATUS_OVERLAY_MARKDOWN_SECTIONS).toEqual([
+      "CURRENT",
+      "GATE",
+      "NEXT",
+      "AUTOMATION",
+      "HOLDS",
+      "UNKNOWNS",
+      "PRS",
+    ]);
+  });
+
+  it("CURRENT / NO_ACTION", () => {
+    const doc = docFrom({});
+    const vm = buildStatusOverlayViewModel(doc);
+    expect(vm.next.code).toBe("NO_ACTION");
+    expect(vm.next.tone).toBe("current");
+    expect(vm.gate.kind).toBe("NoAction");
+    expect(vm.current.snapshotLabel).toBe("CURRENT");
+    expect(vm.holds.empty).toBe(true);
+    expect(vm.holds.emptyLabel).toBe("none");
+    expect(vm.unknowns.empty).toBe(true);
+    expect(vm.unknowns.emptyLabel).toBe("none");
+  });
+
+  it("Draft review", () => {
+    const vm = buildStatusOverlayViewModel(
+      docFrom({ openPullRequests: [designDraft(41)] }),
+    );
+    expect(vm.next.code).toBe("REVIEW_DRAFT_PR");
+    expect(vm.gate.kind).toBe("HumanActionRequired");
+    expect(vm.gate.kindLabel).toBe("Human action required");
+    expect(vm.next.targetPr).toBe(41);
+    expect(vm.next.targetPrUrl).toBe(`https://github.com/${repo}/pull/41`);
+  });
+
+  it("Ready merge-decision", () => {
+    const vm = buildStatusOverlayViewModel(docFrom({ openPullRequests: [readyPr(55)] }));
+    expect(vm.next.code).toBe("DECIDE_MERGE_READY_PR");
+    expect(vm.next.status).toBe("READY");
+    expect(vm.next.tone).toBe("ready");
+    expect(vm.next.targetPr).toBe(55);
+  });
+
+  it("SystemMaintenanceRequired stale Snapshot", () => {
+    const vm = buildStatusOverlayViewModel(
+      docFrom({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        handoff: {
+          nextActionStatus: "NO_ACTION",
+          staleClassification: "stale_architecture_affecting",
+        },
+        autoRefresh: { enabled: false },
+        openPullRequests: [designDraft(30)],
+      }),
+    );
+    expect(vm.next.code).toBe("MAINTAIN_STALE_SNAPSHOT");
+    expect(vm.gate.kind).toBe("SystemMaintenanceRequired");
+    expect(vm.gate.kindLabel).toBe("System maintenance required");
+    expect(vm.gate.tone).toBe("maintenance");
+    expect(vm.current.snapshotLabel).toBe("STALE");
+    expect(vm.current.tone).toBe("stale");
+  });
+
+  it("HOLD is not downplayed as success", () => {
+    const vm = buildStatusOverlayViewModel(
+      docFrom({ safetyHold: true, holdReason: "token scope HOLD" }),
+    );
+    expect(vm.next.code).toBe("RESOLVE_HOLD");
+    expect(vm.next.tone).toBe("hold");
+    expect(vm.holds.items).toContain("token scope HOLD");
+    expect(vm.holds.tone).toBe("hold");
+    expect(vm.next.tone).not.toBe("current");
+  });
+
+  it("OUTCOME_UNKNOWN is distinct", () => {
+    const vm = buildStatusOverlayViewModel(docFrom({ outcomeUnknown: true }));
+    expect(vm.next.code).toBe("RESOLVE_OUTCOME_UNKNOWN");
+    expect(vm.next.status).toBe("OUTCOME_UNKNOWN");
+    expect(vm.next.tone).toBe("outcome-unknown");
+    expect(vm.next.tone).not.toBe("current");
+  });
+
+  it("FAILED automation", () => {
+    const vm = buildStatusOverlayViewModel(docFrom({ automationFailed: true }));
+    expect(vm.next.code).toBe("REVIEW_FAILED_AUTOMATION");
+    expect(vm.next.status).toBe("FAILED");
+    expect(vm.next.tone).toBe("failed");
+  });
+
+  it("observation UNKNOWN", () => {
+    const vm = buildStatusOverlayViewModel(docFrom({ liveObservationFailed: true }));
+    expect(vm.next.code).toBe("UNKNOWN");
+    expect(vm.next.tone).toBe("unknown");
+    expect(vm.gate.kind).toBe("Unknown");
+    expect(vm.gate.tone).toBe("unknown");
+  });
+
+  it("workflow observation UNKNOWN", () => {
+    const vm = buildStatusOverlayViewModel(
+      docFrom({
+        workflowObservationFailed: true,
+        openPullRequests: [designDraft(30)],
+      }),
+    );
+    expect(vm.next.code).toBe("UNKNOWN");
+    expect(vm.next.tone).toBe("unknown");
+    expect(vm.next.code).not.toBe("RESOLVE_OUTCOME_UNKNOWN");
+    expect(vm.next.code).not.toBe("REVIEW_DRAFT_PR");
+  });
+
+  it("active refresh Draft", () => {
+    const vm = buildStatusOverlayViewModel(
+      docFrom({
+        snapshot: {
+          generatedFrom: from,
+          stale: true,
+          staleClassification: "stale_architecture_affecting",
+          architectureRelevantChanges: ["package.json"],
+        },
+        handoff: {
+          nextActionStatus: "NO_ACTION",
+          staleClassification: "stale_architecture_affecting",
+        },
+        autoRefresh: {
+          enabled: true,
+          activeRefreshPr: 44,
+          lastPublicationOutcome: "DRAFT_CREATED",
+        },
+        openPullRequests: [designDraft(30), refreshDraft(44)],
+      }),
+    );
+    expect(vm.automation.activeRefreshPr).toBe(44);
+    expect(vm.automation.activeRefreshPrUrl).toBe(`https://github.com/${repo}/pull/44`);
+    expect(vm.pullRequests.find((p) => p.number === 44)?.isActiveRefresh).toBe(true);
+    expect(vm.next.code).toBe("REVIEW_DRAFT_PR");
+    expect(vm.next.targetPr).toBe(44);
+  });
+
+  it("authorizesMutation is always false and visible in markdown", () => {
+    const doc = docFrom({ openPullRequests: [readyPr(9)] });
+    const vm = buildStatusOverlayViewModel(doc);
+    expect(vm.next.authorizesMutation).toBe(false);
+    const md = renderStatusOverlayMarkdown(doc);
+    expect(md).toContain("authorizesMutation: false");
+    expect(md).toContain("Recommendation does not authorize mutation");
+  });
+
+  it("deterministic view-model and markdown for identical document", () => {
+    const doc = docFrom({
+      openPullRequests: [designDraft(12), readyPr(13)],
+      unknowns: ["sample_unknown"],
+      holds: ["sample_hold"],
+    });
+    expect(buildStatusOverlayViewModel(doc)).toEqual(buildStatusOverlayViewModel(doc));
+    expect(renderStatusOverlayMarkdown(doc)).toBe(renderStatusOverlayMarkdown(doc));
+    const md = renderStatusOverlayMarkdown(doc);
+    expect(md.indexOf("## CURRENT")).toBeLessThan(md.indexOf("## GATE"));
+    expect(md.indexOf("## GATE")).toBeLessThan(md.indexOf("## NEXT"));
+    expect(md.indexOf("## NEXT")).toBeLessThan(md.indexOf("## AUTOMATION"));
+    expect(md.indexOf("## HOLDS")).toBeLessThan(md.indexOf("## UNKNOWNS"));
+    expect(md).toContain("- sample_hold");
+    expect(md).toContain("- sample_unknown");
+  });
+
+  it("empty holds / unknowns render explicit none", () => {
+    const md = renderStatusOverlayMarkdown(docFrom({}));
+    expect(md).toMatch(/## HOLDS\n- none/);
+    expect(md).toMatch(/## UNKNOWNS\n- none/);
+  });
+
+  it("UI modules have no mutation controls or mutation client imports", () => {
+    const viewModel = readFileSync(
+      new URL("../src/ui/statusOverlayViewModel.ts", import.meta.url),
+      "utf8",
+    );
+    const panel = readFileSync(
+      new URL("../src/ui/StatusOverlayPanel.tsx", import.meta.url),
+      "utf8",
+    );
+    for (const source of [viewModel, panel]) {
+      expect(source).not.toMatch(/\bfetch\s*\(/);
+      expect(source).not.toMatch(/\bDate\.now\s*\(/);
+      expect(source).not.toMatch(/new\s+Date\s*\(/);
+      expect(source).not.toMatch(/postLedgerRecord|ledgerApi|ActionGateway|octokit/i);
+      expect(source).not.toMatch(/observeStatusOverlayGithub/);
+      expect(source).not.toMatch(/<button/i);
+      expect(source).not.toMatch(/\bonClick\b/);
+      expect(source).not.toMatch(/Ready|Merge|createPullRequest/);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the read-only **STATUS-OVERLAY-V1 UI Projection** authorized by Issue #35.

```
StatusOverlayDocument
  → buildStatusOverlayViewModel / renderStatusOverlayMarkdown
  → <StatusOverlayPanel />
```

Closes #35

---

## Baseline

| Item | Value |
|---|---|
| Expected main | `58064f0fa7c99a6f9f6492095db4ef87c9cab553` |
| Observed main before implementation | `58064f0fa7c99a6f9f6492095db4ef87c9cab553` (MATCH) |
| Branch | `cursor/status-overlay-ui-2c83` |

---

## Changed files

- `src/ui/statusOverlayViewModel.ts` (new)
- `src/ui/StatusOverlayPanel.tsx` (new)
- `src/ui/App.tsx` (optional `statusOverlay` prop; display-only mount)
- `src/ui/styles.css`
- `src/domain/statusOverlayContract.ts` (UI flag + section order)
- `test/statusOverlayViewModel.test.ts` (new)
- docs pointers

---

## UI contract

Renders compact sections:

`CURRENT` · `GATE` · `NEXT` · `AUTOMATION` · `HOLDS` · `UNKNOWNS` · `PRS`

Guarantees:
- Consumes only `StatusOverlayDocument` (no GitHub/workflow observe in UI)
- Exactly one primary NEXT action
- `authorizesMutation: false` shown explicitly
- UNKNOWN / HOLD / OUTCOME_UNKNOWN / FAILED visually distinct from CURRENT / NO_ACTION
- HumanActionRequired vs SystemMaintenanceRequired distinguishable
- Empty holds/unknowns render explicit `none`
- No `Date.now()`, fetch, buttons, Ready/Merge/Ledger/Gateway imports in UI modules

App integration: optional `statusOverlay` prop only — UI never fetches overlay evidence itself.

---

## Verification

```
npm run verify
→ typecheck PASS
→ 272 tests PASS (22 files)
→ build PASS
```

---

## Explicit non-goals (still NOT IMPLEMENTED)

| Item | Status |
|---|---|
| Repository-file writer | NOT IMPLEMENTED |
| HISTORY writer | NOT IMPLEMENTED |
| Action Gateway | NOT IMPLEMENTED |
| Approval Ledger write (via overlay) | NOT IMPLEMENTED |
| Agent execution | NOT IMPLEMENTED |
| GitHub mutation from overlay UI | NOT IMPLEMENTED |

**Stop at Draft.** Fresh Review on new HEAD. Do not mark Ready. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff3bd-613c-7d0a-b59d-d9615a722c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff3bd-613c-7d0a-b59d-d9615a722c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

