### PR TITLE
AGENT-RUNNER-V1 — isolated execution contract and bounded runner interface (#49)

### DIFF
--- a/docs/agent-runner/agent-runner-v1.md
+++ b/docs/agent-runner/agent-runner-v1.md
@@ -1,0 +1,309 @@
+# AGENT-RUNNER-V1
+
+**Status: IMPLEMENTED (contract + fake/in-memory adapter) · PROVIDER INTEGRATION = HOLD · COMMAND EXECUTION = HOLD · NO GITHUB PUBLICATION**
+
+Smallest bounded runner layer that consumes a `MinOrchestratorResultV1` and may
+perform **isolated workspace activity only** under explicit `AgentTaskV1`
+authority, after independent revalidation.
+
+```text
+ISOLATED WORKSPACE RUNNER CONTRACT
+FAKE / IN-MEMORY ADAPTER ONLY
+PROVIDER INTEGRATION = HOLD
+COMMAND EXECUTION = HOLD
+GITHUB PUBLICATION = NOT IMPLEMENTED
+READY / MERGE / DEPLOY = NOT IMPLEMENTED
+INDEPENDENT VERIFICATION = NOT IMPLEMENTED
+```
+
+Baseline:
+
+```text
+main = 032bd6e88d4cd6f62d4621a840bcd2b3d37cd82e
+AGENT-TASK-CONTRACT-V1 = COMPLETE (PR #44 / Issue #43)
+AGENT-TASK-BUILDER-V1 = COMPLETE (PR #46 / Issue #45)
+MIN-ORCHESTRATOR-V1 = COMPLETE (PR #48 / Issue #47)
+Issue #49 = OPEN (this runner)
+```
+
+---
+
+## 1. Purpose
+
+```text
+Human selects an Issue
+→ Control Center builds AgentTaskV1 automatically
+→ Orchestrator decides dispatch eligibility
+→ Agent executes in an isolated runner               ← this slice
+→ independent verification                           (future — NOT IMPLEMENTED)
+→ Draft PR                                           (future — NOT IMPLEMENTED)
+→ STOP for Human review
+```
+
+Core rules:
+
+```text
+DISPATCH_ELIGIBLE ≠ runner execution authorization by itself
+Runner COMPLETED ≠ independent verification
+Runner COMPLETED ≠ publication authorization
+Runner COMPLETED ≠ Ready authorization
+Runner COMPLETED ≠ Merge authorization
+Runner COMPLETED ≠ GitHub mutation authorization
+```
+
+---
+
+## 2. Source of truth
+
+Upstream contracts remain authoritative and are not weakened:
+
+```text
+src/domain/agentTaskContract.ts
+src/domain/agentTaskBuilder.ts
+src/domain/minOrchestrator.ts
+AgentTaskV1
+AgentTaskValidationResultV1
+MinOrchestratorResultV1
+parseAgentTaskV1()
+validateAgentTaskV1()
+orchestrateAgentTaskV1()
+```
+
+---
+
+## 3. Input
+
+`AgentRunnerInputV1` (unknown root keys → `REJECT`):
+
+| Field | Role |
+|---|---|
+| `orchestratorResult` | `MinOrchestratorResultV1` from MIN-ORCHESTRATOR-V1 |
+| `runnerAttemptId` | Deterministic correlation id for this runner attempt |
+| `observedAt` | Observation timestamp |
+| `workspace` | Exact binding: `{ repository, baseRevision }` |
+
+Preconditions before any adapter invocation:
+
+```text
+orchestratorResult.decision === DISPATCH_ELIGIBLE
+orchestratorResult.metadata.dispatchEligible === true
+orchestratorResult.metadata.executionAuthorized === false
+orchestratorResult.task !== null
+```
+
+Then the runner **independently** re-parses and re-validates the task, checks
+identity bindings, risk class, capabilities, and path policy.
+
+---
+
+## 4. Output
+
+`AgentRunnerResultV1`:
+
+| Field | Meaning |
+|---|---|
+| `status` | `COMPLETED` \| `HOLD` \| `REJECT` \| `FAILED` \| `UNKNOWN` |
+| `reasonCode` | Machine-stable code |
+| `reasonMessage` | Human-readable summary |
+| `runnerAttemptId` | Echo of attempt id |
+| `taskId` / `repository` / `baseRevision` | Bound identity (nullable on early reject) |
+| `changedPaths` | Paths reported by adapter after collect |
+| `workspaceOutcome` | Isolated adapter outcome metadata |
+| `verificationObservation` | Command-execution HOLD observation |
+| `validation` | Independent revalidation result when available |
+| `metadata` | Hard-false authorization flags |
+
+`metadata` always sets:
+
+```text
+independentVerificationComplete = false
+publicationAuthorized = false
+readyAuthorized = false
+mergeAuthorized = false
+githubMutationAuthorized = false
+commandExecutionImplemented = false
+providerIntegration = HOLD
+realWorkspaceExecutionImplemented = false
+```
+
+---
+
+## 5. State mapping
+
+| Condition | Status |
+|---|---|
+| Orchestrator `HOLD` | `HOLD` |
+| Orchestrator `REJECT` | `REJECT` |
+| Orchestrator `UNKNOWN` | `UNKNOWN` |
+| `DISPATCH_ELIGIBLE` + null task | `REJECT` |
+| `DISPATCH_ELIGIBLE` + inconsistent metadata | `REJECT` |
+| Task structural reparse failure | `REJECT` |
+| Task semantic validation failure | `REJECT` |
+| `validation.taskId` / orchestrator taskId binding mismatch | `REJECT` |
+| `workspace.repository !== task.repository` | `HOLD` |
+| `workspace.baseRevision !== task.baseRevision` | `HOLD` |
+| `riskClass` ∈ {R2, R3, R4, R5} | `HOLD` |
+| Unsupported capability (incl. `workspace.write.v1`, `command.execute.v1`) | `HOLD` |
+| Adapter prepare/execute/collect error | `FAILED` |
+| Adapter timeout | `FAILED` |
+| Changed path outside `allowedPaths` | `FAILED` |
+| Changed path in `forbiddenPaths` | `FAILED` |
+| Unsafe path (`../`, absolute, `\`, malformed) | `REJECT` |
+| Symlink write attempted | `REJECT` |
+| Valid R0/R1 + supported caps + exact binding + path policy PASS | `COMPLETED` |
+
+No silent repair of inconsistent upstream state.
+No fetch-latest-main / rebase / base substitution.
+
+---
+
+## 6. Execution policy V1
+
+| Risk | Policy |
+|---|---|
+| R0 | Supported as read-only isolated observation via fake adapter |
+| R1 | Supported as isolated workspace code/test activity via fake adapter |
+| R2 | `HOLD` |
+| R3 | `HOLD` |
+| R4 | `HOLD` |
+| R5 | `HOLD` |
+
+No automatic escalation.
+
+---
+
+## 7. Capability policy
+
+Runner allowlist (inspect-only; empty allowlist OK / default-deny):
+
+```text
+workspace.read.v1
+```
+
+**HOLD (not added in this slice):**
+
+```text
+workspace.write.v1
+command.execute.v1
+```
+
+Rationale: adding write/command capabilities would be a material authority
+expansion relative to MIN-ORCHESTRATOR-V1's allowlist and would require
+coordinated upstream stage changes. The fake adapter records deterministic
+isolated outcomes without requiring those capabilities.
+
+**Never added:**
+
+```text
+agent.execute
+repo.write (generic)
+github.* mutation
+generic shell
+Action Gateway generic execution
+```
+
+---
+
+## 8. Adapter contract
+
+```text
+AgentRunnerAdapterV1
+  prepareWorkspace()
+  executeTask()
+  collectOutcome()
+  cleanupWorkspace()
+```
+
+Requirements:
+
+- Domain runner decides whether the adapter may be invoked
+- Adapter does **not** decide task authority
+- Cleanup is always represented explicitly
+- Adapter failures map deterministically to `FAILED` / timeout
+- Core tests use `createFakeAgentRunnerAdapterV1()` (no network / secrets / GitHub)
+
+Provider integration (Codex / Cursor remote) = **HOLD**.
+
+---
+
+## 9. Path enforcement
+
+Before accepting `COMPLETED`:
+
+```text
+all changedPaths ⊆ allowedPaths
+all changedPaths ∩ forbiddenPaths = ∅
+```
+
+`forbiddenPaths` always wins.
+
+Fail closed for:
+
+```text
+../ traversal
+absolute paths
+backslash separator bypass
+empty / malformed paths
+path normalization ambiguity
+symlink-based writes (rejected entirely in V1)
+```
+
+Unsafe paths are not silently normalized into allowed ones.
+
+---
+
+## 10. Command policy
+
+```text
+COMMAND EXECUTION = HOLD
+```
+
+`verificationCommands` are **not** executed. Issue prose cannot become a
+command. No `gh` / git publication / deploy / secret / production curl.
+
+---
+
+## 11. Artifacts
+
+| Artifact | Path |
+|---|---|
+| Spec | `docs/agent-runner/agent-runner-v1.md` |
+| Domain runner | `src/domain/agentRunner.ts` |
+| Adapter | `src/domain/agentRunnerAdapter.ts` |
+| Tests | `test/agentRunner.test.ts` |
+
+---
+
+## 12. Explicit NOT IMPLEMENTED
+
+```text
+INDEPENDENT-VERIFY-V1
+Real Codex / Cursor remote provider execution
+Real filesystem workspace execution
+verificationCommands shell execution
+workspace.write.v1 capability authorization
+command.execute.v1 capability authorization
+GitHub branch / commit / push / Draft PR (product capability)
+Ready automation
+Merge automation
+Issue close automation
+deploy / production mutation
+secret provisioning
+permission / token expansion
+Action Gateway execution surface expansion
+```
+
+---
+
+## 13. Delivery gate
+
+```text
+Implementation
+→ npm run verify
+→ Draft PR
+→ Fresh Review
+→ STOP
+```
+
+Do not Ready. Do not Merge. Do not close Issue #49 in the implementation run.
+Do not start INDEPENDENT-VERIFY-V1.

--- a/docs/agent-runner/agent-runner-v1.md
+++ b/docs/agent-runner/agent-runner-v1.md
@@ -142,6 +142,8 @@ realWorkspaceExecutionImplemented = false
 | `validation.taskId` / orchestrator taskId binding mismatch | `REJECT` |
 | `workspace.repository !== task.repository` | `HOLD` |
 | `workspace.baseRevision !== task.baseRevision` | `HOLD` |
+| `stopAt = TASK_BUILT` | `HOLD` (no runner activity; adapter not invoked) |
+| `stopAt` unsupported / unknown | `HOLD` |
 | `riskClass` ∈ {R2, R3, R4, R5} | `HOLD` |
 | Unsupported capability (incl. `workspace.write.v1`, `command.execute.v1`) | `HOLD` |
 | Adapter prepare/execute/collect error | `FAILED` |
@@ -159,6 +161,8 @@ No fetch-latest-main / rebase / base substitution.
 
 ## 6. Execution policy V1
 
+### Risk class
+
 | Risk | Policy |
 |---|---|
 | R0 | Supported as read-only isolated observation via fake adapter |
@@ -169,6 +173,24 @@ No fetch-latest-main / rebase / base substitution.
 | R5 | `HOLD` |
 
 No automatic escalation.
+
+### stopAt (independent runner re-check)
+
+Runner MUST re-check `task.stopAt` before adapter invocation. Do not trust
+`DISPATCH_ELIGIBLE` alone.
+
+| stopAt | Policy |
+|---|---|
+| `TASK_BUILT` | `HOLD` — contract-only; adapter MUST NOT be invoked |
+| `AGENT_COMPLETE` | Runner stage allowed |
+| `VERIFY_COMPLETE` | Runner stage allowed; runner does **not** claim verification complete |
+| `DRAFT_PR` | Runner stage allowed; runner does **not** claim Draft PR / publication |
+| Other / unknown | `HOLD` (`HOLD_UNSUPPORTED_STOP_AT`) — fail closed |
+
+```text
+Runner COMPLETED ≠ independentVerificationComplete
+Runner COMPLETED ≠ publicationAuthorized / Draft PR achieved
+```
 
 ---
 

--- a/src/domain/agentRunner.ts
+++ b/src/domain/agentRunner.ts
@@ -1,0 +1,973 @@
+/**
+ * AGENT-RUNNER-V1
+ *
+ * ISOLATED WORKSPACE RUNNER CONTRACT · FAKE/LOCAL ADAPTER ONLY
+ * NO GITHUB PUBLICATION · NO READY/MERGE · NO PROVIDER REMOTE EXECUTION
+ *
+ * Consumes MinOrchestratorResultV1 and may invoke an AgentRunnerAdapterV1 only
+ * after independent task revalidation and runner policy checks.
+ *
+ * COMPLETED ≠ independent verification
+ * COMPLETED ≠ publication / Ready / Merge / GitHub mutation authorization
+ */
+
+import {
+  evaluatePathBoundary,
+  isRepoRelativePath,
+  parseAgentTaskV1,
+  validateAgentTaskV1,
+  type AgentTaskRiskClass,
+  type AgentTaskV1,
+  type AgentTaskValidationResultV1,
+} from "./agentTaskContract";
+import {
+  AGENT_RUNNER_ADAPTER_FAKE,
+  AGENT_RUNNER_COMMAND_EXECUTION_IMPLEMENTED,
+  AGENT_RUNNER_GITHUB_PUBLICATION_IMPLEMENTED,
+  AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS,
+  AGENT_RUNNER_REAL_WORKSPACE_EXECUTION_IMPLEMENTED,
+  createFakeAgentRunnerAdapterV1,
+  type AgentRunnerAdapterV1,
+  type AgentRunnerVerificationObservationV1,
+  type AgentRunnerWorkspaceBindingV1,
+  type AgentRunnerWorkspaceOutcomeV1,
+} from "./agentRunnerAdapter";
+import {
+  MIN_ORCHESTRATOR_RESULT_SCHEMA,
+  MIN_ORCHESTRATOR_VERSION,
+  type MinOrchestratorDecision,
+  type MinOrchestratorResultV1,
+} from "./minOrchestrator";
+
+export const AGENT_RUNNER_VERSION = "AGENT-RUNNER-V1" as const;
+export const AGENT_RUNNER_RESULT_SCHEMA = "AGENT-RUNNER-RESULT-V1" as const;
+
+/** Real remote provider / shell / GitHub publication remain unimplemented. */
+export const AGENT_RUNNER_EXECUTION_SURFACE =
+  "FAKE_IN_MEMORY_ONLY" as const;
+
+export {
+  AGENT_RUNNER_ADAPTER_FAKE,
+  AGENT_RUNNER_COMMAND_EXECUTION_IMPLEMENTED,
+  AGENT_RUNNER_GITHUB_PUBLICATION_IMPLEMENTED,
+  AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS,
+  AGENT_RUNNER_REAL_WORKSPACE_EXECUTION_IMPLEMENTED,
+  createFakeAgentRunnerAdapterV1,
+};
+
+export const AGENT_RUNNER_INPUT_ROOT_KEYS = [
+  "orchestratorResult",
+  "runnerAttemptId",
+  "observedAt",
+  "workspace",
+] as const;
+
+export const AGENT_RUNNER_WORKSPACE_KEYS = [
+  "repository",
+  "baseRevision",
+] as const;
+
+export const AGENT_RUNNER_RESULT_ROOT_KEYS = [
+  "schemaVersion",
+  "runnerVersion",
+  "status",
+  "reasonCode",
+  "reasonMessage",
+  "runnerAttemptId",
+  "taskId",
+  "repository",
+  "baseRevision",
+  "changedPaths",
+  "workspaceOutcome",
+  "verificationObservation",
+  "validation",
+  "metadata",
+] as const;
+
+/**
+ * Capabilities this runner stage may accept without HOLD.
+ * Empty allowlist remains valid (default-deny).
+ * workspace.write.v1 / command.execute.v1 = HOLD (not added; material authority
+ * expansion deferred; fake adapter does not require them).
+ */
+export const AGENT_RUNNER_SUPPORTED_CAPABILITIES = [
+  "workspace.read.v1",
+] as const;
+
+/**
+ * Risk classes that may reach adapter invocation in V1.
+ * R0 = read-only isolated observation (supported).
+ * R1 = isolated workspace code/test activity (supported via fake adapter).
+ * R2–R5 = HOLD (no automatic escalation).
+ */
+export const AGENT_RUNNER_SUPPORTED_RISK_CLASSES = [
+  "R0",
+  "R1",
+] as const satisfies readonly AgentTaskRiskClass[];
+
+export type AgentRunnerStatus =
+  | "COMPLETED"
+  | "HOLD"
+  | "REJECT"
+  | "FAILED"
+  | "UNKNOWN";
+
+export type AgentRunnerReasonCode =
+  | "COMPLETED"
+  | "HOLD_ORCHESTRATOR"
+  | "HOLD_UNSUPPORTED_RISK_CLASS"
+  | "HOLD_UNSUPPORTED_CAPABILITY"
+  | "HOLD_REPOSITORY_MISMATCH"
+  | "HOLD_BASE_REVISION_MISMATCH"
+  | "HOLD_COMMAND_EXECUTION"
+  | "REJECT_INPUT"
+  | "REJECT_ORCHESTRATOR"
+  | "REJECT_DISPATCH_NULL_TASK"
+  | "REJECT_DISPATCH_METADATA_INCONSISTENT"
+  | "REJECT_TASK_MALFORMED"
+  | "REJECT_TASK_SEMANTICS"
+  | "REJECT_TASK_ID_BINDING"
+  | "REJECT_REVALIDATION_MISMATCH"
+  | "REJECT_CHANGED_PATH_UNSAFE"
+  | "REJECT_SYMLINK_WRITE"
+  | "FAILED_ADAPTER"
+  | "FAILED_TIMEOUT"
+  | "FAILED_CHANGED_PATH_OUT_OF_SCOPE"
+  | "FAILED_FORBIDDEN_PATH"
+  | "FAILED_CLEANUP"
+  | "UNKNOWN_ORCHESTRATOR"
+  | "UNKNOWN_RUNNER_STATE";
+
+export interface AgentRunnerInputV1 {
+  orchestratorResult: MinOrchestratorResultV1;
+  runnerAttemptId: string;
+  observedAt: string;
+  workspace: AgentRunnerWorkspaceBindingV1;
+}
+
+export interface AgentRunnerMetadataV1 {
+  observedAt: string;
+  runnerAttemptId: string;
+  adapterKind: string | null;
+  executionInvoked: boolean;
+  cleanupCompleted: boolean;
+  independentVerificationComplete: false;
+  publicationAuthorized: false;
+  readyAuthorized: false;
+  mergeAuthorized: false;
+  githubMutationAuthorized: false;
+  commandExecutionImplemented: false;
+  providerIntegration: typeof AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS;
+  realWorkspaceExecutionImplemented: false;
+}
+
+export interface AgentRunnerResultV1 {
+  schemaVersion: typeof AGENT_RUNNER_RESULT_SCHEMA;
+  runnerVersion: typeof AGENT_RUNNER_VERSION;
+  status: AgentRunnerStatus;
+  reasonCode: AgentRunnerReasonCode;
+  reasonMessage: string;
+  runnerAttemptId: string;
+  taskId: string | null;
+  repository: string | null;
+  baseRevision: string | null;
+  changedPaths: string[];
+  workspaceOutcome: AgentRunnerWorkspaceOutcomeV1 | null;
+  verificationObservation: AgentRunnerVerificationObservationV1 | null;
+  validation: AgentTaskValidationResultV1 | null;
+  metadata: AgentRunnerMetadataV1;
+}
+
+export interface RunAgentTaskV1Options {
+  adapter?: AgentRunnerAdapterV1;
+  validatedAt?: string;
+  treatPrefixOverlapAsHold?: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function isRepository(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(value) &&
+    value.length >= 3 &&
+    value.length <= 256
+  );
+}
+
+function isBaseRevision(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{40}$/.test(value);
+}
+
+function metadataBase(input: {
+  observedAt: string;
+  runnerAttemptId: string;
+  adapterKind?: string | null;
+  executionInvoked?: boolean;
+  cleanupCompleted?: boolean;
+}): AgentRunnerMetadataV1 {
+  return {
+    observedAt: input.observedAt,
+    runnerAttemptId: input.runnerAttemptId,
+    adapterKind: input.adapterKind ?? null,
+    executionInvoked: input.executionInvoked === true,
+    cleanupCompleted: input.cleanupCompleted === true,
+    independentVerificationComplete: false,
+    publicationAuthorized: false,
+    readyAuthorized: false,
+    mergeAuthorized: false,
+    githubMutationAuthorized: false,
+    commandExecutionImplemented: false,
+    providerIntegration: AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS,
+    realWorkspaceExecutionImplemented: false,
+  };
+}
+
+function buildResult(input: {
+  status: AgentRunnerStatus;
+  reasonCode: AgentRunnerReasonCode;
+  reasonMessage: string;
+  runnerAttemptId: string;
+  taskId: string | null;
+  repository: string | null;
+  baseRevision: string | null;
+  changedPaths?: string[];
+  workspaceOutcome?: AgentRunnerWorkspaceOutcomeV1 | null;
+  verificationObservation?: AgentRunnerVerificationObservationV1 | null;
+  validation?: AgentTaskValidationResultV1 | null;
+  observedAt: string;
+  adapterKind?: string | null;
+  executionInvoked?: boolean;
+  cleanupCompleted?: boolean;
+}): AgentRunnerResultV1 {
+  return {
+    schemaVersion: AGENT_RUNNER_RESULT_SCHEMA,
+    runnerVersion: AGENT_RUNNER_VERSION,
+    status: input.status,
+    reasonCode: input.reasonCode,
+    reasonMessage: input.reasonMessage,
+    runnerAttemptId: input.runnerAttemptId,
+    taskId: input.taskId,
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    changedPaths: input.changedPaths ?? [],
+    workspaceOutcome: input.workspaceOutcome ?? null,
+    verificationObservation: input.verificationObservation ?? null,
+    validation: input.validation ?? null,
+    metadata: metadataBase({
+      observedAt: input.observedAt,
+      runnerAttemptId: input.runnerAttemptId,
+      adapterKind: input.adapterKind,
+      executionInvoked: input.executionInvoked,
+      cleanupCompleted: input.cleanupCompleted,
+    }),
+  };
+}
+
+function looksLikeOrchestratorResult(
+  value: unknown,
+): value is MinOrchestratorResultV1 {
+  if (!isPlainObject(value)) return false;
+  if (value.schemaVersion !== MIN_ORCHESTRATOR_RESULT_SCHEMA) return false;
+  if (value.orchestratorVersion !== MIN_ORCHESTRATOR_VERSION) return false;
+  const decision = value.decision;
+  if (
+    decision !== "DISPATCH_ELIGIBLE" &&
+    decision !== "HOLD" &&
+    decision !== "REJECT" &&
+    decision !== "UNKNOWN"
+  ) {
+    return false;
+  }
+  if (typeof value.reasonCode !== "string" || value.reasonCode.length < 1) {
+    return false;
+  }
+  if (
+    typeof value.reasonMessage !== "string" ||
+    value.reasonMessage.length < 1
+  ) {
+    return false;
+  }
+  if (!Object.prototype.hasOwnProperty.call(value, "task")) return false;
+  if (value.task !== null && !isPlainObject(value.task)) return false;
+  if (!isPlainObject(value.metadata)) return false;
+  if (typeof value.metadata.dispatchEligible !== "boolean") return false;
+  if (value.metadata.executionAuthorized !== false) return false;
+  return true;
+}
+
+/**
+ * Fail-closed parse of runner input. Unknown root properties → REJECT.
+ */
+export function parseAgentRunnerInput(
+  value: unknown,
+):
+  | { ok: true; input: AgentRunnerInputV1 }
+  | {
+      ok: false;
+      reasonCode: "REJECT_INPUT";
+      reasonMessage: string;
+    } {
+  if (!isPlainObject(value)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "Runner input must be a JSON object.",
+    };
+  }
+  if (!hasOnlyKeys(value, AGENT_RUNNER_INPUT_ROOT_KEYS)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "Runner input contains unknown properties.",
+    };
+  }
+  if (
+    typeof value.runnerAttemptId !== "string" ||
+    value.runnerAttemptId.length < 1 ||
+    value.runnerAttemptId.length > 128
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "runnerAttemptId must be a non-empty bounded string.",
+    };
+  }
+  if (typeof value.observedAt !== "string" || value.observedAt.length < 1) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "observedAt must be a non-empty string.",
+    };
+  }
+  if (!isPlainObject(value.workspace)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "workspace must be an object.",
+    };
+  }
+  if (!hasOnlyKeys(value.workspace, AGENT_RUNNER_WORKSPACE_KEYS)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "workspace contains unknown properties.",
+    };
+  }
+  if (!isRepository(value.workspace.repository)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "workspace.repository is missing or malformed.",
+    };
+  }
+  if (!isBaseRevision(value.workspace.baseRevision)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage:
+        "workspace.baseRevision must be a 40-character lowercase Git SHA.",
+    };
+  }
+  if (!looksLikeOrchestratorResult(value.orchestratorResult)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "orchestratorResult is missing or malformed.",
+    };
+  }
+
+  return {
+    ok: true,
+    input: {
+      orchestratorResult: value.orchestratorResult,
+      runnerAttemptId: value.runnerAttemptId,
+      observedAt: value.observedAt,
+      workspace: {
+        repository: value.workspace.repository,
+        baseRevision: value.workspace.baseRevision,
+      },
+    },
+  };
+}
+
+function unsupportedCapabilities(task: AgentTaskV1): string[] {
+  const supported = new Set<string>(AGENT_RUNNER_SUPPORTED_CAPABILITIES);
+  return task.allowedCapabilities.filter((cap) => !supported.has(cap));
+}
+
+function isSupportedRiskClass(riskClass: AgentTaskRiskClass): boolean {
+  return (AGENT_RUNNER_SUPPORTED_RISK_CLASSES as readonly string[]).includes(
+    riskClass,
+  );
+}
+
+/**
+ * Enforce changed-path policy after adapter collect.
+ * forbiddenPaths always wins. Unsafe / ambiguous paths fail closed.
+ */
+export function evaluateChangedPathsPolicy(
+  task: AgentTaskV1,
+  changedPaths: string[],
+):
+  | { ok: true }
+  | {
+      ok: false;
+      status: "REJECT" | "FAILED";
+      reasonCode:
+        | "REJECT_CHANGED_PATH_UNSAFE"
+        | "FAILED_CHANGED_PATH_OUT_OF_SCOPE"
+        | "FAILED_FORBIDDEN_PATH";
+      reasonMessage: string;
+      offendingPath: string;
+    } {
+  for (const path of changedPaths) {
+    if (typeof path !== "string" || path.length < 1) {
+      return {
+        ok: false,
+        status: "REJECT",
+        reasonCode: "REJECT_CHANGED_PATH_UNSAFE",
+        reasonMessage: "Changed path is empty or malformed.",
+        offendingPath: String(path),
+      };
+    }
+    // Absolute, backslash, traversal, empty/dot segments — fail closed.
+    if (
+      path.startsWith("/") ||
+      path.includes("\\") ||
+      path.includes("\0") ||
+      !isRepoRelativePath(path)
+    ) {
+      return {
+        ok: false,
+        status: "REJECT",
+        reasonCode: "REJECT_CHANGED_PATH_UNSAFE",
+        reasonMessage: `Changed path fails closed as unsafe or non-repo-relative: ${path}`,
+        offendingPath: path,
+      };
+    }
+
+    const boundary = evaluatePathBoundary(task, path);
+    if (boundary === "FORBIDDEN") {
+      return {
+        ok: false,
+        status: "FAILED",
+        reasonCode: "FAILED_FORBIDDEN_PATH",
+        reasonMessage: `Changed path is forbidden (forbiddenPaths wins): ${path}`,
+        offendingPath: path,
+      };
+    }
+    if (boundary !== "ALLOWED") {
+      return {
+        ok: false,
+        status: "FAILED",
+        reasonCode: "FAILED_CHANGED_PATH_OUT_OF_SCOPE",
+        reasonMessage: `Changed path is outside allowedPaths: ${path}`,
+        offendingPath: path,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+function propagateOrchestratorDecision(
+  orchestratorResult: MinOrchestratorResultV1,
+  runnerAttemptId: string,
+  observedAt: string,
+  workspace: AgentRunnerWorkspaceBindingV1,
+): AgentRunnerResultV1 | null {
+  const decision = orchestratorResult.decision as MinOrchestratorDecision;
+  const taskId = orchestratorResult.task?.taskId ?? null;
+  const repository =
+    orchestratorResult.task?.repository ?? workspace.repository;
+  const baseRevision =
+    orchestratorResult.task?.baseRevision ?? workspace.baseRevision;
+
+  if (decision === "HOLD") {
+    return buildResult({
+      status: "HOLD",
+      reasonCode: "HOLD_ORCHESTRATOR",
+      reasonMessage: `Orchestrator HOLD: ${orchestratorResult.reasonMessage}`,
+      runnerAttemptId,
+      taskId,
+      repository,
+      baseRevision,
+      validation: orchestratorResult.validation,
+      observedAt,
+    });
+  }
+  if (decision === "REJECT") {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_ORCHESTRATOR",
+      reasonMessage: `Orchestrator REJECT: ${orchestratorResult.reasonMessage}`,
+      runnerAttemptId,
+      taskId,
+      repository,
+      baseRevision,
+      validation: orchestratorResult.validation,
+      observedAt,
+    });
+  }
+  if (decision === "UNKNOWN") {
+    return buildResult({
+      status: "UNKNOWN",
+      reasonCode: "UNKNOWN_ORCHESTRATOR",
+      reasonMessage: `Orchestrator UNKNOWN: ${orchestratorResult.reasonMessage}`,
+      runnerAttemptId,
+      taskId,
+      repository,
+      baseRevision,
+      validation: orchestratorResult.validation,
+      observedAt,
+    });
+  }
+  return null;
+}
+
+/**
+ * Run AGENT-RUNNER-V1 against an orchestrator result.
+ * Pure/deterministic aside from the injected adapter. Default adapter is fake.
+ */
+export function runAgentTaskV1(
+  rawInput: unknown,
+  options: RunAgentTaskV1Options = {},
+): AgentRunnerResultV1 {
+  const validatedAt = options.validatedAt ?? new Date(0).toISOString();
+  const adapter = options.adapter ?? createFakeAgentRunnerAdapterV1();
+
+  const parsed = parseAgentRunnerInput(rawInput);
+  if (!parsed.ok) {
+    const attemptId =
+      isPlainObject(rawInput) && typeof rawInput.runnerAttemptId === "string"
+        ? rawInput.runnerAttemptId
+        : "unknown";
+    const observedAt =
+      isPlainObject(rawInput) && typeof rawInput.observedAt === "string"
+        ? rawInput.observedAt
+        : validatedAt;
+    return buildResult({
+      status: "REJECT",
+      reasonCode: parsed.reasonCode,
+      reasonMessage: parsed.reasonMessage,
+      runnerAttemptId: attemptId,
+      taskId: null,
+      repository: null,
+      baseRevision: null,
+      observedAt,
+    });
+  }
+
+  const { orchestratorResult, runnerAttemptId, observedAt, workspace } =
+    parsed.input;
+
+  // Upstream non-dispatch decisions propagate first (no repair).
+  if (orchestratorResult.decision !== "DISPATCH_ELIGIBLE") {
+    const propagated = propagateOrchestratorDecision(
+      orchestratorResult,
+      runnerAttemptId,
+      observedAt,
+      workspace,
+    );
+    if (propagated) return propagated;
+    return buildResult({
+      status: "UNKNOWN",
+      reasonCode: "UNKNOWN_RUNNER_STATE",
+      reasonMessage: "Unrecognized orchestrator decision; fail closed.",
+      runnerAttemptId,
+      taskId: null,
+      repository: workspace.repository,
+      baseRevision: workspace.baseRevision,
+      observedAt,
+    });
+  }
+
+  // DISPATCH_ELIGIBLE path — never trust decision alone.
+  const meta = orchestratorResult.metadata;
+  if (
+    meta.dispatchEligible !== true ||
+    meta.executionAuthorized !== false ||
+    meta.actionGatewayAuthorized !== false ||
+    meta.readyAuthorized !== false ||
+    meta.mergeAuthorized !== false ||
+    meta.githubMutationAuthorized !== false
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_DISPATCH_METADATA_INCONSISTENT",
+      reasonMessage:
+        "DISPATCH_ELIGIBLE metadata is inconsistent with runner preconditions; fail closed.",
+      runnerAttemptId,
+      taskId: orchestratorResult.task?.taskId ?? null,
+      repository: orchestratorResult.task?.repository ?? workspace.repository,
+      baseRevision:
+        orchestratorResult.task?.baseRevision ?? workspace.baseRevision,
+      validation: orchestratorResult.validation,
+      observedAt,
+    });
+  }
+
+  if (orchestratorResult.task === null) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_DISPATCH_NULL_TASK",
+      reasonMessage:
+        "DISPATCH_ELIGIBLE claimed but task is null; fail closed.",
+      runnerAttemptId,
+      taskId: null,
+      repository: workspace.repository,
+      baseRevision: workspace.baseRevision,
+      validation: orchestratorResult.validation,
+      observedAt,
+    });
+  }
+
+  const upstreamTask = orchestratorResult.task;
+
+  // Independent structural + semantic revalidation.
+  const structural = parseAgentTaskV1(upstreamTask);
+  if (!structural.ok) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_TASK_MALFORMED",
+      reasonMessage: `Task failed structural reparse: ${structural.reasonMessage}`,
+      runnerAttemptId,
+      taskId: typeof upstreamTask.taskId === "string" ? upstreamTask.taskId : null,
+      repository: workspace.repository,
+      baseRevision: workspace.baseRevision,
+      observedAt,
+    });
+  }
+
+  const revalidation = validateAgentTaskV1(structural.task, {
+    validatedAt,
+    treatPrefixOverlapAsHold: options.treatPrefixOverlapAsHold,
+  });
+
+  if (revalidation.status !== "VALID") {
+    if (revalidation.status === "HOLD") {
+      return buildResult({
+        status: "HOLD",
+        reasonCode: "HOLD_ORCHESTRATOR",
+        reasonMessage: `Task revalidation HOLD: ${revalidation.reasonMessage}`,
+        runnerAttemptId,
+        taskId: upstreamTask.taskId,
+        repository: upstreamTask.repository,
+        baseRevision: upstreamTask.baseRevision,
+        validation: revalidation,
+        observedAt,
+      });
+    }
+    if (revalidation.status === "UNKNOWN") {
+      return buildResult({
+        status: "UNKNOWN",
+        reasonCode: "UNKNOWN_RUNNER_STATE",
+        reasonMessage: `Task revalidation UNKNOWN: ${revalidation.reasonMessage}`,
+        runnerAttemptId,
+        taskId: upstreamTask.taskId,
+        repository: upstreamTask.repository,
+        baseRevision: upstreamTask.baseRevision,
+        validation: revalidation,
+        observedAt,
+      });
+    }
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_TASK_SEMANTICS",
+      reasonMessage: revalidation.reasonMessage,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  if (revalidation.taskId !== upstreamTask.taskId) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_TASK_ID_BINDING",
+      reasonMessage: `validation.taskId (${String(revalidation.taskId)}) is not bound to task.taskId (${upstreamTask.taskId}); fail closed.`,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  if (
+    orchestratorResult.validation !== null &&
+    orchestratorResult.validation.taskId !== upstreamTask.taskId
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_REVALIDATION_MISMATCH",
+      reasonMessage: `Orchestrator validation.taskId (${String(orchestratorResult.validation.taskId)}) is not bound to task.taskId (${upstreamTask.taskId}); fail closed.`,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  // Exact workspace identity binding — no fetch/rebase/substitution.
+  if (workspace.repository !== upstreamTask.repository) {
+    return buildResult({
+      status: "HOLD",
+      reasonCode: "HOLD_REPOSITORY_MISMATCH",
+      reasonMessage: `workspace.repository (${workspace.repository}) !== task.repository (${upstreamTask.repository}); exact equality required.`,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  if (workspace.baseRevision !== upstreamTask.baseRevision) {
+    return buildResult({
+      status: "HOLD",
+      reasonCode: "HOLD_BASE_REVISION_MISMATCH",
+      reasonMessage: `workspace.baseRevision (${workspace.baseRevision}) !== task.baseRevision (${upstreamTask.baseRevision}); exact equality required; no fetch/rebase/substitution.`,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  if (!isSupportedRiskClass(upstreamTask.riskClass)) {
+    return buildResult({
+      status: "HOLD",
+      reasonCode: "HOLD_UNSUPPORTED_RISK_CLASS",
+      reasonMessage: `riskClass=${upstreamTask.riskClass} is not executable in AGENT-RUNNER-V1 (only R0/R1). No automatic escalation.`,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  const unknownCaps = unsupportedCapabilities(upstreamTask);
+  if (unknownCaps.length > 0) {
+    return buildResult({
+      status: "HOLD",
+      reasonCode: "HOLD_UNSUPPORTED_CAPABILITY",
+      reasonMessage: `Unsupported capability for AGENT-RUNNER-V1: ${unknownCaps.join(", ")}. workspace.write.v1 / command.execute.v1 remain HOLD; no material authority expansion in this slice.`,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  // Adapter invocation path — domain has authorized isolated activity only.
+  const ctx = {
+    runnerAttemptId,
+    task: upstreamTask,
+    workspace,
+    observedAt,
+  };
+
+  let cleanupCompleted = false;
+  const finishCleanup = (): boolean => {
+    const cleanup = adapter.cleanupWorkspace(ctx);
+    cleanupCompleted = cleanup.ok && cleanup.cleaned;
+    return cleanup.ok;
+  };
+
+  const prepared = adapter.prepareWorkspace(ctx);
+  if (!prepared.ok) {
+    finishCleanup();
+    return buildResult({
+      status: "FAILED",
+      reasonCode: "FAILED_ADAPTER",
+      reasonMessage:
+        prepared.reasonMessage ?? "Adapter prepareWorkspace failed.",
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+      adapterKind: adapter.kind,
+      executionInvoked: false,
+      cleanupCompleted,
+    });
+  }
+
+  const executed = adapter.executeTask(ctx);
+  if (!executed.ok) {
+    finishCleanup();
+    return buildResult({
+      status: "FAILED",
+      reasonCode: executed.timedOut ? "FAILED_TIMEOUT" : "FAILED_ADAPTER",
+      reasonMessage:
+        executed.reasonMessage ??
+        (executed.timedOut
+          ? "Adapter executeTask timed out."
+          : "Adapter executeTask failed."),
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+      adapterKind: adapter.kind,
+      executionInvoked: true,
+      cleanupCompleted,
+    });
+  }
+
+  const collected = adapter.collectOutcome(ctx);
+  if (!collected.ok) {
+    finishCleanup();
+    return buildResult({
+      status: "FAILED",
+      reasonCode: "FAILED_ADAPTER",
+      reasonMessage:
+        collected.reasonMessage ?? "Adapter collectOutcome failed.",
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      changedPaths: collected.changedPaths,
+      workspaceOutcome: collected.workspaceOutcome,
+      verificationObservation: collected.verificationObservation,
+      validation: revalidation,
+      observedAt,
+      adapterKind: adapter.kind,
+      executionInvoked: true,
+      cleanupCompleted,
+    });
+  }
+
+  if (collected.symlinkWriteAttempted) {
+    finishCleanup();
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_SYMLINK_WRITE",
+      reasonMessage:
+        "Symlink-based writes are rejected entirely in AGENT-RUNNER-V1; safe containment cannot be proven.",
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      changedPaths: collected.changedPaths,
+      workspaceOutcome: collected.workspaceOutcome,
+      verificationObservation: collected.verificationObservation,
+      validation: revalidation,
+      observedAt,
+      adapterKind: adapter.kind,
+      executionInvoked: true,
+      cleanupCompleted,
+    });
+  }
+
+  const pathPolicy = evaluateChangedPathsPolicy(
+    upstreamTask,
+    collected.changedPaths,
+  );
+  if (!pathPolicy.ok) {
+    finishCleanup();
+    return buildResult({
+      status: pathPolicy.status,
+      reasonCode: pathPolicy.reasonCode,
+      reasonMessage: pathPolicy.reasonMessage,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      changedPaths: collected.changedPaths,
+      workspaceOutcome: collected.workspaceOutcome,
+      verificationObservation: collected.verificationObservation,
+      validation: revalidation,
+      observedAt,
+      adapterKind: adapter.kind,
+      executionInvoked: true,
+      cleanupCompleted,
+    });
+  }
+
+  const cleanupOk = finishCleanup();
+  if (!cleanupOk) {
+    return buildResult({
+      status: "FAILED",
+      reasonCode: "FAILED_CLEANUP",
+      reasonMessage: "Adapter cleanupWorkspace failed after execution.",
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      changedPaths: collected.changedPaths,
+      workspaceOutcome: collected.workspaceOutcome,
+      verificationObservation: collected.verificationObservation,
+      validation: revalidation,
+      observedAt,
+      adapterKind: adapter.kind,
+      executionInvoked: true,
+      cleanupCompleted: false,
+    });
+  }
+
+  return buildResult({
+    status: "COMPLETED",
+    reasonCode: "COMPLETED",
+    reasonMessage:
+      "Isolated runner activity completed via fake/in-memory adapter. COMPLETED ≠ independent verification, publication, Ready, Merge, or GitHub mutation authorization.",
+    runnerAttemptId,
+    taskId: upstreamTask.taskId,
+    repository: upstreamTask.repository,
+    baseRevision: upstreamTask.baseRevision,
+    changedPaths: collected.changedPaths,
+    workspaceOutcome: collected.workspaceOutcome,
+    verificationObservation: collected.verificationObservation,
+    validation: revalidation,
+    observedAt,
+    adapterKind: adapter.kind,
+    executionInvoked: true,
+    cleanupCompleted: true,
+  });
+}
+
+export function assertAgentRunnerBoundaries(): void {
+  if (AGENT_RUNNER_COMMAND_EXECUTION_IMPLEMENTED) {
+    throw new Error(
+      "AGENT-RUNNER-V1 command execution must remain NOT IMPLEMENTED",
+    );
+  }
+  if (AGENT_RUNNER_GITHUB_PUBLICATION_IMPLEMENTED) {
+    throw new Error(
+      "AGENT-RUNNER-V1 GitHub publication must remain NOT IMPLEMENTED",
+    );
+  }
+  if (AGENT_RUNNER_REAL_WORKSPACE_EXECUTION_IMPLEMENTED) {
+    throw new Error(
+      "AGENT-RUNNER-V1 real workspace execution must remain NOT IMPLEMENTED",
+    );
+  }
+  if (AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS !== "HOLD") {
+    throw new Error("AGENT-RUNNER-V1 provider integration must remain HOLD");
+  }
+}

--- a/src/domain/agentRunner.ts
+++ b/src/domain/agentRunner.ts
@@ -17,6 +17,7 @@ import {
   parseAgentTaskV1,
   validateAgentTaskV1,
   type AgentTaskRiskClass,
+  type AgentTaskStopAt,
   type AgentTaskV1,
   type AgentTaskValidationResultV1,
 } from "./agentTaskContract";
@@ -105,6 +106,19 @@ export const AGENT_RUNNER_SUPPORTED_RISK_CLASSES = [
   "R1",
 ] as const satisfies readonly AgentTaskRiskClass[];
 
+/**
+ * stopAt values that may reach adapter invocation in V1.
+ * TASK_BUILT = contract-only / no runner activity → HOLD.
+ * AGENT_COMPLETE / VERIFY_COMPLETE / DRAFT_PR = runner stage allowed.
+ * Runner responsibility ends at isolated Agent activity; COMPLETED never
+ * means independent verification or Draft PR publication was achieved.
+ */
+export const AGENT_RUNNER_SUPPORTED_STOP_AT = [
+  "AGENT_COMPLETE",
+  "VERIFY_COMPLETE",
+  "DRAFT_PR",
+] as const satisfies readonly AgentTaskStopAt[];
+
 export type AgentRunnerStatus =
   | "COMPLETED"
   | "HOLD"
@@ -115,6 +129,8 @@ export type AgentRunnerStatus =
 export type AgentRunnerReasonCode =
   | "COMPLETED"
   | "HOLD_ORCHESTRATOR"
+  | "HOLD_STOP_AT_TASK_BUILT"
+  | "HOLD_UNSUPPORTED_STOP_AT"
   | "HOLD_UNSUPPORTED_RISK_CLASS"
   | "HOLD_UNSUPPORTED_CAPABILITY"
   | "HOLD_REPOSITORY_MISMATCH"
@@ -409,6 +425,10 @@ function isSupportedRiskClass(riskClass: AgentTaskRiskClass): boolean {
   return (AGENT_RUNNER_SUPPORTED_RISK_CLASSES as readonly string[]).includes(
     riskClass,
   );
+}
+
+function isSupportedStopAt(stopAt: AgentTaskStopAt): boolean {
+  return (AGENT_RUNNER_SUPPORTED_STOP_AT as readonly string[]).includes(stopAt);
 }
 
 /**
@@ -744,6 +764,36 @@ export function runAgentTaskV1(
       status: "HOLD",
       reasonCode: "HOLD_BASE_REVISION_MISMATCH",
       reasonMessage: `workspace.baseRevision (${workspace.baseRevision}) !== task.baseRevision (${upstreamTask.baseRevision}); exact equality required; no fetch/rebase/substitution.`,
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  // Independent stopAt policy — never trust DISPATCH_ELIGIBLE alone.
+  if (upstreamTask.stopAt === "TASK_BUILT") {
+    return buildResult({
+      status: "HOLD",
+      reasonCode: "HOLD_STOP_AT_TASK_BUILT",
+      reasonMessage:
+        "stopAt=TASK_BUILT means no runner activity; adapter must not be invoked.",
+      runnerAttemptId,
+      taskId: upstreamTask.taskId,
+      repository: upstreamTask.repository,
+      baseRevision: upstreamTask.baseRevision,
+      validation: revalidation,
+      observedAt,
+    });
+  }
+
+  if (!isSupportedStopAt(upstreamTask.stopAt)) {
+    return buildResult({
+      status: "HOLD",
+      reasonCode: "HOLD_UNSUPPORTED_STOP_AT",
+      reasonMessage: `stopAt=${upstreamTask.stopAt} is unsupported for AGENT-RUNNER-V1; fail closed.`,
       runnerAttemptId,
       taskId: upstreamTask.taskId,
       repository: upstreamTask.repository,

--- a/src/domain/agentRunnerAdapter.ts
+++ b/src/domain/agentRunnerAdapter.ts
@@ -1,0 +1,261 @@
+/**
+ * AGENT-RUNNER-V1 adapter boundary.
+ *
+ * Provider-neutral isolated-workspace interface. Domain runner decides whether
+ * any adapter method may be invoked. Adapters MUST NOT decide task authority.
+ *
+ * V1 ships a fake/in-memory adapter only.
+ * PROVIDER INTEGRATION = HOLD (no Codex / Cursor remote / network / secrets).
+ * COMMAND EXECUTION = HOLD (no arbitrary shell).
+ */
+
+import type { AgentTaskV1 } from "./agentTaskContract";
+
+export const AGENT_RUNNER_ADAPTER_FAKE = "fake-in-memory" as const;
+export const AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS = "HOLD" as const;
+export const AGENT_RUNNER_COMMAND_EXECUTION_IMPLEMENTED = false as const;
+export const AGENT_RUNNER_GITHUB_PUBLICATION_IMPLEMENTED = false as const;
+export const AGENT_RUNNER_REAL_WORKSPACE_EXECUTION_IMPLEMENTED = false as const;
+
+export type AgentRunnerAdapterKindV1 = typeof AGENT_RUNNER_ADAPTER_FAKE;
+
+export interface AgentRunnerWorkspaceBindingV1 {
+  repository: string;
+  baseRevision: string;
+}
+
+export interface AgentRunnerAdapterContextV1 {
+  runnerAttemptId: string;
+  task: AgentTaskV1;
+  workspace: AgentRunnerWorkspaceBindingV1;
+  observedAt: string;
+}
+
+export type AgentRunnerAdapterPhaseFailure =
+  | "prepare"
+  | "execute"
+  | "collect"
+  | "cleanup"
+  | "timeout";
+
+export interface AgentRunnerPrepareResultV1 {
+  ok: boolean;
+  workspaceId: string | null;
+  reasonCode?: string;
+  reasonMessage?: string;
+}
+
+export interface AgentRunnerExecuteResultV1 {
+  ok: boolean;
+  timedOut?: boolean;
+  reasonCode?: string;
+  reasonMessage?: string;
+}
+
+export interface AgentRunnerCollectResultV1 {
+  ok: boolean;
+  changedPaths: string[];
+  /** When true, adapter asserts a symlink-based write was attempted. */
+  symlinkWriteAttempted: boolean;
+  workspaceOutcome: AgentRunnerWorkspaceOutcomeV1;
+  verificationObservation: AgentRunnerVerificationObservationV1;
+  reasonCode?: string;
+  reasonMessage?: string;
+}
+
+export interface AgentRunnerCleanupResultV1 {
+  ok: boolean;
+  cleaned: boolean;
+  reasonCode?: string;
+  reasonMessage?: string;
+}
+
+export interface AgentRunnerWorkspaceOutcomeV1 {
+  adapterKind: AgentRunnerAdapterKindV1;
+  workspaceId: string | null;
+  prepared: boolean;
+  executed: boolean;
+  isolated: true;
+  networkAccess: false;
+  secretsRequired: false;
+  githubMutationPerformed: false;
+  productionMutationPerformed: false;
+  notes: string[];
+}
+
+export interface AgentRunnerVerificationObservationV1 {
+  /**
+   * V1 does not execute verificationCommands.
+   * Observation records that command execution remains HOLD.
+   */
+  commandExecutionImplemented: false;
+  commandsObserved: [];
+  notes: string[];
+}
+
+/**
+ * Provider-neutral adapter. Domain layer owns authority; adapter only performs
+ * isolated workspace activity when invoked.
+ */
+export interface AgentRunnerAdapterV1 {
+  readonly kind: AgentRunnerAdapterKindV1;
+  prepareWorkspace(
+    ctx: AgentRunnerAdapterContextV1,
+  ): AgentRunnerPrepareResultV1;
+  executeTask(ctx: AgentRunnerAdapterContextV1): AgentRunnerExecuteResultV1;
+  collectOutcome(ctx: AgentRunnerAdapterContextV1): AgentRunnerCollectResultV1;
+  cleanupWorkspace(
+    ctx: AgentRunnerAdapterContextV1,
+  ): AgentRunnerCleanupResultV1;
+}
+
+export interface FakeAgentRunnerAdapterOptionsV1 {
+  /** Deterministic changed paths reported by collectOutcome. */
+  changedPaths?: string[];
+  /** Force a phase failure for negative tests. */
+  failAt?: AgentRunnerAdapterPhaseFailure;
+  /** When true, collectOutcome reports a symlink write attempt. */
+  symlinkWriteAttempted?: boolean;
+  /** Optional failure messages. */
+  failureReasonCode?: string;
+  failureReasonMessage?: string;
+}
+
+/**
+ * Deterministic in-memory adapter for domain tests.
+ * Performs no filesystem, network, GitHub, or shell activity.
+ */
+export function createFakeAgentRunnerAdapterV1(
+  options: FakeAgentRunnerAdapterOptionsV1 = {},
+): AgentRunnerAdapterV1 {
+  const changedPaths = options.changedPaths ?? [];
+  const failAt = options.failAt;
+  const symlinkWriteAttempted = options.symlinkWriteAttempted === true;
+  const failureReasonCode = options.failureReasonCode ?? "ADAPTER_FAILURE";
+  const failureReasonMessage =
+    options.failureReasonMessage ?? "Fake adapter forced failure.";
+
+  let workspaceId: string | null = null;
+  let prepared = false;
+  let executed = false;
+
+  return {
+    kind: AGENT_RUNNER_ADAPTER_FAKE,
+
+    prepareWorkspace(ctx) {
+      if (failAt === "prepare") {
+        return {
+          ok: false,
+          workspaceId: null,
+          reasonCode: failureReasonCode,
+          reasonMessage: failureReasonMessage,
+        };
+      }
+      workspaceId = `fake-ws:${ctx.runnerAttemptId}`;
+      prepared = true;
+      return { ok: true, workspaceId };
+    },
+
+    executeTask(_ctx) {
+      if (failAt === "timeout") {
+        return {
+          ok: false,
+          timedOut: true,
+          reasonCode: "ADAPTER_TIMEOUT",
+          reasonMessage: failureReasonMessage,
+        };
+      }
+      if (failAt === "execute") {
+        return {
+          ok: false,
+          timedOut: false,
+          reasonCode: failureReasonCode,
+          reasonMessage: failureReasonMessage,
+        };
+      }
+      executed = true;
+      return { ok: true };
+    },
+
+    collectOutcome(ctx) {
+      if (failAt === "collect") {
+        return {
+          ok: false,
+          changedPaths: [],
+          symlinkWriteAttempted: false,
+          workspaceOutcome: emptyWorkspaceOutcome(workspaceId, prepared, executed),
+          verificationObservation: holdVerificationObservation(),
+          reasonCode: failureReasonCode,
+          reasonMessage: failureReasonMessage,
+        };
+      }
+      return {
+        ok: true,
+        changedPaths: [...changedPaths],
+        symlinkWriteAttempted,
+        workspaceOutcome: {
+          adapterKind: AGENT_RUNNER_ADAPTER_FAKE,
+          workspaceId,
+          prepared,
+          executed,
+          isolated: true,
+          networkAccess: false,
+          secretsRequired: false,
+          githubMutationPerformed: false,
+          productionMutationPerformed: false,
+          notes: [
+            `Fake isolated activity for task ${ctx.task.taskId}.`,
+            "No filesystem, network, GitHub, or shell side effects.",
+          ],
+        },
+        verificationObservation: holdVerificationObservation(),
+      };
+    },
+
+    cleanupWorkspace(_ctx) {
+      if (failAt === "cleanup") {
+        return {
+          ok: false,
+          cleaned: false,
+          reasonCode: failureReasonCode,
+          reasonMessage: failureReasonMessage,
+        };
+      }
+      const cleaned = prepared;
+      workspaceId = null;
+      prepared = false;
+      executed = false;
+      return { ok: true, cleaned };
+    },
+  };
+}
+
+function emptyWorkspaceOutcome(
+  workspaceId: string | null,
+  prepared: boolean,
+  executed: boolean,
+): AgentRunnerWorkspaceOutcomeV1 {
+  return {
+    adapterKind: AGENT_RUNNER_ADAPTER_FAKE,
+    workspaceId,
+    prepared,
+    executed,
+    isolated: true,
+    networkAccess: false,
+    secretsRequired: false,
+    githubMutationPerformed: false,
+    productionMutationPerformed: false,
+    notes: ["Adapter collect failed before outcome materialization."],
+  };
+}
+
+function holdVerificationObservation(): AgentRunnerVerificationObservationV1 {
+  return {
+    commandExecutionImplemented: false,
+    commandsObserved: [],
+    notes: [
+      "COMMAND EXECUTION = HOLD in AGENT-RUNNER-V1.",
+      "verificationCommands are not executed by the fake adapter.",
+    ],
+  };
+}

--- a/test/agentRunner.test.ts
+++ b/test/agentRunner.test.ts
@@ -1,0 +1,642 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentTaskFromIssue,
+  type AgentTaskBuilderResultV1,
+} from "../src/domain/agentTaskBuilder";
+import {
+  AGENT_TASK_SCHEMA,
+  AGENT_TASK_VALIDATION_RESULT_SCHEMA,
+  type AgentTaskV1,
+  type AgentTaskValidationResultV1,
+} from "../src/domain/agentTaskContract";
+import {
+  AGENT_RUNNER_COMMAND_EXECUTION_IMPLEMENTED,
+  AGENT_RUNNER_GITHUB_PUBLICATION_IMPLEMENTED,
+  AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS,
+  AGENT_RUNNER_REAL_WORKSPACE_EXECUTION_IMPLEMENTED,
+  AGENT_RUNNER_RESULT_SCHEMA,
+  AGENT_RUNNER_SUPPORTED_CAPABILITIES,
+  AGENT_RUNNER_SUPPORTED_RISK_CLASSES,
+  AGENT_RUNNER_VERSION,
+  assertAgentRunnerBoundaries,
+  createFakeAgentRunnerAdapterV1,
+  evaluateChangedPathsPolicy,
+  parseAgentRunnerInput,
+  runAgentTaskV1,
+} from "../src/domain/agentRunner";
+import {
+  orchestrateAgentTaskV1,
+  type MinOrchestratorResultV1,
+} from "../src/domain/minOrchestrator";
+
+const BASE = "032bd6e88d4cd6f62d4621a840bcd2b3d37cd82e";
+const OTHER_BASE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OBSERVED_AT = "2026-08-12T11:21:00.000Z";
+const VALIDATED_AT = "2026-08-12T11:21:30.000Z";
+const REVALIDATED_AT = "2026-08-12T11:22:00.000Z";
+const REPO = "yasutakesougo/ai-development-control-center";
+const ATTEMPT = "runner-attempt-49-1";
+
+const ALLOWED_DOC = "docs/agent-runner/agent-runner-v1.md";
+const ALLOWED_SRC = "src/domain/agentRunner.ts";
+const ALLOWED_TEST = "test/agentRunner.test.ts";
+
+function builtFromBuilder(
+  overrides: {
+    allowedCapabilities?: string[];
+    riskClass?: AgentTaskV1["riskClass"];
+    stopAt?: AgentTaskV1["stopAt"];
+    allowedPaths?: string[];
+    forbiddenPaths?: string[];
+    baseRevision?: string;
+    repository?: string;
+  } = {},
+): AgentTaskBuilderResultV1 {
+  return buildAgentTaskFromIssue(
+    {
+      repository: overrides.repository ?? REPO,
+      issueNumber: 49,
+      baseRevision: overrides.baseRevision ?? BASE,
+      issueTitle:
+        "AGENT-RUNNER-V1 — isolated execution contract and bounded runner interface",
+      issueBody:
+        "Isolated runner contract + fake adapter only. No GitHub publication.",
+      issueLabels: ["agent-runner"],
+      observedAt: OBSERVED_AT,
+      proposal: {
+        allowedPaths: overrides.allowedPaths ?? [
+          "docs/agent-runner/",
+          "src/domain/agentRunner.ts",
+          "src/domain/agentRunnerAdapter.ts",
+          "test/agentRunner.test.ts",
+        ],
+        forbiddenPaths: overrides.forbiddenPaths ?? [
+          ".github/workflows/",
+          "migrations/",
+        ],
+        acceptanceCriteria: [
+          "DISPATCH_ELIGIBLE R1 can COMPLETE via fake adapter",
+          "npm run verify passes",
+          "No GitHub publication or provider remote execution",
+        ],
+        verificationCommands: [
+          {
+            id: "verify.all",
+            command: "npm run verify",
+            description: "Typecheck, test, and build",
+          },
+        ],
+        allowedCapabilities: overrides.allowedCapabilities,
+        riskClass: overrides.riskClass ?? "R1",
+        stopAt: overrides.stopAt ?? "AGENT_COMPLETE",
+        constraints: {
+          maxChangedFiles: 16,
+          requireIndependentVerify: true,
+        },
+      },
+    },
+    { validatedAt: VALIDATED_AT },
+  );
+}
+
+function dispatchEligible(
+  overrides: Parameters<typeof builtFromBuilder>[0] = {},
+): MinOrchestratorResultV1 {
+  const built = builtFromBuilder(overrides);
+  const out = orchestrateAgentTaskV1(
+    {
+      builderResult: built,
+      observedAt: OBSERVED_AT,
+      attemptId: "orch-49",
+    },
+    { revalidatedAt: REVALIDATED_AT },
+  );
+  expect(out.decision).toBe("DISPATCH_ELIGIBLE");
+  return out;
+}
+
+function runnerInput(
+  orchestratorResult: MinOrchestratorResultV1,
+  workspace: { repository?: string; baseRevision?: string } = {},
+) {
+  return {
+    orchestratorResult,
+    runnerAttemptId: ATTEMPT,
+    observedAt: OBSERVED_AT,
+    workspace: {
+      repository: workspace.repository ?? REPO,
+      baseRevision: workspace.baseRevision ?? BASE,
+    },
+  };
+}
+
+function run(
+  orchestratorResult: MinOrchestratorResultV1,
+  opts: {
+    workspace?: { repository?: string; baseRevision?: string };
+    adapter?: ReturnType<typeof createFakeAgentRunnerAdapterV1>;
+  } = {},
+) {
+  return runAgentTaskV1(runnerInput(orchestratorResult, opts.workspace), {
+    adapter: opts.adapter,
+    validatedAt: REVALIDATED_AT,
+  });
+}
+
+function syntheticOrchestrator(
+  overrides: Partial<MinOrchestratorResultV1> &
+    Pick<MinOrchestratorResultV1, "decision">,
+): MinOrchestratorResultV1 {
+  const base = dispatchEligible();
+  return {
+    ...base,
+    ...overrides,
+    metadata: {
+      ...base.metadata,
+      ...(overrides.metadata ?? {}),
+    },
+  };
+}
+
+function validationStub(
+  status: AgentTaskValidationResultV1["status"],
+  taskId: string | null,
+): AgentTaskValidationResultV1 {
+  return {
+    schemaVersion: AGENT_TASK_VALIDATION_RESULT_SCHEMA,
+    taskId,
+    status,
+    reasonCode: status,
+    reasonMessage: `stub ${status}`,
+    validatedAt: VALIDATED_AT,
+  };
+}
+
+describe("AGENT-RUNNER-V1 non-goals / boundaries", () => {
+  it("keeps command execution, real workspace, GitHub publication, and provider remote HOLD", () => {
+    expect(AGENT_RUNNER_COMMAND_EXECUTION_IMPLEMENTED).toBe(false);
+    expect(AGENT_RUNNER_REAL_WORKSPACE_EXECUTION_IMPLEMENTED).toBe(false);
+    expect(AGENT_RUNNER_GITHUB_PUBLICATION_IMPLEMENTED).toBe(false);
+    expect(AGENT_RUNNER_PROVIDER_INTEGRATION_STATUS).toBe("HOLD");
+    assertAgentRunnerBoundaries();
+  });
+
+  it("documents runner allowlists", () => {
+    expect(AGENT_RUNNER_SUPPORTED_CAPABILITIES).toEqual(["workspace.read.v1"]);
+    expect(AGENT_RUNNER_SUPPORTED_RISK_CLASSES).toEqual(["R0", "R1"]);
+  });
+
+  it("30. core tests require no production/network (fake adapter only)", () => {
+    const adapter = createFakeAgentRunnerAdapterV1({
+      changedPaths: [ALLOWED_DOC],
+    });
+    const out = run(dispatchEligible(), { adapter });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.workspaceOutcome?.networkAccess).toBe(false);
+    expect(out.workspaceOutcome?.secretsRequired).toBe(false);
+    expect(out.workspaceOutcome?.githubMutationPerformed).toBe(false);
+    expect(out.workspaceOutcome?.productionMutationPerformed).toBe(false);
+    expect(out.metadata.providerIntegration).toBe("HOLD");
+  });
+});
+
+describe("AGENT-RUNNER-V1 positive path", () => {
+  it("1. valid DISPATCH_ELIGIBLE R1 input → COMPLETED", () => {
+    const adapter = createFakeAgentRunnerAdapterV1({
+      changedPaths: [ALLOWED_DOC, ALLOWED_SRC],
+    });
+    const out = run(dispatchEligible(), { adapter });
+    expect(out.schemaVersion).toBe(AGENT_RUNNER_RESULT_SCHEMA);
+    expect(out.runnerVersion).toBe(AGENT_RUNNER_VERSION);
+    expect(out.status).toBe("COMPLETED");
+    expect(out.reasonCode).toBe("COMPLETED");
+    expect(out.runnerAttemptId).toBe(ATTEMPT);
+    expect(out.taskId).not.toBeNull();
+    expect(out.repository).toBe(REPO);
+    expect(out.baseRevision).toBe(BASE);
+    expect(out.changedPaths).toEqual([ALLOWED_DOC, ALLOWED_SRC]);
+    expect(out.metadata.executionInvoked).toBe(true);
+    expect(out.metadata.cleanupCompleted).toBe(true);
+    expect(out.metadata.independentVerificationComplete).toBe(false);
+    expect(out.metadata.publicationAuthorized).toBe(false);
+    expect(out.metadata.readyAuthorized).toBe(false);
+    expect(out.metadata.mergeAuthorized).toBe(false);
+    expect(out.metadata.githubMutationAuthorized).toBe(false);
+    expect(out.verificationObservation?.commandExecutionImplemented).toBe(
+      false,
+    );
+  });
+
+  it("16. supported capability workspace.read.v1 → COMPLETED", () => {
+    const orch = dispatchEligible({
+      allowedCapabilities: ["workspace.read.v1"],
+    });
+    const adapter = createFakeAgentRunnerAdapterV1({
+      changedPaths: [ALLOWED_TEST],
+    });
+    const out = run(orch, { adapter });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.changedPaths).toEqual([ALLOWED_TEST]);
+  });
+
+  it("18. allowed changed path → COMPLETED", () => {
+    const adapter = createFakeAgentRunnerAdapterV1({
+      changedPaths: ["docs/agent-runner/notes.md"],
+    });
+    const out = run(dispatchEligible(), { adapter });
+    expect(out.status).toBe("COMPLETED");
+  });
+
+  it("27. deterministic output for same input", () => {
+    const orch = dispatchEligible();
+    const adapterOpts = { changedPaths: [ALLOWED_DOC] };
+    const a = run(orch, {
+      adapter: createFakeAgentRunnerAdapterV1(adapterOpts),
+    });
+    const b = run(orch, {
+      adapter: createFakeAgentRunnerAdapterV1(adapterOpts),
+    });
+    expect(a).toEqual(b);
+  });
+
+  it("28. changedPaths capture", () => {
+    const paths = [ALLOWED_DOC, ALLOWED_SRC, ALLOWED_TEST];
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({ changedPaths: paths }),
+    });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.changedPaths).toEqual(paths);
+  });
+
+  it("R0 read-only path may COMPLETE", () => {
+    const orch = dispatchEligible({ riskClass: "R0" });
+    const out = run(orch, {
+      adapter: createFakeAgentRunnerAdapterV1({ changedPaths: [] }),
+    });
+    expect(out.status).toBe("COMPLETED");
+  });
+});
+
+describe("AGENT-RUNNER-V1 orchestrator propagation", () => {
+  it("2. orchestrator HOLD → HOLD", () => {
+    const hold = syntheticOrchestrator({
+      decision: "HOLD",
+      reasonCode: "HOLD_BUILDER",
+      reasonMessage: "builder held",
+      metadata: {
+        ...dispatchEligible().metadata,
+        dispatchEligible: false,
+      },
+    });
+    const out = run(hold);
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_ORCHESTRATOR");
+    expect(out.metadata.executionInvoked).toBe(false);
+  });
+
+  it("3. orchestrator REJECT → REJECT", () => {
+    const reject = syntheticOrchestrator({
+      decision: "REJECT",
+      reasonCode: "REJECT_BUILDER_INVALID",
+      reasonMessage: "builder invalid",
+      metadata: {
+        ...dispatchEligible().metadata,
+        dispatchEligible: false,
+      },
+    });
+    const out = run(reject);
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_ORCHESTRATOR");
+  });
+
+  it("4. orchestrator UNKNOWN → UNKNOWN", () => {
+    const unknown = syntheticOrchestrator({
+      decision: "UNKNOWN",
+      reasonCode: "UNKNOWN_BUILDER",
+      reasonMessage: "builder unknown",
+      metadata: {
+        ...dispatchEligible().metadata,
+        dispatchEligible: false,
+      },
+    });
+    const out = run(unknown);
+    expect(out.status).toBe("UNKNOWN");
+    expect(out.reasonCode).toBe("UNKNOWN_ORCHESTRATOR");
+  });
+
+  it("5. DISPATCH_ELIGIBLE + null task → REJECT", () => {
+    const bad = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: null,
+    });
+    const out = run(bad);
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_DISPATCH_NULL_TASK");
+  });
+
+  it("6. dispatchEligible metadata mismatch → REJECT", () => {
+    const bad = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      metadata: {
+        ...dispatchEligible().metadata,
+        dispatchEligible: false,
+      },
+    });
+    const out = run(bad);
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_DISPATCH_METADATA_INCONSISTENT");
+  });
+});
+
+describe("AGENT-RUNNER-V1 task revalidation", () => {
+  it("7. task reparse failure → REJECT", () => {
+    const orch = dispatchEligible();
+    const malformed = {
+      ...orch,
+      task: {
+        ...orch.task!,
+        schemaVersion: "NOT-A-TASK",
+      } as unknown as AgentTaskV1,
+    };
+    const out = run(malformed);
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_TASK_MALFORMED");
+  });
+
+  it("8. task semantic validation failure → REJECT", () => {
+    const orch = dispatchEligible();
+    const semanticBad: AgentTaskV1 = {
+      ...orch.task!,
+      sourceIssue: {
+        repository: "other-owner/other-repo",
+        number: orch.task!.sourceIssue.number,
+      },
+    };
+    const out = run({ ...orch, task: semanticBad });
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_TASK_SEMANTICS");
+  });
+
+  it("9. taskId binding mismatch → REJECT", () => {
+    const orch = dispatchEligible();
+    const mismatched = {
+      ...orch,
+      validation: validationStub("VALID", "foreign-task-id"),
+    };
+    const out = run(mismatched);
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_REVALIDATION_MISMATCH");
+  });
+});
+
+describe("AGENT-RUNNER-V1 identity binding", () => {
+  it("10. repository mismatch → HOLD", () => {
+    const out = run(dispatchEligible(), {
+      workspace: { repository: "other-owner/other-repo", baseRevision: BASE },
+    });
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_REPOSITORY_MISMATCH");
+    expect(out.metadata.executionInvoked).toBe(false);
+  });
+
+  it("11. baseRevision mismatch → HOLD", () => {
+    const out = run(dispatchEligible(), {
+      workspace: { repository: REPO, baseRevision: OTHER_BASE },
+    });
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_BASE_REVISION_MISMATCH");
+    expect(out.metadata.executionInvoked).toBe(false);
+  });
+});
+
+describe("AGENT-RUNNER-V1 risk class policy", () => {
+  it("12. R2 → HOLD", () => {
+    // Orchestrator allows R2 as DISPATCH_ELIGIBLE; runner must HOLD.
+    const orch = dispatchEligible({ riskClass: "R2" });
+    expect(orch.decision).toBe("DISPATCH_ELIGIBLE");
+    const out = run(orch);
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_RISK_CLASS");
+  });
+
+  it("13. R3 → HOLD", () => {
+    const orch = dispatchEligible();
+    const r3 = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: { ...orch.task!, riskClass: "R3" },
+    });
+    const out = run(r3);
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_RISK_CLASS");
+  });
+
+  it("14. R4 → HOLD", () => {
+    const orch = dispatchEligible();
+    const r4 = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: { ...orch.task!, riskClass: "R4" },
+    });
+    const out = run(r4);
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_RISK_CLASS");
+  });
+
+  it("15. R5 → HOLD", () => {
+    const orch = dispatchEligible();
+    const r5 = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: { ...orch.task!, riskClass: "R5" },
+    });
+    const out = run(r5);
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_RISK_CLASS");
+  });
+});
+
+describe("AGENT-RUNNER-V1 capability policy", () => {
+  it("17. unsupported capability → HOLD", () => {
+    const orch = dispatchEligible();
+    const withWrite = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: {
+        ...orch.task!,
+        allowedCapabilities: ["workspace.write.v1"],
+      },
+    });
+    const out = run(withWrite);
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_CAPABILITY");
+  });
+
+  it("unsupported command.execute.v1 → HOLD", () => {
+    const orch = dispatchEligible();
+    const withCmd = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: {
+        ...orch.task!,
+        allowedCapabilities: ["command.execute.v1"],
+      },
+    });
+    const out = run(withCmd);
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_UNSUPPORTED_CAPABILITY");
+  });
+});
+
+describe("AGENT-RUNNER-V1 path enforcement", () => {
+  it("19. changed path outside allowedPaths → FAILED", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: ["src/unrelated/secret.ts"],
+      }),
+    });
+    expect(out.status).toBe("FAILED");
+    expect(out.reasonCode).toBe("FAILED_CHANGED_PATH_OUT_OF_SCOPE");
+  });
+
+  it("20. forbiddenPaths override → FAILED", () => {
+    const orch = dispatchEligible({
+      allowedPaths: [
+        "docs/agent-runner/",
+        "src/domain/agentRunner.ts",
+        "test/agentRunner.test.ts",
+      ],
+      forbiddenPaths: [".github/workflows/", "migrations/"],
+    });
+    const out = run(orch, {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: [".github/workflows/ci.yml"],
+      }),
+    });
+    expect(out.status).toBe("FAILED");
+    expect(out.reasonCode).toBe("FAILED_FORBIDDEN_PATH");
+  });
+
+  it("21. ../ traversal → REJECT", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: ["docs/agent-runner/../../etc/passwd"],
+      }),
+    });
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_CHANGED_PATH_UNSAFE");
+  });
+
+  it("22. backslash bypass → REJECT", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: ["docs\\agent-runner\\agent-runner-v1.md"],
+      }),
+    });
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_CHANGED_PATH_UNSAFE");
+  });
+
+  it("23. absolute path → REJECT", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: ["/etc/passwd"],
+      }),
+    });
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_CHANGED_PATH_UNSAFE");
+  });
+
+  it("24. symlink escape behavior → REJECT", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: [ALLOWED_DOC],
+        symlinkWriteAttempted: true,
+      }),
+    });
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_SYMLINK_WRITE");
+  });
+
+  it("evaluateChangedPathsPolicy unit: empty path unsafe", () => {
+    const task = dispatchEligible().task!;
+    const result = evaluateChangedPathsPolicy(task, [""]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reasonCode).toBe("REJECT_CHANGED_PATH_UNSAFE");
+    }
+  });
+});
+
+describe("AGENT-RUNNER-V1 adapter failures", () => {
+  it("25. adapter failure → FAILED", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({
+        failAt: "execute",
+        failureReasonMessage: "boom",
+      }),
+    });
+    expect(out.status).toBe("FAILED");
+    expect(out.reasonCode).toBe("FAILED_ADAPTER");
+    expect(out.reasonMessage).toContain("boom");
+    expect(out.metadata.executionInvoked).toBe(true);
+  });
+
+  it("26. timeout → FAILED", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({ failAt: "timeout" }),
+    });
+    expect(out.status).toBe("FAILED");
+    expect(out.reasonCode).toBe("FAILED_TIMEOUT");
+  });
+
+  it("prepare failure → FAILED without claiming full execution success", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({ failAt: "prepare" }),
+    });
+    expect(out.status).toBe("FAILED");
+    expect(out.reasonCode).toBe("FAILED_ADAPTER");
+    expect(out.metadata.executionInvoked).toBe(false);
+  });
+});
+
+describe("AGENT-RUNNER-V1 side-effect boundary", () => {
+  it("29. no GitHub mutation authorization or performance", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: [ALLOWED_DOC],
+      }),
+    });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.metadata.githubMutationAuthorized).toBe(false);
+    expect(out.metadata.publicationAuthorized).toBe(false);
+    expect(out.workspaceOutcome?.githubMutationPerformed).toBe(false);
+  });
+
+  it("rejects unknown input root properties", () => {
+    const parsed = parseAgentRunnerInput({
+      ...runnerInput(dispatchEligible()),
+      extra: true,
+    });
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.reasonCode).toBe("REJECT_INPUT");
+    }
+  });
+
+  it("COMPLETED does not authorize Ready/Merge/verify", () => {
+    const out = run(dispatchEligible(), {
+      adapter: createFakeAgentRunnerAdapterV1({ changedPaths: [] }),
+    });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.metadata.readyAuthorized).toBe(false);
+    expect(out.metadata.mergeAuthorized).toBe(false);
+    expect(out.metadata.independentVerificationComplete).toBe(false);
+  });
+});
+
+describe("AGENT-RUNNER-V1 schema constants", () => {
+  it("uses AGENT-TASK-V1 schema on completed task identity", () => {
+    const orch = dispatchEligible();
+    expect(orch.task!.schemaVersion).toBe(AGENT_TASK_SCHEMA);
+    const out = run(orch, {
+      adapter: createFakeAgentRunnerAdapterV1({ changedPaths: [] }),
+    });
+    expect(out.taskId).toBe(orch.task!.taskId);
+  });
+});

--- a/test/agentRunner.test.ts
+++ b/test/agentRunner.test.ts
@@ -17,6 +17,7 @@ import {
   AGENT_RUNNER_RESULT_SCHEMA,
   AGENT_RUNNER_SUPPORTED_CAPABILITIES,
   AGENT_RUNNER_SUPPORTED_RISK_CLASSES,
+  AGENT_RUNNER_SUPPORTED_STOP_AT,
   AGENT_RUNNER_VERSION,
   assertAgentRunnerBoundaries,
   createFakeAgentRunnerAdapterV1,
@@ -184,6 +185,11 @@ describe("AGENT-RUNNER-V1 non-goals / boundaries", () => {
   it("documents runner allowlists", () => {
     expect(AGENT_RUNNER_SUPPORTED_CAPABILITIES).toEqual(["workspace.read.v1"]);
     expect(AGENT_RUNNER_SUPPORTED_RISK_CLASSES).toEqual(["R0", "R1"]);
+    expect(AGENT_RUNNER_SUPPORTED_STOP_AT).toEqual([
+      "AGENT_COMPLETE",
+      "VERIFY_COMPLETE",
+      "DRAFT_PR",
+    ]);
   });
 
   it("30. core tests require no production/network (fake adapter only)", () => {
@@ -406,6 +412,78 @@ describe("AGENT-RUNNER-V1 identity binding", () => {
     expect(out.status).toBe("HOLD");
     expect(out.reasonCode).toBe("HOLD_BASE_REVISION_MISMATCH");
     expect(out.metadata.executionInvoked).toBe(false);
+  });
+});
+
+describe("AGENT-RUNNER-V1 stopAt policy (independent of orchestrator)", () => {
+  it("forged DISPATCH_ELIGIBLE + stopAt=TASK_BUILT → HOLD, adapter not invoked", () => {
+    const orch = dispatchEligible();
+    const forged = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: { ...orch.task!, stopAt: "TASK_BUILT", riskClass: "R1" },
+      metadata: {
+        ...orch.metadata,
+        dispatchEligible: true,
+        executionAuthorized: false,
+      },
+    });
+    expect(forged.decision).toBe("DISPATCH_ELIGIBLE");
+    expect(forged.metadata.dispatchEligible).toBe(true);
+    expect(forged.task!.stopAt).toBe("TASK_BUILT");
+
+    const out = run(forged, {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: [ALLOWED_DOC],
+      }),
+    });
+    expect(out.status).toBe("HOLD");
+    expect(out.reasonCode).toBe("HOLD_STOP_AT_TASK_BUILT");
+    expect(out.metadata.executionInvoked).toBe(false);
+  });
+
+  it("supported stopAt=AGENT_COMPLETE → existing positive path", () => {
+    const orch = dispatchEligible({ stopAt: "AGENT_COMPLETE" });
+    expect(orch.task!.stopAt).toBe("AGENT_COMPLETE");
+    const out = run(orch, {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: [ALLOWED_DOC],
+      }),
+    });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.metadata.executionInvoked).toBe(true);
+  });
+
+  it("supported stopAt=VERIFY_COMPLETE may COMPLETE without claiming verification", () => {
+    const orch = dispatchEligible();
+    const forged = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: { ...orch.task!, stopAt: "VERIFY_COMPLETE", riskClass: "R1" },
+    });
+    const out = run(forged, {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: [ALLOWED_SRC],
+      }),
+    });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.metadata.independentVerificationComplete).toBe(false);
+    expect(out.metadata.publicationAuthorized).toBe(false);
+  });
+
+  it("supported stopAt=DRAFT_PR may COMPLETE without claiming publication", () => {
+    const orch = dispatchEligible();
+    const forged = syntheticOrchestrator({
+      decision: "DISPATCH_ELIGIBLE",
+      task: { ...orch.task!, stopAt: "DRAFT_PR", riskClass: "R1" },
+    });
+    const out = run(forged, {
+      adapter: createFakeAgentRunnerAdapterV1({
+        changedPaths: [ALLOWED_TEST],
+      }),
+    });
+    expect(out.status).toBe("COMPLETED");
+    expect(out.metadata.independentVerificationComplete).toBe(false);
+    expect(out.metadata.publicationAuthorized).toBe(false);
+    expect(out.metadata.githubMutationAuthorized).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Issue #49: smallest bounded AGENT-RUNNER-V1 layer that consumes `MinOrchestratorResultV1` and performs isolated workspace activity under explicit `AgentTaskV1` authority via a fake/in-memory adapter only.

**This slice does NOT publish changes to GitHub as a product capability.** Delivery branch/PR is implementation packaging only.

## Fresh Review follow-up (P1)

Independent `stopAt` policy added before adapter invocation:

| stopAt | Runner policy |
|---|---|
| `TASK_BUILT` | `HOLD` (`HOLD_STOP_AT_TASK_BUILT`); adapter not invoked |
| `AGENT_COMPLETE` | Runner stage allowed |
| `VERIFY_COMPLETE` | Runner stage allowed; does **not** claim verification |
| `DRAFT_PR` | Runner stage allowed; does **not** claim publication |
| Other / unknown | `HOLD` (`HOLD_UNSUPPORTED_STOP_AT`) |

Regression covers forged `DISPATCH_ELIGIBLE` + `stopAt=TASK_BUILT` (does not go through `orchestrateAgentTaskV1()`).

## Baseline

| Item | Value |
|---|---|
| Exact base SHA | `032bd6e88d4cd6f62d4621a840bcd2b3d37cd82e` |
| Exact HEAD SHA | `823fb7a6ddf23dfef7a29282455b4e1153fb96b4` |
| Issue | #49 |

## Changed files

- `docs/agent-runner/agent-runner-v1.md`
- `src/domain/agentRunner.ts`
- `src/domain/agentRunnerAdapter.ts`
- `test/agentRunner.test.ts`

## Verify

```text
npm run verify
typecheck PASS
tests PASS (480 total; 43 in test/agentRunner.test.ts)
build PASS
```

## Runner state mapping

| Condition | Status |
|---|---|
| Orchestrator HOLD / REJECT / UNKNOWN | HOLD / REJECT / UNKNOWN |
| DISPATCH_ELIGIBLE + null task | REJECT |
| DISPATCH_ELIGIBLE + inconsistent metadata | REJECT |
| Task reparse / semantic failure | REJECT |
| taskId binding mismatch | REJECT |
| repository / baseRevision mismatch | HOLD |
| stopAt = TASK_BUILT | HOLD |
| unsupported stopAt | HOLD |
| R2–R5 | HOLD |
| Unsupported capability | HOLD |
| Adapter error / timeout | FAILED |
| Out-of-scope / forbidden changed path | FAILED |
| Unsafe path / symlink write | REJECT |
| Valid R0/R1 + supported stopAt/caps + exact binding + path policy PASS | COMPLETED |

## Actual execution capability status

| Surface | Status |
|---|---|
| Real execution implemented? | **NO** |
| Provider adapter | **fake/in-memory only** |
| Provider integration (Codex/Cursor remote) | **HOLD** |
| Command execution (`verificationCommands`) | **HOLD** |
| `workspace.write.v1` / `command.execute.v1` | **HOLD** (not added) |
| GitHub publication capability | **NO** |
| Production mutation | **NO** |

Supported runner risk classes: `R0`, `R1`  
Supported stopAt: `AGENT_COMPLETE`, `VERIFY_COMPLETE`, `DRAFT_PR`  
Supported capabilities: `workspace.read.v1` (empty allowlist OK / default-deny)

## Explicit NOT IMPLEMENTED

- INDEPENDENT-VERIFY-V1
- Real Codex / Cursor remote provider execution
- Real filesystem workspace execution
- `verificationCommands` shell execution
- `workspace.write.v1` / `command.execute.v1` authorization
- GitHub branch / commit / push / Draft PR (product capability)
- Ready / Merge / Issue close automation
- deploy / production mutation
- secret provisioning / permission expansion
- Action Gateway execution surface expansion

## Gate

```text
Draft PR → Fresh Review → STOP
```

Do not Ready. Do not Merge. Do not close Issue #49. Do not start INDEPENDENT-VERIFY-V1.

Refs #49

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff5b4-4fc3-7f65-b0d3-5051e83b0872?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff5b4-4fc3-7f65-b0d3-5051e83b0872&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

