### PR TITLE
MIN-ORCHESTRATOR-V1 — dispatch eligibility from AgentTaskBuilderResultV1 (#47)

### DIFF
--- a/docs/min-orchestrator/min-orchestrator-v1.md
+++ b/docs/min-orchestrator/min-orchestrator-v1.md
@@ -128,11 +128,16 @@ dispatchEligible = (decision === DISPATCH_ELIGIBLE)
 
 Do **not** trust `builderResult.status` alone. For purported `BUILT`:
 
-1. Require non-null `task`
-2. Run `parseAgentTaskV1(task)`
-3. Run `validateAgentTaskV1(task)`
-4. Require revalidation status to match `builderResult.validation.status`
-5. Only then evaluate stage rules and possibly emit `DISPATCH_ELIGIBLE`
+1. Require `builderVersion === AGENT-TASK-BUILDER-V1`
+2. Require `validation.schemaVersion === AGENT-TASK-VALIDATION-RESULT-V1`
+3. Require claimed `validation.status` handling (`VALID` to continue; else map / fail closed)
+4. Require non-null `task`
+5. Require `validation.taskId === task.taskId` (VALID must be bound to THIS task)
+6. Run `parseAgentTaskV1(task)`
+7. Run `validateAgentTaskV1(task)`
+8. Require revalidation `status` + `taskId` to match builder validation (ignore `validatedAt`)
+9. Require `revalidation.taskId === task.taskId` and `revalidation.status === VALID`
+10. Only then evaluate stage rules and possibly emit `DISPATCH_ELIGIBLE`
 
 No silent repair of inconsistent upstream state.
 

--- a/docs/min-orchestrator/min-orchestrator-v1.md
+++ b/docs/min-orchestrator/min-orchestrator-v1.md
@@ -1,0 +1,233 @@
+# MIN-ORCHESTRATOR-V1
+
+**Status: DESIGNED · ORCHESTRATION DECISION ONLY · NO AGENT EXECUTION · NO GITHUB PUBLICATION**
+
+Smallest deterministic orchestration layer that consumes `AgentTaskBuilderResultV1`
+and produces an explicit dispatch decision.
+
+```text
+ORCHESTRATION DECISION ONLY
+AGENT EXECUTION = NOT IMPLEMENTED
+AGENT RUNNER = NOT IMPLEMENTED
+GITHUB PUBLICATION = NOT IMPLEMENTED
+ACTION GATEWAY EXPANSION = NOT IMPLEMENTED
+DRAFT PR / READY / MERGE AUTOMATION = NOT IMPLEMENTED
+```
+
+Baseline:
+
+```text
+main = bc8ed705f2b94a3938baed47df5a9a87095c6e08
+AGENT-TASK-CONTRACT-V1 = COMPLETE (PR #44 / Issue #43)
+AGENT-TASK-BUILDER-V1 = COMPLETE (PR #46 / Issue #45)
+Issue #47 = OPEN (this orchestrator)
+```
+
+---
+
+## 1. Purpose
+
+```text
+Human selects an Issue
+→ Control Center builds AgentTaskV1 automatically
+→ Orchestrator decides whether dispatch is eligible   ← this slice
+→ Agent executes in an isolated runner               (future — NOT IMPLEMENTED)
+→ independent verification                           (future — NOT IMPLEMENTED)
+→ Draft PR                                           (future — NOT IMPLEMENTED)
+→ STOP for Human review
+```
+
+Core rule:
+
+```text
+DISPATCH_ELIGIBLE ≠ Agent execution authorization
+DISPATCH_ELIGIBLE ≠ Action Gateway authorization
+DISPATCH_ELIGIBLE ≠ Ready / Merge authorization
+DISPATCH_ELIGIBLE ≠ GitHub mutation authorization
+```
+
+---
+
+## 2. Source of truth
+
+Upstream contracts remain authoritative:
+
+```text
+src/domain/agentTaskContract.ts
+src/domain/agentTaskBuilder.ts
+AgentTaskV1
+AgentTaskValidationResultV1
+AgentTaskBuilderResultV1
+parseAgentTaskV1()
+validateAgentTaskV1()
+buildAgentTaskFromIssue()
+```
+
+This slice **must not** weaken or bypass builder / contract validation.
+
+---
+
+## 3. Input
+
+`MinOrchestratorInputV1` (unknown root keys → REJECT):
+
+| Field | Role |
+|---|---|
+| `builderResult` | `AgentTaskBuilderResultV1` from AGENT-TASK-BUILDER-V1 |
+| `observedAt` | Observation timestamp for this orchestration attempt |
+| `attemptId` | Optional deterministic correlation id |
+
+---
+
+## 4. Output
+
+`MinOrchestratorResultV1`:
+
+| Field | Meaning |
+|---|---|
+| `decision` | `DISPATCH_ELIGIBLE` \| `HOLD` \| `REJECT` \| `UNKNOWN` |
+| `reasonCode` | Machine-stable code |
+| `reasonMessage` | Human-readable summary |
+| `task` | Upstream `AgentTaskV1 \| null` (never rewritten / widened) |
+| `builderStatus` | Echo of builder status (or null on input reject) |
+| `validation` | Builder or revalidation result |
+| `metadata` | Includes hard-false authorization flags |
+
+`metadata` always sets:
+
+```text
+executionAuthorized = false
+actionGatewayAuthorized = false
+readyAuthorized = false
+mergeAuthorized = false
+githubMutationAuthorized = false
+dispatchEligible = (decision === DISPATCH_ELIGIBLE)
+```
+
+---
+
+## 5. Decision mapping
+
+| Builder / validation condition | Decision |
+|---|---|
+| `status=BUILT` + `validation=VALID` + non-null task + structural parse PASS + semantic revalidation VALID + stage rules PASS | `DISPATCH_ELIGIBLE` |
+| `status=HOLD` | `HOLD` |
+| `status=INVALID` | `REJECT` |
+| `status=UNKNOWN` | `UNKNOWN` |
+| `BUILT` + null task | `REJECT` |
+| `BUILT` + validation `INVALID` | `REJECT` |
+| `BUILT` + validation `HOLD` | `HOLD` |
+| `BUILT` + validation `UNKNOWN` | `UNKNOWN` |
+| Malformed task on reparse | `REJECT` |
+| Revalidation status ≠ builder validation status | `REJECT` |
+| Internally inconsistent combination | fail closed (`REJECT` / `UNKNOWN`) |
+
+---
+
+## 6. Revalidation (BUILT path)
+
+Do **not** trust `builderResult.status` alone. For purported `BUILT`:
+
+1. Require non-null `task`
+2. Run `parseAgentTaskV1(task)`
+3. Run `validateAgentTaskV1(task)`
+4. Require revalidation status to match `builderResult.validation.status`
+5. Only then evaluate stage rules and possibly emit `DISPATCH_ELIGIBLE`
+
+No silent repair of inconsistent upstream state.
+
+---
+
+## 7. Stage rules (capability / risk / stopAt)
+
+Orchestrator may **inspect** but never **add or modify**:
+
+```text
+allowedCapabilities
+riskClass
+stopAt
+```
+
+Exact V1 rules (deterministic, fail closed):
+
+| Check | Rule | Decision |
+|---|---|---|
+| `stopAt = TASK_BUILT` | Contract-only; no runner activity | `HOLD` (`HOLD_STOP_AT_TASK_BUILT`) |
+| `stopAt ∈ {AGENT_COMPLETE, VERIFY_COMPLETE, DRAFT_PR}` | Supported for dispatch eligibility | continue |
+| Other `stopAt` | Unsupported at this stage | `HOLD` (`HOLD_UNSUPPORTED_STOP_AT`) |
+| `riskClass ∈ {R0, R1, R2}` | Supported for this stage | continue |
+| `riskClass ∈ {R3, R4, R5}` | Future mutation / auth stages | `HOLD` (`HOLD_UNSUPPORTED_RISK_CLASS`) |
+| `allowedCapabilities` empty | Default-deny; OK | continue |
+| Each capability ∈ `{workspace.read.v1}` | Known inspect-only | continue |
+| Any other capability | Unknown / unsupported | `HOLD` (`HOLD_UNSUPPORTED_CAPABILITY`) |
+
+---
+
+## 8. Task immutability
+
+Returned `task` is the upstream validated task. Orchestrator must not rewrite or widen:
+
+```text
+repository
+baseRevision
+sourceIssue
+objective
+allowedPaths
+forbiddenPaths
+acceptanceCriteria
+verificationCommands
+allowedCapabilities
+riskClass
+stopAt
+constraints
+```
+
+---
+
+## 9. Artifacts
+
+| Artifact | Path |
+|---|---|
+| Spec | `docs/min-orchestrator/min-orchestrator-v1.md` |
+| Implementation | `src/domain/minOrchestrator.ts` |
+| Tests | `test/minOrchestrator.test.ts` |
+
+---
+
+## 10. Explicitly NOT IMPLEMENTED
+
+```text
+Agent execution
+agent.execute capability
+Agent runner
+Codex SDK execution
+Cursor Agent execution
+Cloudflare Workflows execution
+GitHub Actions Agent runner
+branch creation automation
+commit automation
+push automation
+Draft PR creation automation
+independent verification runner
+Ready automation
+Merge automation
+Issue close automation
+deploy
+production mutation
+permission/token scope expansion
+new Action Gateway capability
+```
+
+---
+
+## 11. Pipeline context
+
+```text
+1. AGENT-TASK-CONTRACT-V1 = COMPLETE
+2. AGENT-TASK-BUILDER-V1 = COMPLETE
+3. MIN-ORCHESTRATOR-V1 = THIS SLICE
+4. AGENT-RUNNER-V1
+5. INDEPENDENT-VERIFY-V1
+6. DRAFT-PUBLISH-V1
+7. NO-PROMPT-PILOT-V1
+```

--- a/src/domain/minOrchestrator.ts
+++ b/src/domain/minOrchestrator.ts
@@ -18,9 +18,10 @@ import {
   type AgentTaskValidationResultV1,
   type AgentTaskValidationStatus,
 } from "./agentTaskContract";
-import type {
-  AgentTaskBuilderResultV1,
-  AgentTaskBuilderStatus,
+import {
+  AGENT_TASK_BUILDER_VERSION,
+  type AgentTaskBuilderResultV1,
+  type AgentTaskBuilderStatus,
 } from "./agentTaskBuilder";
 
 export const MIN_ORCHESTRATOR_VERSION = "MIN-ORCHESTRATOR-V1" as const;
@@ -97,6 +98,9 @@ export type MinOrchestratorReasonCode =
   | "HOLD_UNSUPPORTED_STOP_AT"
   | "REJECT_BUILDER_INVALID"
   | "REJECT_BUILT_NULL_TASK"
+  | "REJECT_FOREIGN_BUILDER_VERSION"
+  | "REJECT_VALIDATION_SCHEMA"
+  | "REJECT_VALIDATION_TASK_BINDING"
   | "REJECT_VALIDATION_INVALID"
   | "REJECT_TASK_MALFORMED"
   | "REJECT_TASK_SEMANTICS"
@@ -520,6 +524,31 @@ export function orchestrateAgentTaskV1(
 
   // --- BUILT path: do not trust status alone ---
 
+  if (builderResult.builderVersion !== AGENT_TASK_BUILDER_VERSION) {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_FOREIGN_BUILDER_VERSION",
+      reasonMessage: `BUILT result builderVersion must be ${AGENT_TASK_BUILDER_VERSION}; got ${String(builderResult.builderVersion)}.`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (
+    builderResult.validation.schemaVersion !==
+    AGENT_TASK_VALIDATION_RESULT_SCHEMA
+  ) {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_VALIDATION_SCHEMA",
+      reasonMessage: `BUILT result validation.schemaVersion must be ${AGENT_TASK_VALIDATION_RESULT_SCHEMA}.`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
   // Inconsistent: BUILT claiming non-VALID validation before revalidation.
   const claimedValidation = builderResult.validation.status;
 
@@ -578,6 +607,18 @@ export function orchestrateAgentTaskV1(
     });
   }
 
+  // Upstream VALID must be bound to THIS task identity (not a foreign taskId).
+  if (builderResult.validation.taskId !== builderResult.task.taskId) {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_VALIDATION_TASK_BINDING",
+      reasonMessage: `Builder validation.taskId (${String(builderResult.validation.taskId)}) is not bound to task.taskId (${String(builderResult.task.taskId)}); fail closed.`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
   // Revalidate: parse → validate. Do not trust upstream status alone.
   const structural = parseAgentTaskV1(builderResult.task);
   if (!structural.ok) {
@@ -596,17 +637,33 @@ export function orchestrateAgentTaskV1(
     });
   }
 
+  const upstreamTask = builderResult.task;
   const revalidation = validateAgentTaskV1(structural.task, {
     validatedAt: revalidatedAt,
     treatPrefixOverlapAsHold: options.treatPrefixOverlapAsHold,
   });
 
-  if (revalidation.status !== builderResult.validation.status) {
+  // Compare at least task identity + validation status (validatedAt may differ).
+  if (
+    revalidation.status !== builderResult.validation.status ||
+    revalidation.taskId !== builderResult.validation.taskId
+  ) {
     return result({
       decision: "REJECT",
       reasonCode: "REJECT_REVALIDATION_MISMATCH",
-      reasonMessage: `Revalidation status ${revalidation.status} differs from builder validation ${builderResult.validation.status}; fail closed.`,
-      task: builderResult.task,
+      reasonMessage: `Revalidation (status=${revalidation.status}, taskId=${String(revalidation.taskId)}) differs from builder validation (status=${builderResult.validation.status}, taskId=${String(builderResult.validation.taskId)}); fail closed.`,
+      task: upstreamTask,
+      validation: revalidation,
+      ...ctx,
+    });
+  }
+
+  if (revalidation.taskId !== upstreamTask.taskId) {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_REVALIDATION_MISMATCH",
+      reasonMessage: `Revalidation.taskId (${String(revalidation.taskId)}) is not bound to task.taskId (${upstreamTask.taskId}); fail closed.`,
+      task: upstreamTask,
       validation: revalidation,
       ...ctx,
     });
@@ -617,7 +674,7 @@ export function orchestrateAgentTaskV1(
       decision: "REJECT",
       reasonCode: "REJECT_TASK_SEMANTICS",
       reasonMessage: revalidation.reasonMessage,
-      task: builderResult.task,
+      task: upstreamTask,
       validation: revalidation,
       ...ctx,
     });
@@ -628,7 +685,7 @@ export function orchestrateAgentTaskV1(
       decision: "HOLD",
       reasonCode: "HOLD_VALIDATION",
       reasonMessage: revalidation.reasonMessage,
-      task: builderResult.task,
+      task: upstreamTask,
       validation: revalidation,
       ...ctx,
     });
@@ -639,7 +696,7 @@ export function orchestrateAgentTaskV1(
       decision: "UNKNOWN",
       reasonCode: "UNKNOWN_VALIDATION",
       reasonMessage: revalidation.reasonMessage,
-      task: builderResult.task,
+      task: upstreamTask,
       validation: revalidation,
       ...ctx,
     });
