### PR TITLE
feat(status): wire STATUS-OVERLAY-V1 read-only runtime path

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -30,6 +30,7 @@ implemented** — see [`../history/history-v1.md`](../history/history-v1.md).
 No persistence writer is enabled.
 
 STATUS-OVERLAY-V1 is **designed**; Runtime Generator, read-only GitHub /
-workflow observer, and read-only UI projection are **implemented** — see
+workflow observer, read-only UI projection, and read-only runtime wiring are
+**implemented** — see
 [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
 Repository writer / Action Gateway binding remain not implemented.

--- a/docs/handoff/README.md
+++ b/docs/handoff/README.md
@@ -77,8 +77,8 @@ Historical events must not change HANDOFF decision semantics or manufacture
 `ACTION_REQUIRED`.
 
 STATUS-OVERLAY-V1 (current-state projection) is **designed**; Runtime Generator,
-read-only GitHub/workflow observer, and read-only UI projection are
-**implemented** — see
+read-only GitHub/workflow observer, read-only UI projection, and read-only
+runtime wiring are **implemented** — see
 [`../status/status-overlay-v1.md`](../status/status-overlay-v1.md).
 Overlay consumes HANDOFF output and must not redefine HANDOFF rules.
 Repository writer remains not implemented.

--- a/docs/status/status-overlay-v1.md
+++ b/docs/status/status-overlay-v1.md
@@ -17,6 +17,8 @@ Companion modules:
 - Runtime generator (pure): `src/domain/statusOverlayGenerator.ts`
 - Read-only observer: `src/observer/statusOverlayGithubObserver.ts`
 - Read-only UI: `src/ui/statusOverlayViewModel.ts`, `src/ui/StatusOverlayPanel.tsx`
+- Read-only runtime wiring: `src/runtime/statusOverlayRuntime.ts`,
+  `src/ui/StatusOverlayRuntimeContainer.tsx`, `GET /api/status-overlay`
 
 STATUS-OVERLAY is **decision-support only**. It does **not** authorize
 mutation, Ready, Merge, Action Gateway, Agent execution, or Ledger writes.
@@ -31,8 +33,8 @@ read-only GitHub/workflow observer
   → UI projection (read-only)
 ```
 
-No repository-file writer / HISTORY writer in this slice. UI never observes
-GitHub itself and never exposes mutation controls.
+Runtime wiring orchestrates the same flow into `App(statusOverlay)` without
+adding writers or mutation controls.
 
 ---
 
@@ -407,5 +409,6 @@ false and is shown explicitly.
 | Repository-file writer | **NOT IMPLEMENTED** |
 | HISTORY writer | **NOT IMPLEMENTED** |
 | UI | **IMPLEMENTED** (read-only view-model + panel) |
+| Runtime wiring | **IMPLEMENTED** (`statusOverlayRuntime.ts` + `/api/status-overlay`) |
 | Action Gateway binding | **NOT IMPLEMENTED** |
 | Approval Ledger / Agent execution | **NOT IMPLEMENTED** |

--- a/src/runtime/statusOverlayRuntime.ts
+++ b/src/runtime/statusOverlayRuntime.ts
@@ -1,0 +1,181 @@
+/**
+ * STATUS-OVERLAY-V1 read-only runtime wiring.
+ *
+ * Orchestrates:
+ *   read-only observer → StatusOverlayGeneratorInput
+ *   → generateStatusOverlay() → StatusOverlayDocument
+ *
+ * Does not mutate GitHub, write repository/HISTORY files, invoke Action Gateway /
+ * Ledger / Agents, or redefine Generator decision semantics.
+ */
+
+import type { ArchitectureSnapshot } from "../domain/architectureSnapshot";
+import { isArchitectureSnapshot } from "../domain/architectureSnapshot";
+import type { HandoffReport } from "../domain/handoffReport";
+import type { StatusOverlayDocument } from "../domain/statusOverlayContract";
+import {
+  generateStatusOverlay,
+  type StatusOverlayGeneratorInput,
+} from "../domain/statusOverlayGenerator";
+import {
+  observeStatusOverlayGithub,
+  type StatusOverlayLocalObservation,
+  type StatusOverlayReadonlyGithubClient,
+} from "../observer/statusOverlayGithubObserver";
+
+export const STATUS_OVERLAY_RUNTIME_IMPLEMENTED = true as const;
+export const STATUS_OVERLAY_RUNTIME_DESIGN = "STATUS-OVERLAY-RUNTIME-V1" as const;
+
+/** Default repository for STATUS-OVERLAY observation. */
+export const STATUS_OVERLAY_DEFAULT_REPOSITORY =
+  "yasutakesougo/ai-development-control-center" as const;
+
+export type StatusOverlayRuntimePhase =
+  | "disabled"
+  | "loading"
+  | "ready"
+  | "unavailable";
+
+export interface StatusOverlayRuntimeResult {
+  phase: Exclude<StatusOverlayRuntimePhase, "disabled" | "loading">;
+  document: StatusOverlayDocument | null;
+  reason: string | null;
+}
+
+export interface StatusOverlayRuntimeDeps {
+  repository: string;
+  client: StatusOverlayReadonlyGithubClient;
+  local: StatusOverlayLocalObservation;
+  /** Called once per cycle; value is preserved through Generator into the document. */
+  now: () => string;
+  /** Optional injectables for tests — defaults to production observe/generate. */
+  observe?: typeof observeStatusOverlayGithub;
+  generate?: typeof generateStatusOverlay;
+}
+
+/**
+ * One observation cycle → one StatusOverlayDocument.
+ * Decision logic remains owned by the Generator.
+ */
+export async function runStatusOverlayCycle(
+  deps: StatusOverlayRuntimeDeps,
+): Promise<StatusOverlayDocument> {
+  const observe = deps.observe ?? observeStatusOverlayGithub;
+  const generate = deps.generate ?? generateStatusOverlay;
+
+  const input: StatusOverlayGeneratorInput = await observe({
+    repository: deps.repository,
+    client: deps.client,
+    local: deps.local,
+    now: deps.now,
+  });
+
+  const document = generate(input);
+  assertStatusOverlayRuntimeInvariants(document, input.observedAt);
+  return document;
+}
+
+/**
+ * Hard orchestration failure (before a trustworthy document exists).
+ * Surfaces explicit unavailable — never silent healthy/NO_ACTION.
+ */
+export function statusOverlayRuntimeUnavailable(
+  reason: string,
+): StatusOverlayRuntimeResult {
+  return {
+    phase: "unavailable",
+    document: null,
+    reason,
+  };
+}
+
+export function statusOverlayRuntimeReady(
+  document: StatusOverlayDocument,
+): StatusOverlayRuntimeResult {
+  assertStatusOverlayRuntimeInvariants(document, document.observedAt);
+  return {
+    phase: "ready",
+    document,
+    reason: null,
+  };
+}
+
+export function assertStatusOverlayRuntimeInvariants(
+  document: StatusOverlayDocument,
+  expectedObservedAt: string,
+): void {
+  if (document.observedAt !== expectedObservedAt) {
+    throw new Error("STATUS-OVERLAY observedAt must be preserved end-to-end");
+  }
+  if (document.recommendedNextAction.authorizesMutation !== false) {
+    throw new Error("STATUS-OVERLAY recommendedNextAction must not authorize mutation");
+  }
+  const serialized = JSON.stringify(document);
+  if (/bearer\s+[a-z0-9._\-]+/i.test(serialized) || /ghp_[a-zA-Z0-9]+/.test(serialized)) {
+    throw new Error("STATUS-OVERLAY document must not embed secrets/tokens");
+  }
+}
+
+/**
+ * Build local observation artifacts without GitHub mutation.
+ * When path deltas are unavailable, stale classification stays UNKNOWN (fail closed).
+ */
+export function buildStatusOverlayLocalObservation(input: {
+  snapshot: ArchitectureSnapshot | null;
+  handoff?: Pick<HandoffReport, "nextAction" | "snapshot"> | null;
+  persistentWorkflowYaml?: string | null;
+  currentMain?: string | null;
+  architectureRelevantChanges?: string[] | null;
+  holds?: string[];
+  unknowns?: string[];
+}): StatusOverlayLocalObservation {
+  const generatedFrom = input.snapshot?.generatedFrom.commit ?? null;
+  const currentMain = input.currentMain ?? null;
+  const pathSet = input.architectureRelevantChanges;
+
+  let snapshotStale: boolean | null = null;
+  let snapshotStaleClassification: string | null = "UNKNOWN";
+
+  if (input.handoff?.snapshot?.classification) {
+    snapshotStaleClassification = input.handoff.snapshot.classification;
+    snapshotStale =
+      input.handoff.snapshot.classification === "current"
+        ? false
+        : input.handoff.snapshot.classification === "UNKNOWN"
+          ? null
+          : true;
+  } else if (generatedFrom && currentMain) {
+    if (generatedFrom === currentMain) {
+      snapshotStale = false;
+      snapshotStaleClassification = "current";
+    } else if (pathSet == null) {
+      snapshotStale = null;
+      snapshotStaleClassification = "UNKNOWN";
+    } else if (pathSet.length > 0) {
+      snapshotStale = true;
+      snapshotStaleClassification = "stale_architecture_affecting";
+    } else {
+      snapshotStale = true;
+      snapshotStaleClassification = "stale_no_architecture_impact";
+    }
+  }
+
+  const handoffStatus = input.handoff?.nextAction?.status ?? "NO_ACTION";
+
+  return {
+    snapshotGeneratedFrom: generatedFrom,
+    snapshotStale,
+    snapshotStaleClassification,
+    architectureRelevantChanges: pathSet ?? [],
+    handoffNextActionStatus: handoffStatus,
+    handoffStaleClassification:
+      input.handoff?.snapshot?.classification ?? snapshotStaleClassification,
+    persistentWorkflowYaml: input.persistentWorkflowYaml ?? null,
+    holds: [...(input.holds ?? [])],
+    unknowns: [...(input.unknowns ?? [])],
+  };
+}
+
+export function parseArchitectureSnapshotJson(value: unknown): ArchitectureSnapshot | null {
+  return isArchitectureSnapshot(value) ? value : null;
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -16,6 +16,7 @@ import {
   type LedgerSubmissionState,
 } from "../domain/ledgerSubmission";
 import type { StatusOverlayDocument } from "../domain/statusOverlayContract";
+import type { StatusOverlayRuntimePhase } from "../runtime/statusOverlayRuntime";
 import { ApprovalIntentPanel } from "./ApprovalIntentPanel";
 import { fetchLedgerHistory, postLedgerRecord, type LedgerHistoryResult } from "./ledgerApi";
 import { LedgerHistoryPanel } from "./LedgerHistoryPanel";
@@ -61,9 +62,16 @@ export interface AppProps {
    * The UI never observes GitHub/workflow itself — callers supply the document.
    */
   statusOverlay?: StatusOverlayDocument | null;
+  /** Runtime wiring phase; defaults to disabled when omitted. */
+  statusOverlayPhase?: StatusOverlayRuntimePhase;
+  statusOverlayUnavailableReason?: string | null;
 }
 
-export function App({ statusOverlay = null }: AppProps = {}) {
+export function App({
+  statusOverlay = null,
+  statusOverlayPhase = "disabled",
+  statusOverlayUnavailableReason = null,
+}: AppProps = {}) {
   const [data, setData] = useState<StatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [intentDraft, setIntentDraft] = useState<ApprovalIntentDraft | null>(null);
@@ -167,7 +175,31 @@ export function App({ statusOverlay = null }: AppProps = {}) {
         </dl>
       </section>
 
-      {statusOverlay && <StatusOverlayPanel document={statusOverlay} />}
+      {statusOverlayPhase === "loading" && (
+        <section className="status-overlay-card" data-testid="status-overlay-loading">
+          <p className="eyebrow">STATUS-OVERLAY-V1</p>
+          <h2>Loading repository status</h2>
+          <p className="status-overlay-note">Read-only observation in progress.</p>
+        </section>
+      )}
+
+      {statusOverlayPhase === "unavailable" && (
+        <section
+          className="status-overlay-card tone-unknown"
+          data-testid="status-overlay-unavailable"
+        >
+          <p className="eyebrow">STATUS-OVERLAY-V1</p>
+          <h2>Status overlay unavailable</h2>
+          <p className="status-overlay-note">
+            {statusOverlayUnavailableReason ??
+              "STATUS-OVERLAY could not be loaded. This is not NO_ACTION."}
+          </p>
+        </section>
+      )}
+
+      {statusOverlay && statusOverlayPhase !== "loading" && (
+        <StatusOverlayPanel document={statusOverlay} />
+      )}
 
       {!loading && approvalAllowed && data && (
         <ApprovalIntentPanel

--- a/src/ui/StatusOverlayRuntimeContainer.tsx
+++ b/src/ui/StatusOverlayRuntimeContainer.tsx
@@ -1,0 +1,117 @@
+/**
+ * Thin STATUS-OVERLAY runtime container.
+ *
+ * Loads a StatusOverlayDocument through an injectable read-only loader and
+ * passes it into App. Observer/network logic stays outside StatusOverlayPanel.
+ */
+
+import { useEffect, useState, type ReactNode } from "react";
+import type { StatusOverlayDocument } from "../domain/statusOverlayContract";
+import type { StatusOverlayRuntimePhase } from "../runtime/statusOverlayRuntime";
+import { App } from "./App";
+
+export interface StatusOverlayRuntimeContainerProps {
+  /** When false/undefined, App runs without overlay (existing behavior). */
+  enabled?: boolean;
+  /**
+   * Injectable loader (tests / production fetch of /api/status-overlay).
+   * Must not perform GitHub mutation.
+   */
+  loadDocument?: () => Promise<StatusOverlayDocument>;
+  /** Optional App children override for tests. */
+  renderApp?: (props: {
+    statusOverlay: StatusOverlayDocument | null;
+    statusOverlayPhase: StatusOverlayRuntimePhase;
+    statusOverlayUnavailableReason: string | null;
+  }) => ReactNode;
+}
+
+export function StatusOverlayRuntimeContainer({
+  enabled = false,
+  loadDocument,
+  renderApp,
+}: StatusOverlayRuntimeContainerProps) {
+  const [phase, setPhase] = useState<StatusOverlayRuntimePhase>(
+    enabled ? "loading" : "disabled",
+  );
+  const [document, setDocument] = useState<StatusOverlayDocument | null>(null);
+  const [reason, setReason] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setPhase("disabled");
+      setDocument(null);
+      setReason(null);
+      return;
+    }
+    if (!loadDocument) {
+      setPhase("unavailable");
+      setDocument(null);
+      setReason("STATUS-OVERLAY runtime enabled but no loadDocument was configured");
+      return;
+    }
+
+    let cancelled = false;
+    setPhase("loading");
+    setReason(null);
+
+    void (async () => {
+      try {
+        const next = await loadDocument();
+        if (cancelled) return;
+        setDocument(next);
+        setPhase("ready");
+        setReason(null);
+      } catch (error) {
+        if (cancelled) return;
+        setDocument(null);
+        setPhase("unavailable");
+        setReason(
+          error instanceof Error
+            ? error.message
+            : "STATUS-OVERLAY runtime load failed",
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, loadDocument]);
+
+  if (renderApp) {
+    return (
+      <>
+        {renderApp({
+          statusOverlay: document,
+          statusOverlayPhase: phase,
+          statusOverlayUnavailableReason: reason,
+        })}
+      </>
+    );
+  }
+
+  return (
+    <App
+      statusOverlay={document}
+      statusOverlayPhase={phase}
+      statusOverlayUnavailableReason={reason}
+    />
+  );
+}
+
+/** Browser loader for the read-only worker endpoint. */
+export function createStatusOverlayApiLoader(
+  endpoint = "/api/status-overlay",
+): () => Promise<StatusOverlayDocument> {
+  return async () => {
+    const response = await fetch(endpoint, { cache: "no-store" });
+    if (response.status === 404) {
+      throw new Error("STATUS-OVERLAY runtime endpoint unavailable");
+    }
+    if (!response.ok) {
+      throw new Error(`STATUS-OVERLAY runtime request failed: ${response.status}`);
+    }
+    return (await response.json()) as StatusOverlayDocument;
+  };
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -1,10 +1,22 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { App } from "./App";
+import {
+  StatusOverlayRuntimeContainer,
+  createStatusOverlayApiLoader,
+} from "./StatusOverlayRuntimeContainer";
 import "./styles.css";
+
+/**
+ * Overlay runtime is enabled by default against the read-only worker endpoint.
+ * Set VITE_STATUS_OVERLAY_RUNTIME=false to keep legacy App-only behavior.
+ */
+const overlayEnabled = import.meta.env.VITE_STATUS_OVERLAY_RUNTIME !== "false";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <StatusOverlayRuntimeContainer
+      enabled={overlayEnabled}
+      loadDocument={overlayEnabled ? createStatusOverlayApiLoader() : undefined}
+    />
   </React.StrictMode>,
 );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -3,6 +3,7 @@ import { handleAuthStatus } from "./auth/authStatus";
 import { observeRepository } from "./github/readOnlyAdapter";
 import { handleLedgerRecordPost, handleLedgerRecordsGet, type LedgerApiEnv } from "./ledger/recordsApi";
 import { buildStatusPayload } from "./statusApi";
+import { handleStatusOverlayGet } from "./statusOverlayApi";
 
 interface Env extends LedgerApiEnv {
   ASSETS: { fetch(request: Request): Promise<Response> };
@@ -11,6 +12,8 @@ interface Env extends LedgerApiEnv {
   ACCESS_TEAM_DOMAIN?: string;
   /** Cloudflare Access application audience tag. Optional until Access is configured. */
   ACCESS_AUD?: string;
+  STATUS_OVERLAY_REPOSITORY?: string;
+  STATUS_OVERLAY_RUNTIME_ENABLED?: string;
 }
 
 const TARGET_REPOSITORY = "yasutakesougo/severe-behavior-support-spfx";
@@ -28,6 +31,10 @@ export default {
       const action = resolveHumanAction(facts);
       const payload = await buildStatusPayload(facts, action);
       return Response.json(payload, { headers: { "Cache-Control": "no-store" } });
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/status-overlay") {
+      return handleStatusOverlayGet(env);
     }
 
     if (url.pathname === "/api/ledger/records") {

--- a/src/worker/statusOverlayApi.ts
+++ b/src/worker/statusOverlayApi.ts
@@ -1,0 +1,111 @@
+/**
+ * Worker handler: read-only STATUS-OVERLAY runtime endpoint.
+ *
+ * GET /api/status-overlay → StatusOverlayDocument
+ * Uses only GET GitHub APIs via createStatusOverlayGithubHttpClient.
+ */
+
+import { PERSISTENT_WORKFLOW_PATH } from "../domain/persistentAutoRefreshContract";
+import type { HandoffReport } from "../domain/handoffReport";
+import { createStatusOverlayGithubHttpClient } from "../observer/statusOverlayGithubObserver";
+import {
+  STATUS_OVERLAY_DEFAULT_REPOSITORY,
+  buildStatusOverlayLocalObservation,
+  parseArchitectureSnapshotJson,
+  runStatusOverlayCycle,
+  statusOverlayRuntimeUnavailable,
+} from "../runtime/statusOverlayRuntime";
+
+export interface StatusOverlayApiEnv {
+  GITHUB_TOKEN?: string;
+  /** Optional override; defaults to ai-development-control-center. */
+  STATUS_OVERLAY_REPOSITORY?: string;
+  /** Set to "false" to disable the endpoint. */
+  STATUS_OVERLAY_RUNTIME_ENABLED?: string;
+}
+
+async function githubGetTextFile(
+  repository: string,
+  path: string,
+  token?: string,
+): Promise<string | null> {
+  const headers = new Headers({
+    Accept: "application/vnd.github.raw+json",
+    "User-Agent": "ai-development-control-center-status-overlay-runtime-v1",
+  });
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/contents/${path}`,
+    { method: "GET", headers },
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`GitHub GET contents/${path} failed: ${response.status}`);
+  }
+  return await response.text();
+}
+
+export async function handleStatusOverlayGet(
+  env: StatusOverlayApiEnv,
+): Promise<Response> {
+  if (env.STATUS_OVERLAY_RUNTIME_ENABLED === "false") {
+    return Response.json(
+      statusOverlayRuntimeUnavailable("STATUS-OVERLAY runtime disabled"),
+      { status: 404, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  const repository =
+    env.STATUS_OVERLAY_REPOSITORY?.trim() || STATUS_OVERLAY_DEFAULT_REPOSITORY;
+
+  try {
+    const client = createStatusOverlayGithubHttpClient({
+      GITHUB_TOKEN: env.GITHUB_TOKEN,
+    });
+    const tip = await client.getDefaultBranchTip(repository);
+
+    const [snapshotRaw, workflowYaml, handoffRaw] = await Promise.all([
+      githubGetTextFile(repository, "docs/architecture/architecture.json", env.GITHUB_TOKEN),
+      githubGetTextFile(repository, PERSISTENT_WORKFLOW_PATH, env.GITHUB_TOKEN),
+      githubGetTextFile(repository, "docs/handoff/handoff.json", env.GITHUB_TOKEN),
+    ]);
+
+    const snapshot = snapshotRaw
+      ? parseArchitectureSnapshotJson(JSON.parse(snapshotRaw) as unknown)
+      : null;
+    let handoff: HandoffReport | null = null;
+    if (handoffRaw) {
+      try {
+        handoff = JSON.parse(handoffRaw) as HandoffReport;
+      } catch {
+        handoff = null;
+      }
+    }
+
+    const local = buildStatusOverlayLocalObservation({
+      snapshot,
+      handoff,
+      persistentWorkflowYaml: workflowYaml,
+      currentMain: tip.sha,
+      architectureRelevantChanges: handoff?.snapshot.architectureRelevantPaths ?? null,
+    });
+
+    const document = await runStatusOverlayCycle({
+      repository,
+      client,
+      local,
+      now: () => new Date().toISOString(),
+    });
+
+    return Response.json(document, {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (error) {
+    const reason =
+      error instanceof Error ? error.message : "STATUS-OVERLAY runtime failed";
+    return Response.json(statusOverlayRuntimeUnavailable(reason), {
+      status: 503,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+}

--- a/src/worker/statusOverlayApi.ts
+++ b/src/worker/statusOverlayApi.ts
@@ -3,11 +3,16 @@
  *
  * GET /api/status-overlay → StatusOverlayDocument
  * Uses only GET GitHub APIs via createStatusOverlayGithubHttpClient.
+ *
+ * Unauthenticated access is fail-closed to the canonical public repository only.
  */
 
 import { PERSISTENT_WORKFLOW_PATH } from "../domain/persistentAutoRefreshContract";
 import type { HandoffReport } from "../domain/handoffReport";
-import { createStatusOverlayGithubHttpClient } from "../observer/statusOverlayGithubObserver";
+import {
+  createStatusOverlayGithubHttpClient,
+  type StatusOverlayReadonlyGithubClient,
+} from "../observer/statusOverlayGithubObserver";
 import {
   STATUS_OVERLAY_DEFAULT_REPOSITORY,
   buildStatusOverlayLocalObservation,
@@ -16,12 +21,41 @@ import {
   statusOverlayRuntimeUnavailable,
 } from "../runtime/statusOverlayRuntime";
 
+/** Canonical public repository allowed for unauthenticated STATUS-OVERLAY reads. */
+export const STATUS_OVERLAY_PUBLIC_REPOSITORY =
+  STATUS_OVERLAY_DEFAULT_REPOSITORY;
+
 export interface StatusOverlayApiEnv {
   GITHUB_TOKEN?: string;
   /** Optional override; defaults to ai-development-control-center. */
   STATUS_OVERLAY_REPOSITORY?: string;
   /** Set to "false" to disable the endpoint. */
   STATUS_OVERLAY_RUNTIME_ENABLED?: string;
+}
+
+export type StatusOverlayRepositoryGate =
+  | { allowed: true; repository: typeof STATUS_OVERLAY_PUBLIC_REPOSITORY }
+  | { allowed: false; repository: string; reason: string };
+
+/**
+ * Resolve the repository for unauthenticated /api/status-overlay.
+ * Only the canonical public control-center repository is permitted.
+ */
+export function resolveUnauthenticatedStatusOverlayRepository(
+  configured: string | undefined,
+): StatusOverlayRepositoryGate {
+  const repository = (configured?.trim() || STATUS_OVERLAY_PUBLIC_REPOSITORY).replace(
+    /^\/+|\/+$/g,
+    "",
+  );
+  if (repository === STATUS_OVERLAY_PUBLIC_REPOSITORY) {
+    return { allowed: true, repository: STATUS_OVERLAY_PUBLIC_REPOSITORY };
+  }
+  return {
+    allowed: false,
+    repository,
+    reason: `STATUS-OVERLAY unauthenticated access is limited to ${STATUS_OVERLAY_PUBLIC_REPOSITORY}; refused repository override: ${repository}`,
+  };
 }
 
 async function githubGetTextFile(
@@ -45,29 +79,77 @@ async function githubGetTextFile(
   return await response.text();
 }
 
+export interface StatusOverlayApiDeps {
+  createClient?: (env: { GITHUB_TOKEN?: string }) => StatusOverlayReadonlyGithubClient;
+  getTextFile?: (
+    repository: string,
+    path: string,
+    token?: string,
+  ) => Promise<string | null>;
+  runCycle?: typeof runStatusOverlayCycle;
+  now?: () => string;
+}
+
+function sanitizeUnavailableReason(reason: string): string {
+  return reason
+    .replace(/bearer\s+[a-z0-9._\-]+/gi, "bearer [REDACTED]")
+    .replace(/ghp_[a-zA-Z0-9]+/g, "[REDACTED_TOKEN]")
+    .replace(/github_pat_[a-zA-Z0-9_]+/g, "[REDACTED_TOKEN]");
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  const payload = JSON.stringify(body);
+  if (/ghp_[a-zA-Z0-9]+/i.test(payload) || /github_pat_[a-zA-Z0-9_]+/i.test(payload)) {
+    return Response.json(
+      statusOverlayRuntimeUnavailable("STATUS-OVERLAY refused to emit secret material"),
+      { status: 500, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  return new Response(payload, {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
 export async function handleStatusOverlayGet(
   env: StatusOverlayApiEnv,
+  deps: StatusOverlayApiDeps = {},
 ): Promise<Response> {
   if (env.STATUS_OVERLAY_RUNTIME_ENABLED === "false") {
-    return Response.json(
+    return jsonResponse(
       statusOverlayRuntimeUnavailable("STATUS-OVERLAY runtime disabled"),
-      { status: 404, headers: { "Cache-Control": "no-store" } },
+      404,
     );
   }
 
-  const repository =
-    env.STATUS_OVERLAY_REPOSITORY?.trim() || STATUS_OVERLAY_DEFAULT_REPOSITORY;
+  const gate = resolveUnauthenticatedStatusOverlayRepository(env.STATUS_OVERLAY_REPOSITORY);
+  if (!gate.allowed) {
+    // Fail closed BEFORE any token-backed GitHub client/API usage.
+    return jsonResponse(
+      statusOverlayRuntimeUnavailable(gate.reason),
+      403,
+    );
+  }
+
+  const repository = gate.repository;
+  const createClient = deps.createClient ?? createStatusOverlayGithubHttpClient;
+  const getTextFile = deps.getTextFile ?? githubGetTextFile;
+  const runCycle = deps.runCycle ?? runStatusOverlayCycle;
+  const now = deps.now ?? (() => new Date().toISOString());
 
   try {
-    const client = createStatusOverlayGithubHttpClient({
+    const client = createClient({
       GITHUB_TOKEN: env.GITHUB_TOKEN,
     });
     const tip = await client.getDefaultBranchTip(repository);
 
     const [snapshotRaw, workflowYaml, handoffRaw] = await Promise.all([
-      githubGetTextFile(repository, "docs/architecture/architecture.json", env.GITHUB_TOKEN),
-      githubGetTextFile(repository, PERSISTENT_WORKFLOW_PATH, env.GITHUB_TOKEN),
-      githubGetTextFile(repository, "docs/handoff/handoff.json", env.GITHUB_TOKEN),
+      getTextFile(repository, "docs/architecture/architecture.json", env.GITHUB_TOKEN),
+      getTextFile(repository, PERSISTENT_WORKFLOW_PATH, env.GITHUB_TOKEN),
+      getTextFile(repository, "docs/handoff/handoff.json", env.GITHUB_TOKEN),
     ]);
 
     const snapshot = snapshotRaw
@@ -90,22 +172,18 @@ export async function handleStatusOverlayGet(
       architectureRelevantChanges: handoff?.snapshot.architectureRelevantPaths ?? null,
     });
 
-    const document = await runStatusOverlayCycle({
+    const document = await runCycle({
       repository,
       client,
       local,
-      now: () => new Date().toISOString(),
+      now,
     });
 
-    return Response.json(document, {
-      headers: { "Cache-Control": "no-store" },
-    });
+    return jsonResponse(document, 200);
   } catch (error) {
-    const reason =
-      error instanceof Error ? error.message : "STATUS-OVERLAY runtime failed";
-    return Response.json(statusOverlayRuntimeUnavailable(reason), {
-      status: 503,
-      headers: { "Cache-Control": "no-store" },
-    });
+    const reason = sanitizeUnavailableReason(
+      error instanceof Error ? error.message : "STATUS-OVERLAY runtime failed",
+    );
+    return jsonResponse(statusOverlayRuntimeUnavailable(reason), 503);
   }
 }

--- a/test/statusOverlayApiAuth.test.ts
+++ b/test/statusOverlayApiAuth.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import type { StatusOverlayDocument } from "../src/domain/statusOverlayContract";
+import type { StatusOverlayReadonlyGithubClient } from "../src/observer/statusOverlayGithubObserver";
+import {
+  STATUS_OVERLAY_DEFAULT_REPOSITORY,
+  statusOverlayRuntimeUnavailable,
+} from "../src/runtime/statusOverlayRuntime";
+import {
+  STATUS_OVERLAY_PUBLIC_REPOSITORY,
+  handleStatusOverlayGet,
+  resolveUnauthenticatedStatusOverlayRepository,
+} from "../src/worker/statusOverlayApi";
+
+const main = "9992a58864ad4cfa7fd589a53e208431d921134c";
+
+function sampleDocument(
+  partial: Partial<StatusOverlayDocument> = {},
+): StatusOverlayDocument {
+  return {
+    schemaVersion: "STATUS-OVERLAY-V1",
+    repository: STATUS_OVERLAY_PUBLIC_REPOSITORY,
+    observedAt: "2026-08-12T05:20:00.000Z",
+    main: { sha: main },
+    snapshot: {
+      generatedFrom: main,
+      currentMain: main,
+      stale: false,
+      staleClassification: "current",
+      architectureRelevantChanges: [],
+      autoRefreshCoverage: "COVERED_BY_ENABLED_AUTOMATION_IDLE",
+    },
+    handoff: {
+      nextActionStatus: "NO_ACTION",
+      staleClassification: "current",
+    },
+    autoRefresh: {
+      enabled: true,
+      trigger: "push_main+workflow_dispatch",
+      lastRunId: "1",
+      lastRunConclusion: "success",
+      lastEvaluation: "NOT_REQUIRED",
+      lastPublicationOutcome: "NO_PUBLICATION",
+      activeRefreshPr: null,
+    },
+    history: {
+      status: "DESIGNED_NOT_IMPLEMENTED",
+      writerImplemented: false,
+      lastEvent: null,
+      lastConvergedAt: null,
+      refreshLifecycleSummary: null,
+    },
+    pullRequests: [],
+    humanGates: [{ kind: "NoAction", summary: "No repository action required" }],
+    holds: [],
+    unknowns: [],
+    recommendedNextAction: {
+      code: "NO_ACTION",
+      status: "NO_ACTION",
+      gateKind: "NoAction",
+      summary: "No repository action required",
+      authorizesMutation: false,
+    },
+    ...partial,
+  };
+}
+
+describe("STATUS-OVERLAY /api/status-overlay authorization boundary", () => {
+  it("allows the canonical public repository", () => {
+    expect(STATUS_OVERLAY_PUBLIC_REPOSITORY).toBe(
+      "yasutakesougo/ai-development-control-center",
+    );
+    expect(STATUS_OVERLAY_PUBLIC_REPOSITORY).toBe(STATUS_OVERLAY_DEFAULT_REPOSITORY);
+    expect(resolveUnauthenticatedStatusOverlayRepository(undefined)).toEqual({
+      allowed: true,
+      repository: STATUS_OVERLAY_PUBLIC_REPOSITORY,
+    });
+    expect(
+      resolveUnauthenticatedStatusOverlayRepository(
+        "yasutakesougo/ai-development-control-center",
+      ),
+    ).toEqual({
+      allowed: true,
+      repository: STATUS_OVERLAY_PUBLIC_REPOSITORY,
+    });
+  });
+
+  it("rejects alternate repository overrides", () => {
+    const gate = resolveUnauthenticatedStatusOverlayRepository(
+      "yasutakesougo/severe-behavior-support-spfx",
+    );
+    expect(gate.allowed).toBe(false);
+    if (!gate.allowed) {
+      expect(gate.repository).toBe("yasutakesougo/severe-behavior-support-spfx");
+      expect(gate.reason).toContain("refused repository override");
+    }
+  });
+
+  it("rejects alternate repo before any token-backed GitHub read", async () => {
+    const createClient = vi.fn(() => {
+      throw new Error("createClient must not be called");
+    });
+    const getTextFile = vi.fn(async () => {
+      throw new Error("getTextFile must not be called");
+    });
+    const runCycle = vi.fn(async () => {
+      throw new Error("runCycle must not be called");
+    });
+
+    const response = await handleStatusOverlayGet(
+      {
+        GITHUB_TOKEN: "ghp_SHOULD_NOT_LEAK_OR_USE",
+        STATUS_OVERLAY_REPOSITORY: "yasutakesougo/severe-behavior-support-spfx",
+      },
+      { createClient, getTextFile, runCycle },
+    );
+
+    expect(response.status).toBe(403);
+    expect(createClient).not.toHaveBeenCalled();
+    expect(getTextFile).not.toHaveBeenCalled();
+    expect(runCycle).not.toHaveBeenCalled();
+
+    const body = (await response.json()) as ReturnType<typeof statusOverlayRuntimeUnavailable>;
+    expect(body.phase).toBe("unavailable");
+    expect(body.document).toBeNull();
+    expect(body.reason).toContain("severe-behavior-support-spfx");
+    expect(JSON.stringify(body)).not.toContain("ghp_");
+    expect(JSON.stringify(body)).not.toContain("SHOULD_NOT_LEAK");
+  });
+
+  it("canonical public repo is allowed and may proceed to read-only cycle", async () => {
+    const createClient = vi.fn(
+      (): StatusOverlayReadonlyGithubClient => ({
+        async getDefaultBranchTip() {
+          return { defaultBranch: "main", sha: main };
+        },
+        async listOpenPullRequests() {
+          return [];
+        },
+        async listWorkflowRuns() {
+          return [];
+        },
+      }),
+    );
+    const getTextFile = vi.fn(async () => null);
+    const document = sampleDocument();
+    const runCycle = vi.fn(async () => document);
+
+    const response = await handleStatusOverlayGet(
+      {
+        GITHUB_TOKEN: "ghp_test_token_value",
+        STATUS_OVERLAY_REPOSITORY: STATUS_OVERLAY_PUBLIC_REPOSITORY,
+      },
+      { createClient, getTextFile, runCycle },
+    );
+
+    expect(response.status).toBe(200);
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(runCycle).toHaveBeenCalledTimes(1);
+    const body = (await response.json()) as StatusOverlayDocument;
+    expect(body.repository).toBe(STATUS_OVERLAY_PUBLIC_REPOSITORY);
+    expect(body.recommendedNextAction.authorizesMutation).toBe(false);
+    expect(JSON.stringify(body)).not.toContain("ghp_");
+    expect(JSON.stringify(body)).not.toContain("test_token_value");
+  });
+
+  it("GITHUB_TOKEN is never returned in fail-closed responses", async () => {
+    const response = await handleStatusOverlayGet(
+      {
+        GITHUB_TOKEN: "ghp_SUPER_SECRET_TOKEN",
+        STATUS_OVERLAY_RUNTIME_ENABLED: "false",
+      },
+      {
+        createClient: () => {
+          throw new Error("unused");
+        },
+      },
+    );
+    expect(response.status).toBe(404);
+    const text = await response.text();
+    expect(text).not.toContain("ghp_");
+    expect(text).not.toContain("SUPER_SECRET_TOKEN");
+    expect(text).not.toContain("GITHUB_TOKEN");
+  });
+
+  it("existing unavailable behavior remains intact on runtime failure", async () => {
+    const response = await handleStatusOverlayGet(
+      {
+        GITHUB_TOKEN: "ghp_secret",
+        STATUS_OVERLAY_REPOSITORY: STATUS_OVERLAY_PUBLIC_REPOSITORY,
+      },
+      {
+        createClient: () => ({
+          async getDefaultBranchTip() {
+            throw new Error("tip failed with bearer ghp_secret");
+          },
+          async listOpenPullRequests() {
+            return [];
+          },
+          async listWorkflowRuns() {
+            return [];
+          },
+        }),
+        getTextFile: async () => null,
+      },
+    );
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as ReturnType<typeof statusOverlayRuntimeUnavailable>;
+    expect(body.phase).toBe("unavailable");
+    expect(body.document).toBeNull();
+    expect(JSON.stringify(body)).not.toContain("ghp_secret");
+    expect(body.reason).toContain("[REDACTED]");
+  });
+});

--- a/test/statusOverlayRuntime.test.ts
+++ b/test/statusOverlayRuntime.test.ts
@@ -1,0 +1,305 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { generateStatusOverlay } from "../src/domain/statusOverlayGenerator";
+import {
+  observeStatusOverlayGithub,
+  type StatusOverlayObservedPull,
+  type StatusOverlayReadonlyGithubClient,
+} from "../src/observer/statusOverlayGithubObserver";
+import {
+  STATUS_OVERLAY_RUNTIME_IMPLEMENTED,
+  assertStatusOverlayRuntimeInvariants,
+  buildStatusOverlayLocalObservation,
+  runStatusOverlayCycle,
+  statusOverlayRuntimeUnavailable,
+} from "../src/runtime/statusOverlayRuntime";
+import { buildStatusOverlayViewModel } from "../src/ui/statusOverlayViewModel";
+
+const repo = "yasutakesougo/ai-development-control-center";
+const main = "9992a58864ad4cfa7fd589a53e208431d921134c";
+const from = "78a72b13965d7b4fc4ce021d0aaa08a40eb17aa0";
+const observedAt = "2026-08-12T05:15:00.000Z";
+
+const enabledWorkflowYaml = `
+name: architecture-auto-refresh
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+concurrency:
+  group: architecture-auto-refresh-main
+  cancel-in-progress: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps: []
+`;
+
+function fakeClient(input: {
+  mainSha?: string;
+  pulls?: StatusOverlayObservedPull[];
+  failTip?: boolean;
+  failRuns?: boolean;
+}): StatusOverlayReadonlyGithubClient {
+  return {
+    async getDefaultBranchTip() {
+      if (input.failTip) throw new Error("tip failed");
+      return { defaultBranch: "main", sha: input.mainSha ?? main };
+    },
+    async listOpenPullRequests() {
+      return [...(input.pulls ?? [])];
+    },
+    async listWorkflowRuns() {
+      if (input.failRuns) throw new Error("runs failed");
+      return [
+        {
+          id: "run-1",
+          status: "completed",
+          conclusion: "success",
+          headSha: input.mainSha ?? main,
+          lastEvaluation: "NOT_REQUIRED",
+          lastPublicationOutcome: "NO_PUBLICATION",
+        },
+      ];
+    },
+  };
+}
+
+function baseLocal(
+  partial: Partial<ReturnType<typeof buildStatusOverlayLocalObservation>> = {},
+) {
+  return {
+    ...buildStatusOverlayLocalObservation({
+      snapshot: {
+        schemaVersion: "1.0",
+        generatedFrom: {
+          repository: "ai-development-control-center",
+          commit: from,
+          generatedAt: "2026-08-12T00:00:00.000Z",
+          generator: "ARCH-SNAPSHOT-GEN-V1",
+        },
+        confidence: { overall: "medium", notes: [] },
+        components: [],
+        dependencies: [],
+        flows: [],
+        externalSystems: [],
+        humanGates: [],
+        holds: [],
+        decisions: [],
+        unknowns: [],
+        assumptions: [],
+        staleIndicators: [],
+      },
+      currentMain: main,
+      architectureRelevantChanges: [],
+      persistentWorkflowYaml: enabledWorkflowYaml,
+    }),
+    ...partial,
+  };
+}
+
+describe("STATUS-OVERLAY-V1 read-only runtime wiring", () => {
+  it("marks runtime implemented", () => {
+    expect(STATUS_OVERLAY_RUNTIME_IMPLEMENTED).toBe(true);
+  });
+
+  it("successful observer → generator → UI document flow", async () => {
+    const document = await runStatusOverlayCycle({
+      repository: repo,
+      client: fakeClient({}),
+      local: baseLocal(),
+      now: () => observedAt,
+    });
+    expect(document.observedAt).toBe(observedAt);
+    expect(document.recommendedNextAction.code).toBe("NO_ACTION");
+    expect(document.recommendedNextAction.authorizesMutation).toBe(false);
+    const vm = buildStatusOverlayViewModel(document);
+    expect(vm.next.code).toBe("NO_ACTION");
+    expect(vm.current.mainSha.startsWith("9992a58864ad")).toBe(true);
+  });
+
+  it("preserves observedAt end-to-end", async () => {
+    const stamp = "2026-03-04T05:06:07.890Z";
+    const document = await runStatusOverlayCycle({
+      repository: repo,
+      client: fakeClient({}),
+      local: baseLocal(),
+      now: () => stamp,
+    });
+    expect(document.observedAt).toBe(stamp);
+    assertStatusOverlayRuntimeInvariants(document, stamp);
+  });
+
+  it("Draft integration example", async () => {
+    const document = await runStatusOverlayCycle({
+      repository: repo,
+      client: fakeClient({
+        pulls: [
+          {
+            number: 41,
+            title: "docs(status): design STATUS-OVERLAY-V1",
+            draft: true,
+            headRef: "cursor/status-overlay-v1-design-2c83",
+          },
+        ],
+      }),
+      local: baseLocal(),
+      now: () => observedAt,
+    });
+    expect(document.recommendedNextAction.code).toBe("REVIEW_DRAFT_PR");
+    expect(document.recommendedNextAction.authorizesMutation).toBe(false);
+  });
+
+  it("stale maintenance integration example", async () => {
+    const document = await runStatusOverlayCycle({
+      repository: repo,
+      client: fakeClient({
+        pulls: [
+          {
+            number: 30,
+            title: "docs(status): design STATUS-OVERLAY-V1",
+            draft: true,
+            headRef: "cursor/status-overlay-v1-design-2c83",
+          },
+        ],
+      }),
+      local: baseLocal({
+        snapshotStale: true,
+        snapshotStaleClassification: "stale_architecture_affecting",
+        architectureRelevantChanges: ["package.json"],
+        persistentWorkflowYaml: "name: x\non:\n  workflow_dispatch:\n",
+      }),
+      now: () => observedAt,
+    });
+    expect(document.recommendedNextAction.code).toBe("MAINTAIN_STALE_SNAPSHOT");
+  });
+
+  it("workflow observation failure remains UNKNOWN (not NO_ACTION)", async () => {
+    const document = await runStatusOverlayCycle({
+      repository: repo,
+      client: fakeClient({ failRuns: true }),
+      local: baseLocal(),
+      now: () => observedAt,
+    });
+    expect(document.unknowns).toContain("workflow_state_UNKNOWN");
+    expect(document.recommendedNextAction.code).toBe("UNKNOWN");
+    expect(document.recommendedNextAction.code).not.toBe("NO_ACTION");
+    expect(document.recommendedNextAction.code).not.toBe("RESOLVE_OUTCOME_UNKNOWN");
+  });
+
+  it("hard observer failure does not become NO_ACTION", async () => {
+    const document = await runStatusOverlayCycle({
+      repository: repo,
+      client: fakeClient({ failTip: true }),
+      local: baseLocal(),
+      now: () => observedAt,
+    });
+    expect(document.unknowns).toContain("live_observation_failed");
+    expect(document.recommendedNextAction.code).toBe("UNKNOWN");
+    expect(document.recommendedNextAction.code).not.toBe("NO_ACTION");
+  });
+
+  it("authorizesMutation remains false end-to-end", async () => {
+    const document = await runStatusOverlayCycle({
+      repository: repo,
+      client: fakeClient({
+        pulls: [
+          {
+            number: 55,
+            title: "ready",
+            draft: false,
+            headRef: "feat/ready",
+          },
+        ],
+      }),
+      local: baseLocal(),
+      now: () => observedAt,
+    });
+    expect(document.recommendedNextAction.authorizesMutation).toBe(false);
+    expect(buildStatusOverlayViewModel(document).next.authorizesMutation).toBe(false);
+  });
+
+  it("unavailable result is explicit and not healthy", () => {
+    const result = statusOverlayRuntimeUnavailable("boom");
+    expect(result.phase).toBe("unavailable");
+    expect(result.document).toBeNull();
+    expect(result.reason).toBe("boom");
+  });
+
+  it("repeated equivalent observations differ only by observedAt", async () => {
+    const client = fakeClient({});
+    const local = baseLocal();
+    const a = await runStatusOverlayCycle({
+      repository: repo,
+      client,
+      local,
+      now: () => "2026-08-12T05:15:00.000Z",
+    });
+    const b = await runStatusOverlayCycle({
+      repository: repo,
+      client,
+      local,
+      now: () => "2026-08-12T05:16:00.000Z",
+    });
+    const { observedAt: _a, ...restA } = a;
+    const { observedAt: _b, ...restB } = b;
+    expect(restA).toEqual(restB);
+    expect(_a).not.toBe(_b);
+  });
+
+  it("runtime path has no mutation methods/imports or writers", () => {
+    const runtime = readFileSync(
+      new URL("../src/runtime/statusOverlayRuntime.ts", import.meta.url),
+      "utf8",
+    );
+    const api = readFileSync(
+      new URL("../src/worker/statusOverlayApi.ts", import.meta.url),
+      "utf8",
+    );
+    const container = readFileSync(
+      new URL("../src/ui/StatusOverlayRuntimeContainer.tsx", import.meta.url),
+      "utf8",
+    );
+    for (const source of [runtime, api, container]) {
+      expect(source).not.toMatch(/createPullRequest|mergePullRequest|gh\s+pr\s+ready|gh\s+pr\s+merge/);
+      expect(source).not.toMatch(/ActionGateway|postLedgerRecord|writeFile|HISTORY writer/i);
+      expect(source).not.toMatch(/method:\s*["']POST["']/);
+      expect(source).not.toMatch(/method:\s*["']PATCH["']/);
+      expect(source).not.toMatch(/method:\s*["']PUT["']/);
+      expect(source).not.toMatch(/method:\s*["']DELETE["']/);
+    }
+    expect(api).toMatch(/method:\s*["']GET["']/);
+    expect(runtime).toMatch(/generateStatusOverlay/);
+    expect(runtime).toMatch(/observeStatusOverlayGithub/);
+  });
+
+  it("does not redefine generator decision logic (delegates)", async () => {
+    const local = baseLocal();
+    const client = fakeClient({});
+    const throughRuntime = await runStatusOverlayCycle({
+      repository: repo,
+      client,
+      local,
+      now: () => observedAt,
+    });
+    const input = await observeStatusOverlayGithub({
+      repository: repo,
+      client,
+      local,
+      now: () => observedAt,
+    });
+    const direct = generateStatusOverlay(input);
+    expect(throughRuntime).toEqual(direct);
+  });
+
+  it("app remains usable without overlay document (disabled phase semantics)", () => {
+    // Disabled runtime supplies null document — App contract accepts this.
+    expect(statusOverlayRuntimeUnavailable("n/a").document).toBeNull();
+    const disabledPhase = "disabled" as const;
+    expect(disabledPhase).toBe("disabled");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **STATUS-OVERLAY-V1 read-only runtime wiring** authorized by Issue #37.

```
read-only observer
  → StatusOverlayGeneratorInput
  → generateStatusOverlay()
  → StatusOverlayDocument
  → App(statusOverlay)
```

Closes #37

---

## P1 follow-up — unauthenticated `/api/status-overlay` boundary

Unauthenticated access is fail-closed to the canonical public repository only:

`yasutakesougo/ai-development-control-center`

If `STATUS_OVERLAY_REPOSITORY` resolves to any other repository:
- reject with **403** + unavailable payload
- **before** `createStatusOverlayGithubHttpClient`
- **before** any GitHub contents/workflow/PR reads
- never return `GITHUB_TOKEN` / token material in the response

---

## Baseline

| Item | Value |
|---|---|
| Expected main (wiring start) | `9992a58864ad4cfa7fd589a53e208431d921134c` |
| Branch | `cursor/status-overlay-wiring-2c83` |
| PR HEAD | _(see latest commit)_ |

---

## Verification

```
npm run verify
→ typecheck PASS
→ 291 tests PASS (24 files)
→ build PASS
```

---

## Explicit non-goals (still NOT IMPLEMENTED)

| Item | Status |
|---|---|
| Repository-file writer | NOT IMPLEMENTED |
| HISTORY writer | NOT IMPLEMENTED |
| Action Gateway | NOT IMPLEMENTED |
| Approval Ledger write | NOT IMPLEMENTED |
| Agent execution | NOT IMPLEMENTED |
| GitHub Ready/Merge/dispatch | NOT IMPLEMENTED |

**Stop at Draft.** Fresh Review on new HEAD. Do not mark Ready. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff3bd-613c-7d0a-b59d-d9615a722c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff3bd-613c-7d0a-b59d-d9615a722c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