@@ -650,14 +707,14 @@ export function orchestrateAgentTaskV1(
       decision: "UNKNOWN",
       reasonCode: "UNKNOWN_ORCHESTRATOR_STATE",
       reasonMessage: "Unrecognized revalidation status; fail closed.",
-      task: builderResult.task,
+      task: upstreamTask,
       validation: revalidation,
       ...ctx,
     });
   }
 
   // Preserve upstream validated task (no rewrite / widen).
-  return applyStageRules(builderResult.task, revalidation, ctx);
+  return applyStageRules(upstreamTask, revalidation, ctx);
 }
 
 export function assertMinOrchestratorNotExecuting(): void {

--- a/src/domain/minOrchestrator.ts
+++ b/src/domain/minOrchestrator.ts
@@ -1,0 +1,674 @@
+/**
+ * MIN-ORCHESTRATOR-V1
+ *
+ * ORCHESTRATION DECISION ONLY · NO AGENT EXECUTION · NO GITHUB PUBLICATION
+ *
+ * Consumes AgentTaskBuilderResultV1 and produces an explicit dispatch decision.
+ * DISPATCH_ELIGIBLE ≠ Agent execution, Action Gateway, Ready, Merge, or GitHub
+ * mutation authorization.
+ */
+
+import {
+  AGENT_TASK_VALIDATION_RESULT_SCHEMA,
+  parseAgentTaskV1,
+  validateAgentTaskV1,
+  type AgentTaskRiskClass,
+  type AgentTaskStopAt,
+  type AgentTaskV1,
+  type AgentTaskValidationResultV1,
+  type AgentTaskValidationStatus,
+} from "./agentTaskContract";
+import type {
+  AgentTaskBuilderResultV1,
+  AgentTaskBuilderStatus,
+} from "./agentTaskBuilder";
+
+export const MIN_ORCHESTRATOR_VERSION = "MIN-ORCHESTRATOR-V1" as const;
+export const MIN_ORCHESTRATOR_RESULT_SCHEMA =
+  "MIN-ORCHESTRATOR-RESULT-V1" as const;
+
+/** Orchestrator surfaces remain non-executing in this slice. */
+export const MIN_ORCHESTRATOR_EXECUTION_IMPLEMENTED = false as const;
+export const MIN_ORCHESTRATOR_PUBLICATION_IMPLEMENTED = false as const;
+export const MIN_ORCHESTRATOR_AGENT_RUNNER_IMPLEMENTED = false as const;
+export const MIN_ORCHESTRATOR_ACTION_GATEWAY_EXPANSION_IMPLEMENTED =
+  false as const;
+
+export const MIN_ORCHESTRATOR_INPUT_ROOT_KEYS = [
+  "builderResult",
+  "observedAt",
+  "attemptId",
+] as const;
+
+export const MIN_ORCHESTRATOR_RESULT_ROOT_KEYS = [
+  "schemaVersion",
+  "orchestratorVersion",
+  "decision",
+  "reasonCode",
+  "reasonMessage",
+  "task",
+  "builderStatus",
+  "validation",
+  "metadata",
+] as const;
+
+/**
+ * Capabilities this orchestration stage may observe without HOLD.
+ * Empty allowlist remains valid (default-deny). Any other capability fails closed.
+ * Orchestrator never adds or widens capabilities.
+ */
+export const MIN_ORCHESTRATOR_SUPPORTED_CAPABILITIES = [
+  "workspace.read.v1",
+] as const;
+
+/**
+ * Risk classes eligible for DISPATCH_ELIGIBLE at this non-executing stage.
+ * R3–R5 require future mutation/authorization stages → HOLD.
+ */
+export const MIN_ORCHESTRATOR_SUPPORTED_RISK_CLASSES = [
+  "R0",
+  "R1",
+  "R2",
+] as const satisfies readonly AgentTaskRiskClass[];
+
+/**
+ * stopAt values that may become DISPATCH_ELIGIBLE.
+ * TASK_BUILT means contract-only / no runner activity → HOLD.
+ */
+export const MIN_ORCHESTRATOR_SUPPORTED_STOP_AT = [
+  "AGENT_COMPLETE",
+  "VERIFY_COMPLETE",
+  "DRAFT_PR",
+] as const satisfies readonly AgentTaskStopAt[];
+
+export type MinOrchestratorDecision =
+  | "DISPATCH_ELIGIBLE"
+  | "HOLD"
+  | "REJECT"
+  | "UNKNOWN";
+
+export type MinOrchestratorReasonCode =
+  | "DISPATCH_ELIGIBLE"
+  | "HOLD_BUILDER"
+  | "HOLD_VALIDATION"
+  | "HOLD_STOP_AT_TASK_BUILT"
+  | "HOLD_UNSUPPORTED_RISK_CLASS"
+  | "HOLD_UNSUPPORTED_CAPABILITY"
+  | "HOLD_UNSUPPORTED_STOP_AT"
+  | "REJECT_BUILDER_INVALID"
+  | "REJECT_BUILT_NULL_TASK"
+  | "REJECT_VALIDATION_INVALID"
+  | "REJECT_TASK_MALFORMED"
+  | "REJECT_TASK_SEMANTICS"
+  | "REJECT_REVALIDATION_MISMATCH"
+  | "REJECT_INCONSISTENT_BUILDER_STATE"
+  | "REJECT_INPUT"
+  | "UNKNOWN_BUILDER"
+  | "UNKNOWN_VALIDATION"
+  | "UNKNOWN_ORCHESTRATOR_STATE";
+
+export interface MinOrchestratorInputV1 {
+  builderResult: AgentTaskBuilderResultV1;
+  observedAt: string;
+  /** Optional deterministic attempt / correlation id. */
+  attemptId?: string;
+}
+
+export interface MinOrchestratorMetadata {
+  observedAt: string;
+  attemptId?: string;
+  revalidatedAt: string;
+  /** True only when DISPATCH_ELIGIBLE; still ≠ execution authorization. */
+  dispatchEligible: boolean;
+  executionAuthorized: false;
+  actionGatewayAuthorized: false;
+  readyAuthorized: false;
+  mergeAuthorized: false;
+  githubMutationAuthorized: false;
+}
+
+export interface MinOrchestratorResultV1 {
+  schemaVersion: typeof MIN_ORCHESTRATOR_RESULT_SCHEMA;
+  orchestratorVersion: typeof MIN_ORCHESTRATOR_VERSION;
+  decision: MinOrchestratorDecision;
+  reasonCode: MinOrchestratorReasonCode;
+  reasonMessage: string;
+  task: AgentTaskV1 | null;
+  builderStatus: AgentTaskBuilderStatus | null;
+  validation: AgentTaskValidationResultV1 | null;
+  metadata: MinOrchestratorMetadata;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function emptyValidation(
+  taskId: string | null,
+  validatedAt: string,
+  reasonCode: string,
+  reasonMessage: string,
+  status: AgentTaskValidationStatus = "INVALID",
+): AgentTaskValidationResultV1 {
+  return {
+    schemaVersion: AGENT_TASK_VALIDATION_RESULT_SCHEMA,
+    taskId,
+    status,
+    reasonCode,
+    reasonMessage,
+    validatedAt,
+  };
+}
+
+function metadataBase(input: {
+  observedAt: string;
+  attemptId?: string;
+  revalidatedAt: string;
+}): MinOrchestratorMetadata {
+  return {
+    observedAt: input.observedAt,
+    attemptId: input.attemptId,
+    revalidatedAt: input.revalidatedAt,
+    dispatchEligible: false,
+    executionAuthorized: false,
+    actionGatewayAuthorized: false,
+    readyAuthorized: false,
+    mergeAuthorized: false,
+    githubMutationAuthorized: false,
+  };
+}
+
+function result(input: {
+  decision: MinOrchestratorDecision;
+  reasonCode: MinOrchestratorReasonCode;
+  reasonMessage: string;
+  task: AgentTaskV1 | null;
+  builderStatus: AgentTaskBuilderStatus | null;
+  validation: AgentTaskValidationResultV1 | null;
+  observedAt: string;
+  attemptId?: string;
+  revalidatedAt: string;
+}): MinOrchestratorResultV1 {
+  const meta = metadataBase({
+    observedAt: input.observedAt,
+    attemptId: input.attemptId,
+    revalidatedAt: input.revalidatedAt,
+  });
+  if (input.decision === "DISPATCH_ELIGIBLE") {
+    meta.dispatchEligible = true;
+  }
+  return {
+    schemaVersion: MIN_ORCHESTRATOR_RESULT_SCHEMA,
+    orchestratorVersion: MIN_ORCHESTRATOR_VERSION,
+    decision: input.decision,
+    reasonCode: input.reasonCode,
+    reasonMessage: input.reasonMessage,
+    task: input.task,
+    builderStatus: input.builderStatus,
+    validation: input.validation,
+    metadata: meta,
+  };
+}
+
+function isBuilderStatus(value: unknown): value is AgentTaskBuilderStatus {
+  return (
+    value === "BUILT" ||
+    value === "HOLD" ||
+    value === "INVALID" ||
+    value === "UNKNOWN"
+  );
+}
+
+function isValidationStatus(value: unknown): value is AgentTaskValidationStatus {
+  return (
+    value === "VALID" ||
+    value === "INVALID" ||
+    value === "HOLD" ||
+    value === "UNKNOWN"
+  );
+}
+
+/**
+ * Minimal structural check for builderResult. Unknown keys on the orchestration
+ * input are rejected by parseMinOrchestratorInput; builderResult itself is
+ * treated as an already-produced upstream document — inconsistent shapes fail closed.
+ */
+function looksLikeBuilderResult(
+  value: unknown,
+): value is AgentTaskBuilderResultV1 {
+  if (!isPlainObject(value)) return false;
+  if (value.schemaVersion !== "AGENT-TASK-BUILDER-RESULT-V1") return false;
+  if (typeof value.builderVersion !== "string") return false;
+  if (!isBuilderStatus(value.status)) return false;
+  if (!Object.prototype.hasOwnProperty.call(value, "task")) return false;
+  if (value.task !== null && !isPlainObject(value.task)) return false;
+  if (!isPlainObject(value.validation)) return false;
+  if (!isValidationStatus(value.validation.status)) return false;
+  if (typeof value.reasonCode !== "string" || value.reasonCode.length < 1) {
+    return false;
+  }
+  if (
+    typeof value.reasonMessage !== "string" ||
+    value.reasonMessage.length < 1
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Fail-closed parse of orchestration input. Unknown root keys are rejected.
+ */
+export function parseMinOrchestratorInput(
+  value: unknown,
+):
+  | { ok: true; input: MinOrchestratorInputV1 }
+  | {
+      ok: false;
+      reasonCode: "REJECT_INPUT";
+      reasonMessage: string;
+    } {
+  if (!isPlainObject(value)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "Orchestrator input must be a JSON object.",
+    };
+  }
+  if (!hasOnlyKeys(value, MIN_ORCHESTRATOR_INPUT_ROOT_KEYS)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "Orchestrator input contains unknown properties.",
+    };
+  }
+  if (typeof value.observedAt !== "string" || value.observedAt.length < 1) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "observedAt must be a non-empty string.",
+    };
+  }
+  if (value.attemptId !== undefined) {
+    if (typeof value.attemptId !== "string" || value.attemptId.length < 1) {
+      return {
+        ok: false,
+        reasonCode: "REJECT_INPUT",
+        reasonMessage: "attemptId must be a non-empty string when provided.",
+      };
+    }
+  }
+  if (!looksLikeBuilderResult(value.builderResult)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "builderResult is missing or malformed.",
+    };
+  }
+
+  return {
+    ok: true,
+    input: {
+      builderResult: value.builderResult,
+      observedAt: value.observedAt,
+      attemptId: value.attemptId as string | undefined,
+    },
+  };
+}
+
+function unsupportedCapabilities(task: AgentTaskV1): string[] {
+  const supported = new Set<string>(MIN_ORCHESTRATOR_SUPPORTED_CAPABILITIES);
+  return task.allowedCapabilities.filter((cap) => !supported.has(cap));
+}
+
+function isSupportedRiskClass(riskClass: AgentTaskRiskClass): boolean {
+  return (MIN_ORCHESTRATOR_SUPPORTED_RISK_CLASSES as readonly string[]).includes(
+    riskClass,
+  );
+}
+
+function isSupportedStopAt(stopAt: AgentTaskStopAt): boolean {
+  return (MIN_ORCHESTRATOR_SUPPORTED_STOP_AT as readonly string[]).includes(
+    stopAt,
+  );
+}
+
+/**
+ * Apply capability / riskClass / stopAt stage rules after successful revalidation.
+ * Never mutates the task. Unsupported future states fail closed (HOLD).
+ */
+function applyStageRules(
+  task: AgentTaskV1,
+  validation: AgentTaskValidationResultV1,
+  ctx: {
+    builderStatus: AgentTaskBuilderStatus;
+    observedAt: string;
+    attemptId?: string;
+    revalidatedAt: string;
+  },
+): MinOrchestratorResultV1 {
+  if (task.stopAt === "TASK_BUILT") {
+    return result({
+      decision: "HOLD",
+      reasonCode: "HOLD_STOP_AT_TASK_BUILT",
+      reasonMessage:
+        "stopAt=TASK_BUILT means no runner activity; dispatch is not eligible.",
+      task,
+      builderStatus: ctx.builderStatus,
+      validation,
+      observedAt: ctx.observedAt,
+      attemptId: ctx.attemptId,
+      revalidatedAt: ctx.revalidatedAt,
+    });
+  }
+
+  if (!isSupportedStopAt(task.stopAt)) {
+    return result({
+      decision: "HOLD",
+      reasonCode: "HOLD_UNSUPPORTED_STOP_AT",
+      reasonMessage: `stopAt=${task.stopAt} is unsupported for MIN-ORCHESTRATOR-V1 dispatch eligibility.`,
+      task,
+      builderStatus: ctx.builderStatus,
+      validation,
+      observedAt: ctx.observedAt,
+      attemptId: ctx.attemptId,
+      revalidatedAt: ctx.revalidatedAt,
+    });
+  }
+
+  if (!isSupportedRiskClass(task.riskClass)) {
+    return result({
+      decision: "HOLD",
+      reasonCode: "HOLD_UNSUPPORTED_RISK_CLASS",
+      reasonMessage: `riskClass=${task.riskClass} requires a future authorization stage; HOLD for Human resolution.`,
+      task,
+      builderStatus: ctx.builderStatus,
+      validation,
+      observedAt: ctx.observedAt,
+      attemptId: ctx.attemptId,
+      revalidatedAt: ctx.revalidatedAt,
+    });
+  }
+
+  const unknownCaps = unsupportedCapabilities(task);
+  if (unknownCaps.length > 0) {
+    return result({
+      decision: "HOLD",
+      reasonCode: "HOLD_UNSUPPORTED_CAPABILITY",
+      reasonMessage: `Unsupported or unknown capability for this stage: ${unknownCaps.join(", ")}. Orchestrator does not widen or authorize capabilities.`,
+      task,
+      builderStatus: ctx.builderStatus,
+      validation,
+      observedAt: ctx.observedAt,
+      attemptId: ctx.attemptId,
+      revalidatedAt: ctx.revalidatedAt,
+    });
+  }
+
+  return result({
+    decision: "DISPATCH_ELIGIBLE",
+    reasonCode: "DISPATCH_ELIGIBLE",
+    reasonMessage:
+      "Builder BUILT + VALID task revalidated; stage rules passed. DISPATCH_ELIGIBLE ≠ execution or publication authorization.",
+    task,
+    builderStatus: ctx.builderStatus,
+    validation,
+    observedAt: ctx.observedAt,
+    attemptId: ctx.attemptId,
+    revalidatedAt: ctx.revalidatedAt,
+  });
+}
+
+/**
+ * Decide dispatch eligibility from a builder result.
+ * Pure / deterministic. Never executes Agents, mutates GitHub, or widens task authority.
+ */
+export function orchestrateAgentTaskV1(
+  rawInput: unknown,
+  options: { revalidatedAt?: string; treatPrefixOverlapAsHold?: boolean } = {},
+): MinOrchestratorResultV1 {
+  const revalidatedAt = options.revalidatedAt ?? new Date(0).toISOString();
+
+  const parsed = parseMinOrchestratorInput(rawInput);
+  if (!parsed.ok) {
+    return result({
+      decision: "REJECT",
+      reasonCode: parsed.reasonCode,
+      reasonMessage: parsed.reasonMessage,
+      task: null,
+      builderStatus: null,
+      validation: emptyValidation(
+        null,
+        revalidatedAt,
+        parsed.reasonCode,
+        parsed.reasonMessage,
+      ),
+      observedAt:
+        isPlainObject(rawInput) && typeof rawInput.observedAt === "string"
+          ? rawInput.observedAt
+          : revalidatedAt,
+      attemptId: undefined,
+      revalidatedAt,
+    });
+  }
+
+  const { builderResult, observedAt, attemptId } = parsed.input;
+  const ctx = {
+    builderStatus: builderResult.status,
+    observedAt,
+    attemptId,
+    revalidatedAt,
+  };
+
+  // Non-BUILT statuses map directly — never promote to DISPATCH_ELIGIBLE.
+  if (builderResult.status === "HOLD") {
+    return result({
+      decision: "HOLD",
+      reasonCode: "HOLD_BUILDER",
+      reasonMessage: `Builder HOLD: ${builderResult.reasonMessage}`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (builderResult.status === "INVALID") {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_BUILDER_INVALID",
+      reasonMessage: `Builder INVALID: ${builderResult.reasonMessage}`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (builderResult.status === "UNKNOWN") {
+    return result({
+      decision: "UNKNOWN",
+      reasonCode: "UNKNOWN_BUILDER",
+      reasonMessage: `Builder UNKNOWN: ${builderResult.reasonMessage}`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (builderResult.status !== "BUILT") {
+    return result({
+      decision: "UNKNOWN",
+      reasonCode: "UNKNOWN_ORCHESTRATOR_STATE",
+      reasonMessage: "Unrecognized builder status; fail closed.",
+      task: null,
+      validation: emptyValidation(
+        null,
+        revalidatedAt,
+        "UNKNOWN_ORCHESTRATOR_STATE",
+        "Unrecognized builder status; fail closed.",
+        "UNKNOWN",
+      ),
+      ...ctx,
+    });
+  }
+
+  // --- BUILT path: do not trust status alone ---
+
+  // Inconsistent: BUILT claiming non-VALID validation before revalidation.
+  const claimedValidation = builderResult.validation.status;
+
+  if (claimedValidation === "INVALID") {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_VALIDATION_INVALID",
+      reasonMessage: `BUILT result reports validation INVALID: ${builderResult.validation.reasonMessage}`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (claimedValidation === "HOLD") {
+    return result({
+      decision: "HOLD",
+      reasonCode: "HOLD_VALIDATION",
+      reasonMessage: `BUILT result reports validation HOLD: ${builderResult.validation.reasonMessage}`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (claimedValidation === "UNKNOWN") {
+    return result({
+      decision: "UNKNOWN",
+      reasonCode: "UNKNOWN_VALIDATION",
+      reasonMessage: `BUILT result reports validation UNKNOWN: ${builderResult.validation.reasonMessage}`,
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (claimedValidation !== "VALID") {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_INCONSISTENT_BUILDER_STATE",
+      reasonMessage: "BUILT result has unrecognized validation status; fail closed.",
+      task: builderResult.task,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  if (builderResult.task === null) {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_BUILT_NULL_TASK",
+      reasonMessage: "BUILT + VALID claimed but task is null; fail closed.",
+      task: null,
+      validation: builderResult.validation,
+      ...ctx,
+    });
+  }
+
+  // Revalidate: parse → validate. Do not trust upstream status alone.
+  const structural = parseAgentTaskV1(builderResult.task);
+  if (!structural.ok) {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_TASK_MALFORMED",
+      reasonMessage: `Task failed structural reparse: ${structural.reasonMessage}`,
+      task: null,
+      validation: emptyValidation(
+        null,
+        revalidatedAt,
+        structural.reasonCode,
+        structural.reasonMessage,
+      ),
+      ...ctx,
+    });
+  }
+
+  const revalidation = validateAgentTaskV1(structural.task, {
+    validatedAt: revalidatedAt,
+    treatPrefixOverlapAsHold: options.treatPrefixOverlapAsHold,
+  });
+
+  if (revalidation.status !== builderResult.validation.status) {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_REVALIDATION_MISMATCH",
+      reasonMessage: `Revalidation status ${revalidation.status} differs from builder validation ${builderResult.validation.status}; fail closed.`,
+      task: builderResult.task,
+      validation: revalidation,
+      ...ctx,
+    });
+  }
+
+  if (revalidation.status === "INVALID") {
+    return result({
+      decision: "REJECT",
+      reasonCode: "REJECT_TASK_SEMANTICS",
+      reasonMessage: revalidation.reasonMessage,
+      task: builderResult.task,
+      validation: revalidation,
+      ...ctx,
+    });
+  }
+
+  if (revalidation.status === "HOLD") {
+    return result({
+      decision: "HOLD",
+      reasonCode: "HOLD_VALIDATION",
+      reasonMessage: revalidation.reasonMessage,
+      task: builderResult.task,
+      validation: revalidation,
+      ...ctx,
+    });
+  }
+
+  if (revalidation.status === "UNKNOWN") {
+    return result({
+      decision: "UNKNOWN",
+      reasonCode: "UNKNOWN_VALIDATION",
+      reasonMessage: revalidation.reasonMessage,
+      task: builderResult.task,
+      validation: revalidation,
+      ...ctx,
+    });
+  }
+
+  if (revalidation.status !== "VALID") {
+    return result({
+      decision: "UNKNOWN",
+      reasonCode: "UNKNOWN_ORCHESTRATOR_STATE",
+      reasonMessage: "Unrecognized revalidation status; fail closed.",
+      task: builderResult.task,
+      validation: revalidation,
+      ...ctx,
+    });
+  }
+
+  // Preserve upstream validated task (no rewrite / widen).
+  return applyStageRules(builderResult.task, revalidation, ctx);
+}
+
+export function assertMinOrchestratorNotExecuting(): void {
+  if (
+    MIN_ORCHESTRATOR_EXECUTION_IMPLEMENTED ||
+    MIN_ORCHESTRATOR_PUBLICATION_IMPLEMENTED ||
+    MIN_ORCHESTRATOR_AGENT_RUNNER_IMPLEMENTED ||
+    MIN_ORCHESTRATOR_ACTION_GATEWAY_EXPANSION_IMPLEMENTED
+  ) {
+    throw new Error(
+      "MIN-ORCHESTRATOR-V1 execution/publication/runner/gateway-expansion surfaces must remain NOT IMPLEMENTED",
+    );
+  }
+}

--- a/test/minOrchestrator.test.ts
+++ b/test/minOrchestrator.test.ts
@@ -295,7 +295,7 @@ describe("MIN-ORCHESTRATOR-V1 revalidation", () => {
     const inconsistent = syntheticBuilderResult({
       status: "BUILT",
       task: malformed,
-      validation: validationStub("VALID", "malformed"),
+      validation: validationStub("VALID", built.task!.taskId),
       reasonCode: "BUILT",
       reasonMessage: "claimed valid malformed",
     });
@@ -350,6 +350,56 @@ describe("MIN-ORCHESTRATOR-V1 revalidation", () => {
     expect(out.decision).toBe("REJECT");
     expect(out.reasonCode).toBe("REJECT_REVALIDATION_MISMATCH");
     expect(out.validation?.status).toBe("HOLD");
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 upstream validation binding", () => {
+  it("rejects BUILT + VALID when validation.taskId != task.taskId", () => {
+    const built = builtFromBuilder();
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: built.task,
+      validation: validationStub("VALID", "foreign-task-id-not-bound"),
+      reasonCode: "BUILT",
+      reasonMessage: "claimed valid with foreign validation taskId",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_VALIDATION_TASK_BINDING");
+    expect(out.metadata.dispatchEligible).toBe(false);
+  });
+
+  it("rejects BUILT with foreign builderVersion", () => {
+    const built = builtFromBuilder();
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      builderVersion: "FOREIGN-BUILDER-V0" as AgentTaskBuilderResultV1["builderVersion"],
+      task: built.task,
+      validation: built.validation,
+      reasonCode: "BUILT",
+      reasonMessage: "claimed built by foreign builder",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_FOREIGN_BUILDER_VERSION");
+  });
+
+  it("rejects BUILT with malformed validation schemaVersion", () => {
+    const built = builtFromBuilder();
+    const badValidation: AgentTaskValidationResultV1 = {
+      ...built.validation,
+      schemaVersion: "NOT-A-VALIDATION-RESULT" as AgentTaskValidationResultV1["schemaVersion"],
+    };
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: built.task,
+      validation: badValidation,
+      reasonCode: "BUILT",
+      reasonMessage: "claimed built with bad validation schema",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_VALIDATION_SCHEMA");
   });
 });
 

--- a/test/minOrchestrator.test.ts
+++ b/test/minOrchestrator.test.ts
@@ -1,0 +1,498 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAgentTaskFromIssue,
+  type AgentTaskBuilderResultV1,
+} from "../src/domain/agentTaskBuilder";
+import {
+  AGENT_TASK_SCHEMA,
+  AGENT_TASK_VALIDATION_RESULT_SCHEMA,
+  type AgentTaskV1,
+  type AgentTaskValidationResultV1,
+} from "../src/domain/agentTaskContract";
+import {
+  MIN_ORCHESTRATOR_AGENT_RUNNER_IMPLEMENTED,
+  MIN_ORCHESTRATOR_ACTION_GATEWAY_EXPANSION_IMPLEMENTED,
+  MIN_ORCHESTRATOR_EXECUTION_IMPLEMENTED,
+  MIN_ORCHESTRATOR_PUBLICATION_IMPLEMENTED,
+  MIN_ORCHESTRATOR_RESULT_SCHEMA,
+  MIN_ORCHESTRATOR_SUPPORTED_CAPABILITIES,
+  MIN_ORCHESTRATOR_SUPPORTED_RISK_CLASSES,
+  MIN_ORCHESTRATOR_SUPPORTED_STOP_AT,
+  MIN_ORCHESTRATOR_VERSION,
+  assertMinOrchestratorNotExecuting,
+  orchestrateAgentTaskV1,
+  parseMinOrchestratorInput,
+} from "../src/domain/minOrchestrator";
+
+const BASE = "bc8ed705f2b94a3938baed47df5a9a87095c6e08";
+const OBSERVED_AT = "2026-08-12T10:37:00.000Z";
+const REVALIDATED_AT = "2026-08-12T10:38:00.000Z";
+const VALIDATED_AT = "2026-08-12T10:37:30.000Z";
+
+function builtFromBuilder(
+  overrides: {
+    allowedCapabilities?: string[];
+    riskClass?: AgentTaskV1["riskClass"];
+    stopAt?: AgentTaskV1["stopAt"];
+    allowedPaths?: string[];
+    forbiddenPaths?: string[];
+  } = {},
+): AgentTaskBuilderResultV1 {
+  return buildAgentTaskFromIssue(
+    {
+      repository: "yasutakesougo/ai-development-control-center",
+      issueNumber: 47,
+      baseRevision: BASE,
+      issueTitle: "MIN-ORCHESTRATOR-V1 — dispatch decision from built AgentTaskV1",
+      issueBody:
+        "Orchestration decision only. No Agent execution or GitHub publication.",
+      issueLabels: ["min-orchestrator"],
+      observedAt: OBSERVED_AT,
+      proposal: {
+        allowedPaths: overrides.allowedPaths ?? [
+          "docs/min-orchestrator/",
+          "src/domain/minOrchestrator.ts",
+          "test/minOrchestrator.test.ts",
+        ],
+        forbiddenPaths: overrides.forbiddenPaths ?? [
+          ".github/workflows/",
+          "migrations/",
+        ],
+        acceptanceCriteria: [
+          "BUILT+VALID maps to DISPATCH_ELIGIBLE",
+          "npm run verify passes",
+          "No Agent execution or GitHub publication",
+        ],
+        verificationCommands: [
+          {
+            id: "verify.all",
+            command: "npm run verify",
+            description: "Typecheck, test, and build",
+          },
+        ],
+        allowedCapabilities: overrides.allowedCapabilities,
+        riskClass: overrides.riskClass ?? "R1",
+        stopAt: overrides.stopAt ?? "DRAFT_PR",
+        constraints: {
+          maxChangedFiles: 16,
+          requireIndependentVerify: true,
+        },
+      },
+    },
+    { validatedAt: VALIDATED_AT },
+  );
+}
+
+function orchestrate(
+  builderResult: AgentTaskBuilderResultV1,
+  attemptId?: string,
+) {
+  return orchestrateAgentTaskV1(
+    {
+      builderResult,
+      observedAt: OBSERVED_AT,
+      attemptId,
+    },
+    { revalidatedAt: REVALIDATED_AT },
+  );
+}
+
+function validationStub(
+  status: AgentTaskValidationResultV1["status"],
+  taskId: string | null = null,
+): AgentTaskValidationResultV1 {
+  return {
+    schemaVersion: AGENT_TASK_VALIDATION_RESULT_SCHEMA,
+    taskId,
+    status,
+    reasonCode: status,
+    reasonMessage: `stub ${status}`,
+    validatedAt: VALIDATED_AT,
+  };
+}
+
+function syntheticBuilderResult(
+  overrides: Partial<AgentTaskBuilderResultV1> &
+    Pick<AgentTaskBuilderResultV1, "status">,
+): AgentTaskBuilderResultV1 {
+  return {
+    schemaVersion: "AGENT-TASK-BUILDER-RESULT-V1",
+    builderVersion: "AGENT-TASK-BUILDER-V1",
+    task: null,
+    validation: validationStub(
+      overrides.status === "BUILT" ? "VALID" : "INVALID",
+    ),
+    reasonCode:
+      overrides.status === "BUILT"
+        ? "BUILT"
+        : overrides.status === "HOLD"
+          ? "HOLD_PATH_SCOPE_MISSING"
+          : overrides.status === "UNKNOWN"
+            ? "UNKNOWN_BUILDER_STATE"
+            : "INVALID_INPUT",
+    reasonMessage: `synthetic ${overrides.status}`,
+    ...overrides,
+  };
+}
+
+describe("MIN-ORCHESTRATOR-V1 non-goals", () => {
+  it("keeps execution, publication, runner, and gateway expansion unimplemented", () => {
+    expect(MIN_ORCHESTRATOR_EXECUTION_IMPLEMENTED).toBe(false);
+    expect(MIN_ORCHESTRATOR_PUBLICATION_IMPLEMENTED).toBe(false);
+    expect(MIN_ORCHESTRATOR_AGENT_RUNNER_IMPLEMENTED).toBe(false);
+    expect(MIN_ORCHESTRATOR_ACTION_GATEWAY_EXPANSION_IMPLEMENTED).toBe(false);
+    assertMinOrchestratorNotExecuting();
+  });
+
+  it("documents stage allowlists", () => {
+    expect(MIN_ORCHESTRATOR_SUPPORTED_CAPABILITIES).toEqual([
+      "workspace.read.v1",
+    ]);
+    expect(MIN_ORCHESTRATOR_SUPPORTED_RISK_CLASSES).toEqual(["R0", "R1", "R2"]);
+    expect(MIN_ORCHESTRATOR_SUPPORTED_STOP_AT).toEqual([
+      "AGENT_COMPLETE",
+      "VERIFY_COMPLETE",
+      "DRAFT_PR",
+    ]);
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 positive path", () => {
+  it("BUILT + VALID + valid task → DISPATCH_ELIGIBLE", () => {
+    const built = builtFromBuilder();
+    expect(built.status).toBe("BUILT");
+    expect(built.validation.status).toBe("VALID");
+    expect(built.task).not.toBeNull();
+
+    const out = orchestrate(built, "attempt-47-1");
+    expect(out.schemaVersion).toBe(MIN_ORCHESTRATOR_RESULT_SCHEMA);
+    expect(out.orchestratorVersion).toBe(MIN_ORCHESTRATOR_VERSION);
+    expect(out.decision).toBe("DISPATCH_ELIGIBLE");
+    expect(out.reasonCode).toBe("DISPATCH_ELIGIBLE");
+    expect(out.task).not.toBeNull();
+    expect(out.metadata.dispatchEligible).toBe(true);
+    expect(out.metadata.executionAuthorized).toBe(false);
+    expect(out.metadata.actionGatewayAuthorized).toBe(false);
+    expect(out.metadata.readyAuthorized).toBe(false);
+    expect(out.metadata.mergeAuthorized).toBe(false);
+    expect(out.metadata.githubMutationAuthorized).toBe(false);
+    expect(out.metadata.attemptId).toBe("attempt-47-1");
+  });
+
+  it("is deterministic for the same input", () => {
+    const built = builtFromBuilder();
+    const a = orchestrate(built, "attempt-det");
+    const b = orchestrate(built, "attempt-det");
+    expect(a).toEqual(b);
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 builder status mapping", () => {
+  it("builder HOLD → HOLD", () => {
+    const hold = syntheticBuilderResult({
+      status: "HOLD",
+      reasonCode: "HOLD_PATH_SCOPE_MISSING",
+      reasonMessage: "paths missing",
+      validation: validationStub("HOLD"),
+    });
+    const out = orchestrate(hold);
+    expect(out.decision).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_BUILDER");
+    expect(out.metadata.dispatchEligible).toBe(false);
+  });
+
+  it("builder INVALID → REJECT", () => {
+    const invalid = syntheticBuilderResult({
+      status: "INVALID",
+      reasonCode: "INVALID_REPOSITORY",
+      reasonMessage: "bad repo",
+      validation: validationStub("INVALID"),
+    });
+    const out = orchestrate(invalid);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_BUILDER_INVALID");
+  });
+
+  it("builder UNKNOWN → UNKNOWN", () => {
+    const unknown = syntheticBuilderResult({
+      status: "UNKNOWN",
+      reasonCode: "UNKNOWN_BUILDER_STATE",
+      reasonMessage: "unknown",
+      validation: validationStub("UNKNOWN", null),
+    });
+    const out = orchestrate(unknown);
+    expect(out.decision).toBe("UNKNOWN");
+    expect(out.reasonCode).toBe("UNKNOWN_BUILDER");
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 BUILT inconsistency mapping", () => {
+  it("BUILT + null task → REJECT", () => {
+    const built = builtFromBuilder();
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: null,
+      validation: built.validation,
+      reasonCode: "BUILT",
+      reasonMessage: "claimed built without task",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_BUILT_NULL_TASK");
+    expect(out.task).toBeNull();
+  });
+
+  it("BUILT + validation INVALID → REJECT", () => {
+    const built = builtFromBuilder();
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: built.task,
+      validation: validationStub("INVALID", built.task!.taskId),
+      reasonCode: "BUILT",
+      reasonMessage: "claimed built with invalid validation",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_VALIDATION_INVALID");
+  });
+
+  it("BUILT + validation HOLD → HOLD", () => {
+    const built = builtFromBuilder();
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: built.task,
+      validation: validationStub("HOLD", built.task!.taskId),
+      reasonCode: "BUILT",
+      reasonMessage: "claimed built with hold validation",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_VALIDATION");
+  });
+
+  it("BUILT + validation UNKNOWN → UNKNOWN", () => {
+    const built = builtFromBuilder();
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: built.task,
+      validation: validationStub("UNKNOWN", built.task!.taskId),
+      reasonCode: "BUILT",
+      reasonMessage: "claimed built with unknown validation",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("UNKNOWN");
+    expect(out.reasonCode).toBe("UNKNOWN_VALIDATION");
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 revalidation", () => {
+  it("rejects malformed task on reparse", () => {
+    const built = builtFromBuilder();
+    const malformed = {
+      ...built.task!,
+      schemaVersion: "NOT-A-TASK",
+    } as unknown as AgentTaskV1;
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: malformed,
+      validation: validationStub("VALID", "malformed"),
+      reasonCode: "BUILT",
+      reasonMessage: "claimed valid malformed",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_TASK_MALFORMED");
+    expect(out.task).toBeNull();
+  });
+
+  it("rejects semantic invalidity when revalidation mismatches builder VALID", () => {
+    const built = builtFromBuilder();
+    const semanticBad: AgentTaskV1 = {
+      ...built.task!,
+      sourceIssue: {
+        repository: "other-org/other-repo",
+        number: built.task!.sourceIssue.number,
+      },
+    };
+    const inconsistent = syntheticBuilderResult({
+      status: "BUILT",
+      task: semanticBad,
+      validation: validationStub("VALID", semanticBad.taskId),
+      reasonCode: "BUILT",
+      reasonMessage: "claimed valid but semantics broken",
+    });
+    const out = orchestrate(inconsistent);
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_REVALIDATION_MISMATCH");
+    expect(out.validation?.status).toBe("INVALID");
+  });
+
+  it("rejects builder validation / revalidation mismatch (VALID vs HOLD)", () => {
+    // Construct a BUILT+VALID claim around a prefix-overlapping task; revalidate
+    // with treatPrefixOverlapAsHold → HOLD, which mismatches claimed VALID.
+    const validBuilt = builtFromBuilder();
+    const overlapping: AgentTaskV1 = {
+      ...validBuilt.task!,
+      allowedPaths: ["docs/"],
+      forbiddenPaths: ["docs/secret/"],
+    };
+    const claimed = syntheticBuilderResult({
+      status: "BUILT",
+      task: overlapping,
+      validation: validationStub("VALID", overlapping.taskId),
+      reasonCode: "BUILT",
+      reasonMessage: "claimed valid overlapping",
+    });
+    const out = orchestrateAgentTaskV1(
+      { builderResult: claimed, observedAt: OBSERVED_AT },
+      { revalidatedAt: REVALIDATED_AT, treatPrefixOverlapAsHold: true },
+    );
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_REVALIDATION_MISMATCH");
+    expect(out.validation?.status).toBe("HOLD");
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 task preservation", () => {
+  it("preserves repository, baseRevision, sourceIssue, paths, capabilities, risk, stopAt", () => {
+    const built = builtFromBuilder({
+      allowedCapabilities: ["workspace.read.v1"],
+      riskClass: "R1",
+      stopAt: "DRAFT_PR",
+    });
+    expect(built.status).toBe("BUILT");
+    const out = orchestrate(built);
+    expect(out.decision).toBe("DISPATCH_ELIGIBLE");
+    expect(out.task).toBe(built.task);
+    expect(out.task!.repository).toBe(
+      "yasutakesougo/ai-development-control-center",
+    );
+    expect(out.task!.baseRevision).toBe(BASE);
+    expect(out.task!.sourceIssue).toEqual({
+      repository: "yasutakesougo/ai-development-control-center",
+      number: 47,
+    });
+    expect(out.task!.allowedPaths).toEqual(built.task!.allowedPaths);
+    expect(out.task!.forbiddenPaths).toEqual(built.task!.forbiddenPaths);
+    expect(out.task!.allowedCapabilities).toEqual(["workspace.read.v1"]);
+    expect(out.task!.riskClass).toBe("R1");
+    expect(out.task!.stopAt).toBe("DRAFT_PR");
+    expect(out.task!.objective).toBe(built.task!.objective);
+    expect(out.task!.acceptanceCriteria).toEqual(built.task!.acceptanceCriteria);
+    expect(out.task!.verificationCommands).toEqual(
+      built.task!.verificationCommands,
+    );
+    expect(out.task!.schemaVersion).toBe(AGENT_TASK_SCHEMA);
+  });
+
+  it("does not widen allowedCapabilities or paths", () => {
+    const built = builtFromBuilder({
+      allowedCapabilities: [],
+      allowedPaths: ["docs/min-orchestrator/"],
+    });
+    const out = orchestrate(built);
+    expect(out.decision).toBe("DISPATCH_ELIGIBLE");
+    expect(out.task!.allowedCapabilities).toEqual([]);
+    expect(out.task!.allowedPaths).toEqual(["docs/min-orchestrator/"]);
+    expect(out.task!.allowedPaths).not.toContain("src/");
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 stage rules", () => {
+  it("HOLDs when stopAt=TASK_BUILT", () => {
+    const built = builtFromBuilder({ stopAt: "TASK_BUILT" });
+    expect(built.status).toBe("BUILT");
+    const out = orchestrate(built);
+    expect(out.decision).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_STOP_AT_TASK_BUILT");
+    expect(out.task!.stopAt).toBe("TASK_BUILT");
+  });
+
+  it("HOLDs unsupported riskClass R3/R4/R5", () => {
+    for (const riskClass of ["R3", "R4", "R5"] as const) {
+      const built = builtFromBuilder({ riskClass });
+      expect(built.status).toBe("BUILT");
+      const out = orchestrate(built);
+      expect(out.decision).toBe("HOLD");
+      expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_RISK_CLASS");
+      expect(out.task!.riskClass).toBe(riskClass);
+    }
+  });
+
+  it("HOLDs unknown / unsupported capability", () => {
+    const built = builtFromBuilder({
+      allowedCapabilities: ["github.comment.create.v1"],
+    });
+    expect(built.status).toBe("BUILT");
+    const out = orchestrate(built);
+    expect(out.decision).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_CAPABILITY");
+    expect(out.task!.allowedCapabilities).toEqual([
+      "github.comment.create.v1",
+    ]);
+  });
+
+  it("allows empty capabilities and supported stop/risk", () => {
+    const built = builtFromBuilder({
+      allowedCapabilities: [],
+      riskClass: "R0",
+      stopAt: "AGENT_COMPLETE",
+    });
+    expect(built.status).toBe("BUILT");
+    const out = orchestrate(built);
+    expect(out.decision).toBe("DISPATCH_ELIGIBLE");
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 input fail-closed", () => {
+  it("rejects unknown input properties", () => {
+    const built = builtFromBuilder();
+    const parsed = parseMinOrchestratorInput({
+      builderResult: built,
+      observedAt: OBSERVED_AT,
+      extra: true,
+    });
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.reasonCode).toBe("REJECT_INPUT");
+    }
+
+    const out = orchestrateAgentTaskV1(
+      {
+        builderResult: built,
+        observedAt: OBSERVED_AT,
+        unexpected: 1,
+      },
+      { revalidatedAt: REVALIDATED_AT },
+    );
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_INPUT");
+  });
+
+  it("rejects malformed builderResult", () => {
+    const out = orchestrateAgentTaskV1(
+      {
+        builderResult: { not: "a builder result" },
+        observedAt: OBSERVED_AT,
+      },
+      { revalidatedAt: REVALIDATED_AT },
+    );
+    expect(out.decision).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_INPUT");
+  });
+});
+
+describe("MIN-ORCHESTRATOR-V1 side effects", () => {
+  it("has no execution or GitHub mutation side effects", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      throw new Error("fetch must not be called");
+    });
+    const built = builtFromBuilder();
+    const out = orchestrate(built);
+    expect(out.decision).toBe("DISPATCH_ELIGIBLE");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(MIN_ORCHESTRATOR_EXECUTION_IMPLEMENTED).toBe(false);
+    expect(MIN_ORCHESTRATOR_PUBLICATION_IMPLEMENTED).toBe(false);
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Issue #47 — MIN-ORCHESTRATOR-V1**: smallest deterministic orchestration layer that consumes `AgentTaskBuilderResultV1` and produces an explicit dispatch decision (`DISPATCH_ELIGIBLE` | `HOLD` | `REJECT` | `UNKNOWN`).

Eligibility only. **Does not execute an Agent.**

## SHAs

| | SHA |
|---|---|
| **exact base SHA** | `bc8ed705f2b94a3938baed47df5a9a87095c6e08` |
| **exact HEAD SHA** | `feffc8dc404cba57012f2960088b90aef2b6734f` |

## Changed files

- `docs/min-orchestrator/min-orchestrator-v1.md`
- `src/domain/minOrchestrator.ts`
- `test/minOrchestrator.test.ts`

## Verification

```text
npm run verify → PASS
typecheck PASS
all tests PASS
build PASS
total tests: 437
minOrchestrator tests: 26
```

## Fresh Review follow-up (P1)

BUILT path now fail-closes unless:

- `builderVersion === AGENT-TASK-BUILDER-V1`
- `validation.schemaVersion === AGENT-TASK-VALIDATION-RESULT-V1`
- `validation.taskId === task.taskId`
- `validation.status === VALID`

After revalidation:

- compare builder vs revalidation on **status + taskId** (`validatedAt` may differ)
- require `revalidation.taskId === task.taskId` and `revalidation.status === VALID`

Regression tests added for foreign `validation.taskId`, foreign `builderVersion`, and malformed validation `schemaVersion`.

## Orchestration decision mapping

| Condition | Decision |
|---|---|
| BUILT + VALID + bound taskId + non-null task + reparse/revalidate VALID + stage rules PASS | `DISPATCH_ELIGIBLE` |
| builder `HOLD` | `HOLD` |
| builder `INVALID` | `REJECT` |
| builder `UNKNOWN` | `UNKNOWN` |
| BUILT + null task / unbound validation.taskId / foreign builderVersion / bad validation schema | `REJECT` |
| BUILT + validation `INVALID` | `REJECT` |
| BUILT + validation `HOLD` | `HOLD` |
| BUILT + validation `UNKNOWN` | `UNKNOWN` |
| malformed task / revalidation mismatch / inconsistent state | fail closed |

### Stage rules (inspect only; never widen)

- `stopAt=TASK_BUILT` → `HOLD`
- `stopAt ∈ {AGENT_COMPLETE, VERIFY_COMPLETE, DRAFT_PR}` → continue
- `riskClass ∈ {R0,R1,R2}` → continue; `R3–R5` → `HOLD`
- capabilities empty or only `workspace.read.v1` → continue; any other → `HOLD`

### Semantics reminder

```text
DISPATCH_ELIGIBLE ≠ Agent execution authorization
DISPATCH_ELIGIBLE ≠ Action Gateway authorization
DISPATCH_ELIGIBLE ≠ Ready / Merge authorization
DISPATCH_ELIGIBLE ≠ GitHub mutation authorization
```

## Explicitly NOT IMPLEMENTED

- Agent execution / `agent.execute` / Agent runner
- Codex SDK / Cursor Agent / Cloudflare Workflows / GitHub Actions Agent runner
- branch / commit / push / Draft PR automation
- independent verification runner
- Ready / Merge / Issue close automation
- deploy / production mutation
- permission/token scope expansion
- new Action Gateway capability

## Delivery gate

Draft PR → Fresh Review → **STOP**

Do not Ready / Merge / close Issue #47 / start AGENT-RUNNER-V1.

Refs: #47

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff58b-fd75-77c4-8251-4bc5c0768443?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff58b-fd75-77c4-8251-4bc5c0768443&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

