### PR TITLE
RUNNER-PUBLISH-HANDOFF-V1 — explicit execution-to-publication authority transition (#57)

### DIFF
--- a/docs/draft-publish/draft-publish-v1.md
+++ b/docs/draft-publish/draft-publish-v1.md
@@ -191,7 +191,9 @@ generic `github.write` / `repo.write`.
 | Verifier `HOLD` / `REJECT` / `FAILED` / `UNKNOWN` | same status |
 | Foreign verifier schema/version | `REJECT` |
 | `VERIFIED` + exact identity + R2 + capability + `DRAFT_PR` + draft=true + base exact + adapter success | `PUBLISHED_DRAFT` |
-| taskId mismatch | `REJECT` |
+| taskId mismatch without `authorizedPublicationHandoff` | `REJECT_PUBLICATION_HANDOFF_REQUIRED` |
+| taskId A→B with valid `authorizedPublicationHandoff` provenance | allowed (then normal eligibility) |
+| forged / mismatched handoff provenance | `REJECT` (`REJECT_HANDOFF_*`) |
 | repository mismatch | `HOLD` |
 | baseRevision mismatch | `HOLD` |
 | path set mismatch / unsafe / forbidden / duplicate | `REJECT` / `FAILED` |

--- a/docs/draft-publish/draft-publish-v1.md
+++ b/docs/draft-publish/draft-publish-v1.md
@@ -192,7 +192,9 @@ generic `github.write` / `repo.write`.
 | Foreign verifier schema/version | `REJECT` |
 | `VERIFIED` + exact identity + R2 + capability + `DRAFT_PR` + draft=true + base exact + adapter success | `PUBLISHED_DRAFT` |
 | taskId mismatch without `authorizedPublicationHandoff` | `REJECT_PUBLICATION_HANDOFF_REQUIRED` |
-| taskId A→B with valid `authorizedPublicationHandoff` provenance | allowed (then normal eligibility) |
+| taskId A→B with valid `authorizedPublicationHandoff` + canonical derivation | allowed (then normal eligibility) |
+| taskId A→B with self-asserted / non-canonical PublicationTask B | `REJECT_HANDOFF_CANONICAL_TASK_ID` |
+| missing / forged `authorityFingerprint` | `REJECT_HANDOFF_AUTHORITY_FINGERPRINT` |
 | forged / mismatched handoff provenance | `REJECT` (`REJECT_HANDOFF_*`) |
 | repository mismatch | `HOLD` |
 | baseRevision mismatch | `HOLD` |

--- a/docs/publication-handoff/publication-handoff-v1.md
+++ b/docs/publication-handoff/publication-handoff-v1.md
@@ -105,18 +105,23 @@ is carried on `PublicationHandoffV1` and passed to DRAFT-PUBLISH-V1 as
 `authorizedPublicationHandoff` — not by rewriting verify taskId or mutating
 the execution task.
 
-DRAFT-PUBLISH-V1 accepts A→B only when that authorized handoff binds:
+DRAFT-PUBLISH-V1 accepts A→B only when that authorized handoff binds **and**
+independently recomputes (via shared `publicationHandoffCanonical` helpers):
 
 ```text
 verifiedResult.taskId === handoff.sourceExecutionTaskId
-expectedTask.taskId === handoff.publicationTaskId
+expectedTask.taskId === canonical publicationTaskId
+handoff.publicationTaskId === canonical publicationTaskId
+authorityFingerprint recomputes exactly
+verificationFingerprint recomputes exactly
 repository / baseRevision / sourceIssue exact
-verificationAttemptId / verificationFingerprint exact
 verifiedChangedPaths === publicationTask.allowedPaths
 capability / risk / stopAt exact publication authority
 ```
 
-Forged or mismatched handoff provenance fails closed.
+Self-asserted handoff objects paired with an arbitrary valid R2 PublicationTask
+fail closed (`REJECT_HANDOFF_CANONICAL_TASK_ID` /
+`REJECT_HANDOFF_AUTHORITY_FINGERPRINT`). Forged provenance fails closed.
 
 ---
 

--- a/docs/publication-handoff/publication-handoff-v1.md
+++ b/docs/publication-handoff/publication-handoff-v1.md
@@ -1,0 +1,178 @@
+# RUNNER-PUBLISH-HANDOFF-V1
+
+**Status: IMPLEMENTED · FAKE/LOCAL ONLY · REAL PROVIDER = HOLD · REAL GITHUB PUBLICATION = HOLD**
+
+Explicit execution → publication authority transition. Resolves the
+`RUNNER_PUBLISHER_AUTHORITY_INCOMPATIBLE` blocker discovered by
+NO-PROMPT-PILOT-V1 **without** widening AGENT-RUNNER-V1 into R2 / GitHub
+publication authority.
+
+```text
+ExecutionTask (R0/R1 + workspace.read.v1)
+→ Runner
+→ IndependentVerifyResultV1 = VERIFIED
+→ PublicationHandoffV1
+→ PublicationTask (R2 + github.draft-pr.publish.v1 + DRAFT_PR)
+→ DRAFT-PUBLISH-V1 (future / follow-up pilot)
+```
+
+Baseline:
+
+```text
+main = 1a494780ffb92bc6b1e27c99fbb24b39dfc1af75
+NO-PROMPT-PILOT-V1 = COMPLETE (PR #56 / Issue #55)
+Issue #57 = OPEN (this slice)
+```
+
+---
+
+## 1. Core rule
+
+Do **not** mutate the original execution `AgentTaskV1`.
+
+Forbidden:
+
+```text
+executionTask.riskClass = R2
+executionTask.allowedCapabilities += github.draft-pr.publish.v1
+executionTask.stopAt rewrite
+generic github.write / repo.write / github.*
+Action Gateway broadening
+AGENT-RUNNER-V1 accepting R2 publication
+```
+
+Publication authority lives only in a **distinct** publication-scoped task.
+
+---
+
+## 2. Input (fail closed)
+
+`PublicationHandoffInputV1` requires explicit:
+
+```text
+handoffId
+sourceExecutionTask
+independentVerifyResult
+requestedPublicationCapability = github.draft-pr.publish.v1
+requestedRiskClass = R2
+requestedStopAt = DRAFT_PR
+observedAt
+```
+
+Missing / undefined / wrong type → REJECT (never defaulted).
+
+---
+
+## 3. Eligibility
+
+READY_FOR_PUBLICATION_TASK only when:
+
+1. `independentVerifyResult.status === VERIFIED`
+2. source execution task reparses + revalidates VALID
+3. exact identity: taskId / repository / baseRevision
+4. `verifiedChangedPaths` present, non-empty, duplicate-free, safe, within
+   source allowedPaths, not forbidden
+5. verifier auth flags exactly `false` (publication/ready/merge/githubMutation/deploy)
+6. evidence: networkAccess / secretsRequired / githubMutationPerformed /
+   productionMutationPerformed exactly `false`
+7. requested publication authority exactly matches required constants
+8. publication task validates as AgentTaskV1 VALID
+9. publication taskId ≠ source taskId
+10. publication `allowedPaths` exact set equals `verifiedChangedPaths`
+11. publication capabilities exact set `["github.draft-pr.publish.v1"]`
+
+Non-VERIFIED verifier statuses propagate: HOLD / REJECT / FAILED / UNKNOWN.
+
+---
+
+## 4. Publication task
+
+Distinct `AgentTaskV1`:
+
+| Field | Value |
+|---|---|
+| taskId | deterministic from handoff seed (≠ source) |
+| repository / baseRevision / sourceIssue | exact copy from source |
+| allowedPaths | exact `verifiedChangedPaths` |
+| forbiddenPaths | source forbidden scope preserved |
+| allowedCapabilities | `["github.draft-pr.publish.v1"]` only |
+| riskClass | `R2` |
+| stopAt | `DRAFT_PR` |
+
+No `workspace.read.v1`. Provenance (`handoffId`, `sourceExecutionTaskId`,
+`verificationAttemptId`) stays on the handoff / result — not abused into
+unrelated AgentTask fields.
+
+---
+
+## 5. Idempotency / fingerprint
+
+Authority fingerprint (no `observedAt`):
+
+```text
+handoffId, sourceExecutionTaskId, sourceIssue, repository, baseRevision,
+verifiedChangedPaths (stable order), verificationAttemptId,
+requestedPublicationCapability, requestedRiskClass, requestedStopAt
+```
+
+```text
+same handoffId + same fingerprint → deterministic replay
+same handoffId + different fingerprint → REJECT_HANDOFF_IDEMPOTENCY_CONFLICT
+```
+
+Registry is injected/local only. No external persistence in V1.
+
+---
+
+## 6. Authorization flags
+
+Always false on every result:
+
+```text
+readyAuthorized
+mergeAuthorized
+issueCloseAuthorized
+deployAuthorized
+productionMutationAuthorized
+realAgentProviderExecution
+realGithubPublication
+githubMutationPerformed
+```
+
+This slice never authorizes GitHub mutation.
+
+---
+
+## 7. Runner / publisher boundaries
+
+```text
+AGENT_RUNNER_SUPPORTED_RISK_CLASSES = {R0, R1}  — unchanged
+AGENT_RUNNER_SUPPORTED_CAPABILITIES = {workspace.read.v1}  — unchanged
+```
+
+Do **not** call `runAgentTaskV1(publicationTask)`.
+
+DRAFT-PUBLISH-V1 eligibility constants are satisfied by the publication task
+shape; DRAFT-PUBLISH semantics are not altered. NO-PROMPT-PILOT-V1 is not
+updated to PASS in this slice.
+
+---
+
+## 8. Artifacts
+
+| Artifact | Path |
+|---|---|
+| Spec | `docs/publication-handoff/publication-handoff-v1.md` |
+| Domain | `src/domain/publicationHandoff.ts` |
+| Tests | `test/publicationHandoff.test.ts` |
+
+---
+
+## 9. Delivery gate
+
+```text
+Implementation → npm run verify → Draft PR → Fresh Review → STOP
+```
+
+Do not Ready / Merge / close Issue #57 / run follow-up pilot / enable real
+provider or GitHub publication.

--- a/docs/publication-handoff/publication-handoff-v1.md
+++ b/docs/publication-handoff/publication-handoff-v1.md
@@ -85,7 +85,7 @@ Non-VERIFIED verifier statuses propagate: HOLD / REJECT / FAILED / UNKNOWN.
 
 ---
 
-## 4. Publication task
+## 4. Separate publication task
 
 Distinct `AgentTaskV1`:
 
@@ -100,8 +100,23 @@ Distinct `AgentTaskV1`:
 | stopAt | `DRAFT_PR` |
 
 No `workspace.read.v1`. Provenance (`handoffId`, `sourceExecutionTaskId`,
-`verificationAttemptId`) stays on the handoff / result — not abused into
-unrelated AgentTask fields.
+`publicationTaskId`, `verificationAttemptId`, `verificationFingerprint`)
+is carried on `PublicationHandoffV1` and passed to DRAFT-PUBLISH-V1 as
+`authorizedPublicationHandoff` — not by rewriting verify taskId or mutating
+the execution task.
+
+DRAFT-PUBLISH-V1 accepts A→B only when that authorized handoff binds:
+
+```text
+verifiedResult.taskId === handoff.sourceExecutionTaskId
+expectedTask.taskId === handoff.publicationTaskId
+repository / baseRevision / sourceIssue exact
+verificationAttemptId / verificationFingerprint exact
+verifiedChangedPaths === publicationTask.allowedPaths
+capability / risk / stopAt exact publication authority
+```
+
+Forged or mismatched handoff provenance fails closed.
 
 ---
 

--- a/src/domain/draftPublish.ts
+++ b/src/domain/draftPublish.ts
@@ -14,7 +14,6 @@
  */
 
 import {
-  normalizeRepoPath,
   parseAgentTaskV1,
   validateAgentTaskV1,
   type AgentTaskRiskClass,
@@ -33,6 +32,9 @@ import {
   type IndependentVerifyResultV1,
   type IndependentVerifyStatus,
 } from "./independentVerify";
+import {
+  deriveCanonicalPublicationHandoffIdentities,
+} from "./publicationHandoffCanonical";
 import {
   DRAFT_PUBLISH_ADAPTER_FAKE,
   DRAFT_PUBLISH_GITHUB_MUTATION_PERFORMED,
@@ -94,6 +96,7 @@ export const DRAFT_PUBLISH_AUTHORIZED_HANDOFF_KEYS = [
   "verifiedChangedPaths",
   "verificationAttemptId",
   "verificationFingerprint",
+  "authorityFingerprint",
   "requestedPublicationCapability",
   "requestedRiskClass",
   "requestedStopAt",
@@ -168,6 +171,8 @@ export type DraftPublishReasonCode =
   | "REJECT_HANDOFF_VERIFICATION_BINDING"
   | "REJECT_HANDOFF_PATHS"
   | "REJECT_HANDOFF_AUTHORITY"
+  | "REJECT_HANDOFF_CANONICAL_TASK_ID"
+  | "REJECT_HANDOFF_AUTHORITY_FINGERPRINT"
   | "HOLD_TASK_VALIDATION"
   | "HOLD_REPOSITORY_MISMATCH"
   | "HOLD_BASE_REVISION_MISMATCH"
@@ -227,6 +232,8 @@ export interface DraftPublishAuthorizedHandoffV1 {
   verifiedChangedPaths: string[];
   verificationAttemptId: string;
   verificationFingerprint: string;
+  /** Required — recomputed by DRAFT-PUBLISH against shared canonical helpers. */
+  authorityFingerprint: string;
   requestedPublicationCapability: typeof DRAFT_PUBLISH_REQUIRED_CAPABILITY;
   requestedRiskClass: typeof DRAFT_PUBLISH_REQUIRED_RISK_CLASS;
   requestedStopAt: typeof DRAFT_PUBLISH_REQUIRED_STOP_AT;
@@ -514,32 +521,6 @@ export function computeDraftPublishPayloadFingerprint(input: {
   return `fp:v1:${JSON.stringify(payload)}`;
 }
 
-/**
- * Deterministic verification binding fingerprint (must match
- * publicationHandoff.computeVerificationFingerprint format).
- * observedAt is intentionally excluded — audit metadata, not authority.
- */
-export function computeDraftPublishVerificationFingerprint(input: {
-  verificationAttemptId: string;
-  taskId: string;
-  repository: string;
-  baseRevision: string;
-  verifiedChangedPaths: string[];
-  status: string;
-}): string {
-  const paths = [...input.verifiedChangedPaths]
-    .map((p) => normalizeRepoPath(p))
-    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-  return `vf:v1:${JSON.stringify({
-    verificationAttemptId: input.verificationAttemptId,
-    taskId: input.taskId,
-    repository: input.repository,
-    baseRevision: input.baseRevision,
-    verifiedChangedPaths: paths,
-    status: input.status,
-  })}`;
-}
-
 function parseAuthorizedPublicationHandoff(
   value: unknown,
 ):
@@ -681,6 +662,17 @@ function parseAuthorizedPublicationHandoff(
         "authorizedPublicationHandoff.verificationAttemptId/fingerprint required.",
     };
   }
+  if (
+    typeof value.authorityFingerprint !== "string" ||
+    value.authorityFingerprint.length < 1
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY_FINGERPRINT",
+      reasonMessage:
+        "authorizedPublicationHandoff.authorityFingerprint is required; missing fails closed.",
+    };
+  }
   if (typeof value.observedAt !== "string" || value.observedAt.length < 1) {
     return {
       ok: false,
@@ -727,6 +719,7 @@ function parseAuthorizedPublicationHandoff(
       verifiedChangedPaths: value.verifiedChangedPaths as string[],
       verificationAttemptId: value.verificationAttemptId,
       verificationFingerprint: value.verificationFingerprint,
+      authorityFingerprint: value.authorityFingerprint,
       requestedPublicationCapability: DRAFT_PUBLISH_REQUIRED_CAPABILITY,
       requestedRiskClass: DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
       requestedStopAt: DRAFT_PUBLISH_REQUIRED_STOP_AT,
@@ -738,6 +731,8 @@ function parseAuthorizedPublicationHandoff(
 /**
  * Bind verified execution A + publication task B through an authorized handoff.
  * Does not mutate verifiedResult or rewrite taskIds.
+ * Independently recomputes canonical publicationTaskId + fingerprints via
+ * shared RUNNER-PUBLISH-HANDOFF-V1 helpers — self-asserted handoffs fail closed.
  */
 function bindAuthorizedPublicationHandoff(input: {
   handoff: DraftPublishAuthorizedHandoffV1;
@@ -818,15 +813,54 @@ function bindAuthorizedPublicationHandoff(input: {
     };
   }
 
-  const expectedFingerprint = computeDraftPublishVerificationFingerprint({
-    verificationAttemptId: verifiedResult.verificationAttemptId,
-    taskId: String(verifiedResult.taskId),
-    repository: String(verifiedResult.repository),
-    baseRevision: String(verifiedResult.baseRevision),
-    verifiedChangedPaths: verifiedResult.verifiedChangedPaths,
-    status: "VERIFIED",
-  });
-  if (handoff.verificationFingerprint !== expectedFingerprint) {
+  // Independent canonical recompute — do not trust self-asserted IDs/fingerprints.
+  const canonical = deriveCanonicalPublicationHandoffIdentities(
+    {
+      handoffId: handoff.handoffId,
+      sourceExecutionTaskId: handoff.sourceExecutionTaskId,
+      sourceIssue: handoff.sourceIssue,
+      repository: handoff.repository,
+      baseRevision: handoff.baseRevision,
+      verifiedChangedPaths: handoff.verifiedChangedPaths,
+      verificationAttemptId: handoff.verificationAttemptId,
+      requestedPublicationCapability: handoff.requestedPublicationCapability,
+      requestedRiskClass: handoff.requestedRiskClass,
+      requestedStopAt: handoff.requestedStopAt,
+    },
+    {
+      verificationAttemptId: String(verifiedResult.verificationAttemptId),
+      sourceExecutionTaskId: String(verifiedResult.taskId),
+      repository: String(verifiedResult.repository),
+      baseRevision: String(verifiedResult.baseRevision),
+      verifiedChangedPaths: verifiedResult.verifiedChangedPaths,
+    },
+  );
+
+  if (handoff.publicationTaskId !== canonical.publicationTaskId) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_CANONICAL_TASK_ID",
+      reasonMessage:
+        "handoff.publicationTaskId is not the canonical RUNNER-PUBLISH-HANDOFF-V1 derivation; forged/self-asserted publication task rejected.",
+    };
+  }
+  if (expectedTask.taskId !== canonical.publicationTaskId) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_CANONICAL_TASK_ID",
+      reasonMessage:
+        "expectedTask.taskId is not the canonical publication taskId derived from authorized handoff fields.",
+    };
+  }
+  if (handoff.authorityFingerprint !== canonical.authorityFingerprint) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY_FINGERPRINT",
+      reasonMessage:
+        "handoff.authorityFingerprint does not recompute exactly; forged/stale authority rejected.",
+    };
+  }
+  if (handoff.verificationFingerprint !== canonical.verificationFingerprint) {
     return {
       ok: false,
       reasonCode: "REJECT_HANDOFF_VERIFICATION_BINDING",

--- a/src/domain/draftPublish.ts
+++ b/src/domain/draftPublish.ts
@@ -14,6 +14,7 @@
  */
 
 import {
+  normalizeRepoPath,
   parseAgentTaskV1,
   validateAgentTaskV1,
   type AgentTaskRiskClass,
@@ -74,7 +75,33 @@ export const DRAFT_PUBLISH_INPUT_ROOT_KEYS = [
   "observedAt",
   "sourceArtifact",
   "proposedDraftPr",
+  "authorizedPublicationHandoff",
 ] as const;
+
+/**
+ * Machine-readable A→B publication handoff binding accepted by DRAFT-PUBLISH-V1.
+ * Compatible with PUBLICATION-HANDOFF-V1 (must include publicationTaskId).
+ * Absent → legacy same-taskId path only.
+ */
+export const DRAFT_PUBLISH_AUTHORIZED_HANDOFF_KEYS = [
+  "schemaVersion",
+  "handoffId",
+  "sourceExecutionTaskId",
+  "publicationTaskId",
+  "sourceIssue",
+  "repository",
+  "baseRevision",
+  "verifiedChangedPaths",
+  "verificationAttemptId",
+  "verificationFingerprint",
+  "requestedPublicationCapability",
+  "requestedRiskClass",
+  "requestedStopAt",
+  "observedAt",
+] as const;
+
+export const DRAFT_PUBLISH_AUTHORIZED_HANDOFF_SCHEMA =
+  "PUBLICATION-HANDOFF-V1" as const;
 
 export const DRAFT_PUBLISH_SOURCE_ARTIFACT_KEYS = [
   "repository",
@@ -133,6 +160,14 @@ export type DraftPublishReasonCode =
   | "REJECT_TASK_SEMANTICS"
   | "REJECT_TASK_ID_BINDING"
   | "REJECT_TASK_ID_MISMATCH"
+  | "REJECT_PUBLICATION_HANDOFF_REQUIRED"
+  | "REJECT_PUBLICATION_HANDOFF"
+  | "REJECT_HANDOFF_SOURCE_TASK_ID"
+  | "REJECT_HANDOFF_PUBLICATION_TASK_ID"
+  | "REJECT_HANDOFF_SOURCE_ISSUE"
+  | "REJECT_HANDOFF_VERIFICATION_BINDING"
+  | "REJECT_HANDOFF_PATHS"
+  | "REJECT_HANDOFF_AUTHORITY"
   | "HOLD_TASK_VALIDATION"
   | "HOLD_REPOSITORY_MISMATCH"
   | "HOLD_BASE_REVISION_MISMATCH"
@@ -181,6 +216,23 @@ export type DraftPublishReasonCode =
   | "FAILED_CLEANUP"
   | "UNKNOWN_PUBLISHER_STATE";
 
+export interface DraftPublishAuthorizedHandoffV1 {
+  schemaVersion: typeof DRAFT_PUBLISH_AUTHORIZED_HANDOFF_SCHEMA;
+  handoffId: string;
+  sourceExecutionTaskId: string;
+  publicationTaskId: string;
+  sourceIssue: { repository: string; number: number };
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  verificationAttemptId: string;
+  verificationFingerprint: string;
+  requestedPublicationCapability: typeof DRAFT_PUBLISH_REQUIRED_CAPABILITY;
+  requestedRiskClass: typeof DRAFT_PUBLISH_REQUIRED_RISK_CLASS;
+  requestedStopAt: typeof DRAFT_PUBLISH_REQUIRED_STOP_AT;
+  observedAt: string;
+}
+
 export interface DraftPublishInputV1 {
   verifiedResult: IndependentVerifyResultV1;
   expectedTask: AgentTaskV1;
@@ -188,6 +240,11 @@ export interface DraftPublishInputV1 {
   observedAt: string;
   sourceArtifact: DraftPublishSourceArtifactV1;
   proposedDraftPr: DraftPublishProposedDraftPrV1;
+  /**
+   * Required when verifiedResult.taskId !== expectedTask.taskId
+   * (execution A → publication B via RUNNER-PUBLISH-HANDOFF-V1).
+   */
+  authorizedPublicationHandoff?: DraftPublishAuthorizedHandoffV1;
 }
 
 export interface DraftPublishMetadataV1 {
@@ -455,6 +512,392 @@ export function computeDraftPublishPayloadFingerprint(input: {
     },
   };
   return `fp:v1:${JSON.stringify(payload)}`;
+}
+
+/**
+ * Deterministic verification binding fingerprint (must match
+ * publicationHandoff.computeVerificationFingerprint format).
+ * observedAt is intentionally excluded — audit metadata, not authority.
+ */
+export function computeDraftPublishVerificationFingerprint(input: {
+  verificationAttemptId: string;
+  taskId: string;
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  status: string;
+}): string {
+  const paths = [...input.verifiedChangedPaths]
+    .map((p) => normalizeRepoPath(p))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return `vf:v1:${JSON.stringify({
+    verificationAttemptId: input.verificationAttemptId,
+    taskId: input.taskId,
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    verifiedChangedPaths: paths,
+    status: input.status,
+  })}`;
+}
+
+function parseAuthorizedPublicationHandoff(
+  value: unknown,
+):
+  | { ok: true; handoff: DraftPublishAuthorizedHandoffV1 }
+  | { ok: false; reasonCode: DraftPublishReasonCode; reasonMessage: string } {
+  if (value === undefined || value === null) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage:
+        "authorizedPublicationHandoff is present but null/undefined; fail closed.",
+    };
+  }
+  if (!isPlainObject(value)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage: "authorizedPublicationHandoff must be an object.",
+    };
+  }
+  if (!hasOnlyKeys(value, DRAFT_PUBLISH_AUTHORIZED_HANDOFF_KEYS)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage:
+        "authorizedPublicationHandoff contains unknown properties; fail closed.",
+    };
+  }
+  for (const key of DRAFT_PUBLISH_AUTHORIZED_HANDOFF_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) {
+      return {
+        ok: false,
+        reasonCode: "REJECT_PUBLICATION_HANDOFF",
+        reasonMessage: `authorizedPublicationHandoff.${key} is required; missing fails closed.`,
+      };
+    }
+    if (value[key] === undefined) {
+      return {
+        ok: false,
+        reasonCode: "REJECT_PUBLICATION_HANDOFF",
+        reasonMessage: `authorizedPublicationHandoff.${key} must not be undefined.`,
+      };
+    }
+  }
+  if (value.schemaVersion !== DRAFT_PUBLISH_AUTHORIZED_HANDOFF_SCHEMA) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage: `authorizedPublicationHandoff.schemaVersion must be ${DRAFT_PUBLISH_AUTHORIZED_HANDOFF_SCHEMA}.`,
+    };
+  }
+  if (
+    typeof value.handoffId !== "string" ||
+    value.handoffId.length < 1 ||
+    value.handoffId.length > 128
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage: "authorizedPublicationHandoff.handoffId malformed.",
+    };
+  }
+  if (
+    typeof value.sourceExecutionTaskId !== "string" ||
+    value.sourceExecutionTaskId.length < 1
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_SOURCE_TASK_ID",
+      reasonMessage:
+        "authorizedPublicationHandoff.sourceExecutionTaskId malformed.",
+    };
+  }
+  if (
+    typeof value.publicationTaskId !== "string" ||
+    value.publicationTaskId.length < 1
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_PUBLICATION_TASK_ID",
+      reasonMessage: "authorizedPublicationHandoff.publicationTaskId malformed.",
+    };
+  }
+  if (value.sourceExecutionTaskId === value.publicationTaskId) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage:
+        "authorizedPublicationHandoff requires distinct sourceExecutionTaskId and publicationTaskId.",
+    };
+  }
+  if (!isRepository(value.repository) || !isBaseRevision(value.baseRevision)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage:
+        "authorizedPublicationHandoff.repository/baseRevision malformed.",
+    };
+  }
+  if (!isPlainObject(value.sourceIssue)) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_SOURCE_ISSUE",
+      reasonMessage: "authorizedPublicationHandoff.sourceIssue must be an object.",
+    };
+  }
+  if (
+    typeof value.sourceIssue.repository !== "string" ||
+    typeof value.sourceIssue.number !== "number"
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_SOURCE_ISSUE",
+      reasonMessage: "authorizedPublicationHandoff.sourceIssue malformed.",
+    };
+  }
+  if (
+    !Array.isArray(value.verifiedChangedPaths) ||
+    !value.verifiedChangedPaths.every((p) => typeof p === "string") ||
+    value.verifiedChangedPaths.length < 1
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_PATHS",
+      reasonMessage:
+        "authorizedPublicationHandoff.verifiedChangedPaths must be a non-empty string array.",
+    };
+  }
+  if (
+    typeof value.verificationAttemptId !== "string" ||
+    value.verificationAttemptId.length < 1 ||
+    typeof value.verificationFingerprint !== "string" ||
+    value.verificationFingerprint.length < 1
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_VERIFICATION_BINDING",
+      reasonMessage:
+        "authorizedPublicationHandoff.verificationAttemptId/fingerprint required.",
+    };
+  }
+  if (typeof value.observedAt !== "string" || value.observedAt.length < 1) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage: "authorizedPublicationHandoff.observedAt malformed.",
+    };
+  }
+  if (
+    value.requestedPublicationCapability !== DRAFT_PUBLISH_REQUIRED_CAPABILITY
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY",
+      reasonMessage: `authorizedPublicationHandoff.requestedPublicationCapability must be exactly ${DRAFT_PUBLISH_REQUIRED_CAPABILITY}.`,
+    };
+  }
+  if (value.requestedRiskClass !== DRAFT_PUBLISH_REQUIRED_RISK_CLASS) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY",
+      reasonMessage: `authorizedPublicationHandoff.requestedRiskClass must be exactly ${DRAFT_PUBLISH_REQUIRED_RISK_CLASS}.`,
+    };
+  }
+  if (value.requestedStopAt !== DRAFT_PUBLISH_REQUIRED_STOP_AT) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY",
+      reasonMessage: `authorizedPublicationHandoff.requestedStopAt must be exactly ${DRAFT_PUBLISH_REQUIRED_STOP_AT}.`,
+    };
+  }
+  return {
+    ok: true,
+    handoff: {
+      schemaVersion: DRAFT_PUBLISH_AUTHORIZED_HANDOFF_SCHEMA,
+      handoffId: value.handoffId,
+      sourceExecutionTaskId: value.sourceExecutionTaskId,
+      publicationTaskId: value.publicationTaskId,
+      sourceIssue: {
+        repository: value.sourceIssue.repository,
+        number: value.sourceIssue.number,
+      },
+      repository: value.repository,
+      baseRevision: value.baseRevision,
+      verifiedChangedPaths: value.verifiedChangedPaths as string[],
+      verificationAttemptId: value.verificationAttemptId,
+      verificationFingerprint: value.verificationFingerprint,
+      requestedPublicationCapability: DRAFT_PUBLISH_REQUIRED_CAPABILITY,
+      requestedRiskClass: DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
+      requestedStopAt: DRAFT_PUBLISH_REQUIRED_STOP_AT,
+      observedAt: value.observedAt,
+    },
+  };
+}
+
+/**
+ * Bind verified execution A + publication task B through an authorized handoff.
+ * Does not mutate verifiedResult or rewrite taskIds.
+ */
+function bindAuthorizedPublicationHandoff(input: {
+  handoff: DraftPublishAuthorizedHandoffV1;
+  verifiedResult: IndependentVerifyResultV1;
+  expectedTask: AgentTaskV1;
+}):
+  | { ok: true }
+  | { ok: false; reasonCode: DraftPublishReasonCode; reasonMessage: string } {
+  const { handoff, verifiedResult, expectedTask } = input;
+
+  if (verifiedResult.taskId !== handoff.sourceExecutionTaskId) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_SOURCE_TASK_ID",
+      reasonMessage: `verifiedResult.taskId (${String(verifiedResult.taskId)}) !== handoff.sourceExecutionTaskId (${handoff.sourceExecutionTaskId}).`,
+    };
+  }
+  if (expectedTask.taskId !== handoff.publicationTaskId) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_PUBLICATION_TASK_ID",
+      reasonMessage: `expectedTask.taskId (${expectedTask.taskId}) !== handoff.publicationTaskId (${handoff.publicationTaskId}).`,
+    };
+  }
+  if (verifiedResult.taskId === expectedTask.taskId) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage:
+        "authorizedPublicationHandoff present but verifiedResult.taskId === expectedTask.taskId; A→B transition required.",
+    };
+  }
+
+  if (
+    handoff.repository !== expectedTask.repository ||
+    handoff.repository !== verifiedResult.repository
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage:
+        "handoff.repository must equal verifiedResult.repository and expectedTask.repository.",
+    };
+  }
+  if (
+    handoff.baseRevision !== expectedTask.baseRevision ||
+    handoff.baseRevision !== verifiedResult.baseRevision
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF",
+      reasonMessage:
+        "handoff.baseRevision must equal verifiedResult.baseRevision and expectedTask.baseRevision.",
+    };
+  }
+
+  if (
+    handoff.sourceIssue.repository !== expectedTask.sourceIssue.repository ||
+    handoff.sourceIssue.number !== expectedTask.sourceIssue.number ||
+    handoff.sourceIssue.repository !== handoff.repository
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_SOURCE_ISSUE",
+      reasonMessage:
+        "handoff.sourceIssue must bind exactly to expectedTask.sourceIssue and handoff.repository.",
+    };
+  }
+
+  if (
+    handoff.verificationAttemptId !== verifiedResult.verificationAttemptId
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_VERIFICATION_BINDING",
+      reasonMessage:
+        "handoff.verificationAttemptId !== verifiedResult.verificationAttemptId.",
+    };
+  }
+
+  const expectedFingerprint = computeDraftPublishVerificationFingerprint({
+    verificationAttemptId: verifiedResult.verificationAttemptId,
+    taskId: String(verifiedResult.taskId),
+    repository: String(verifiedResult.repository),
+    baseRevision: String(verifiedResult.baseRevision),
+    verifiedChangedPaths: verifiedResult.verifiedChangedPaths,
+    status: "VERIFIED",
+  });
+  if (handoff.verificationFingerprint !== expectedFingerprint) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_VERIFICATION_BINDING",
+      reasonMessage:
+        "handoff.verificationFingerprint does not match recomputed VERIFIED binding fingerprint; forged/stale provenance rejected.",
+    };
+  }
+
+  if (
+    !changedPathSetsEqual(
+      handoff.verifiedChangedPaths,
+      verifiedResult.verifiedChangedPaths,
+    )
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_PATHS",
+      reasonMessage:
+        "handoff.verifiedChangedPaths !== verifiedResult.verifiedChangedPaths.",
+    };
+  }
+  if (
+    !changedPathSetsEqual(
+      expectedTask.allowedPaths,
+      verifiedResult.verifiedChangedPaths,
+    ) ||
+    expectedTask.allowedPaths.length !==
+      verifiedResult.verifiedChangedPaths.length
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_PATHS",
+      reasonMessage:
+        "expectedTask.allowedPaths must equal verifiedResult.verifiedChangedPaths under authorized handoff.",
+    };
+  }
+
+  if (
+    expectedTask.allowedCapabilities.length !== 1 ||
+    expectedTask.allowedCapabilities[0] !== DRAFT_PUBLISH_REQUIRED_CAPABILITY ||
+    handoff.requestedPublicationCapability !== DRAFT_PUBLISH_REQUIRED_CAPABILITY
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY",
+      reasonMessage:
+        "Under authorized handoff, publication capability must be exactly github.draft-pr.publish.v1 (no generics).",
+    };
+  }
+  if (
+    expectedTask.riskClass !== DRAFT_PUBLISH_REQUIRED_RISK_CLASS ||
+    handoff.requestedRiskClass !== DRAFT_PUBLISH_REQUIRED_RISK_CLASS
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY",
+      reasonMessage: "Under authorized handoff, riskClass must be exactly R2.",
+    };
+  }
+  if (
+    expectedTask.stopAt !== DRAFT_PUBLISH_REQUIRED_STOP_AT ||
+    handoff.requestedStopAt !== DRAFT_PUBLISH_REQUIRED_STOP_AT
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECT_HANDOFF_AUTHORITY",
+      reasonMessage: "Under authorized handoff, stopAt must be exactly DRAFT_PR.",
+    };
+  }
+
+  return { ok: true };
 }
 
 function propagateVerifiedStatus(
@@ -1191,11 +1634,53 @@ export function publishDraftPrV1(
   }
 
   // Identity binding — verified ↔ expectedTask.
-  if (verifiedResult.taskId !== expectedTask.taskId) {
+  // Same taskId: legacy direct path.
+  // Distinct taskIds: require authorizedPublicationHandoff (A→B) provenance.
+  const handoffRaw = Object.prototype.hasOwnProperty.call(
+    rawInput,
+    "authorizedPublicationHandoff",
+  )
+    ? rawInput.authorizedPublicationHandoff
+    : undefined;
+
+  if (handoffRaw !== undefined) {
+    const handoffParsed = parseAuthorizedPublicationHandoff(handoffRaw);
+    if (!handoffParsed.ok) {
+      return buildResult({
+        status: "REJECT",
+        reasonCode: handoffParsed.reasonCode,
+        reasonMessage: handoffParsed.reasonMessage,
+        publicationAttemptId,
+        taskId: expectedTask.taskId,
+        repository: expectedTask.repository,
+        baseRevision: expectedTask.baseRevision,
+        taskValidation: revalidation,
+        observedAt,
+      });
+    }
+    const handoffBind = bindAuthorizedPublicationHandoff({
+      handoff: handoffParsed.handoff,
+      verifiedResult,
+      expectedTask,
+    });
+    if (!handoffBind.ok) {
+      return buildResult({
+        status: "REJECT",
+        reasonCode: handoffBind.reasonCode,
+        reasonMessage: handoffBind.reasonMessage,
+        publicationAttemptId,
+        taskId: expectedTask.taskId,
+        repository: expectedTask.repository,
+        baseRevision: expectedTask.baseRevision,
+        taskValidation: revalidation,
+        observedAt,
+      });
+    }
+  } else if (verifiedResult.taskId !== expectedTask.taskId) {
     return buildResult({
       status: "REJECT",
-      reasonCode: "REJECT_TASK_ID_MISMATCH",
-      reasonMessage: `verifiedResult.taskId (${String(verifiedResult.taskId)}) !== expectedTask.taskId (${expectedTask.taskId}); fail closed.`,
+      reasonCode: "REJECT_PUBLICATION_HANDOFF_REQUIRED",
+      reasonMessage: `verifiedResult.taskId (${String(verifiedResult.taskId)}) !== expectedTask.taskId (${expectedTask.taskId}); authorizedPublicationHandoff is required for A→B publication (do not rewrite verify taskId). Legacy same-taskId path remains available without handoff.`,
       publicationAttemptId,
       taskId: expectedTask.taskId,
       repository: expectedTask.repository,

--- a/src/domain/publicationHandoff.ts
+++ b/src/domain/publicationHandoff.ts
@@ -23,6 +23,7 @@ import {
   validateAgentTaskV1,
   type AgentTaskRiskClass,
   type AgentTaskSourceIssue,
+  type AgentTaskStopAt,
   type AgentTaskV1,
   type AgentTaskValidationResultV1,
 } from "./agentTaskContract";
@@ -31,11 +32,6 @@ import {
   AGENT_RUNNER_SUPPORTED_RISK_CLASSES,
   evaluateChangedPathsPolicy,
 } from "./agentRunner";
-import {
-  DRAFT_PUBLISH_REQUIRED_CAPABILITY,
-  DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
-  DRAFT_PUBLISH_REQUIRED_STOP_AT,
-} from "./draftPublish";
 import {
   findDuplicateChangedPaths,
   changedPathSetsEqual,
@@ -49,12 +45,17 @@ export const PUBLICATION_HANDOFF_SCHEMA = "PUBLICATION-HANDOFF-V1" as const;
 export const PUBLICATION_HANDOFF_RESULT_SCHEMA =
   "PUBLICATION-HANDOFF-RESULT-V1" as const;
 
+/**
+ * Publication authority constants — string-identical to DRAFT-PUBLISH-V1
+ * requirements. Kept local (no draftPublish import) to avoid cycles so
+ * DRAFT-PUBLISH-V1 can consume handoff provenance.
+ */
 export const PUBLICATION_HANDOFF_REQUIRED_CAPABILITY =
-  DRAFT_PUBLISH_REQUIRED_CAPABILITY;
+  "github.draft-pr.publish.v1" as const;
 export const PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS =
-  DRAFT_PUBLISH_REQUIRED_RISK_CLASS;
+  "R2" as const satisfies AgentTaskRiskClass;
 export const PUBLICATION_HANDOFF_REQUIRED_STOP_AT =
-  DRAFT_PUBLISH_REQUIRED_STOP_AT;
+  "DRAFT_PR" as const satisfies AgentTaskStopAt;
 
 /** Frozen snapshot of runner allowlists — must never expand in this slice. */
 export const PUBLICATION_HANDOFF_RUNNER_RISK_CLASSES_SNAPSHOT = [
@@ -126,6 +127,8 @@ export interface PublicationHandoffV1 {
   schemaVersion: typeof PUBLICATION_HANDOFF_SCHEMA;
   handoffId: string;
   sourceExecutionTaskId: string;
+  /** Distinct publication-scoped task identity (≠ sourceExecutionTaskId). */
+  publicationTaskId: string;
   sourceIssue: AgentTaskSourceIssue;
   repository: string;
   baseRevision: string;
@@ -324,17 +327,17 @@ export function buildDeterministicPublicationTaskId(input: {
 }
 
 /**
- * Narrow compatibility check against existing DRAFT-PUBLISH-V1 constants.
+ * Narrow compatibility check against DRAFT-PUBLISH-V1 authority constants.
  * Does not invoke publishDraftPrV1.
  */
 export function publicationTaskMeetsDraftPublishAuthority(
   task: AgentTaskV1,
 ): boolean {
   return (
-    task.riskClass === DRAFT_PUBLISH_REQUIRED_RISK_CLASS &&
-    task.stopAt === DRAFT_PUBLISH_REQUIRED_STOP_AT &&
+    task.riskClass === PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS &&
+    task.stopAt === PUBLICATION_HANDOFF_REQUIRED_STOP_AT &&
     task.allowedCapabilities.length === 1 &&
-    task.allowedCapabilities[0] === DRAFT_PUBLISH_REQUIRED_CAPABILITY
+    task.allowedCapabilities[0] === PUBLICATION_HANDOFF_REQUIRED_CAPABILITY
   );
 }
 
@@ -1276,6 +1279,7 @@ export function createPublicationHandoffV1(
     schemaVersion: PUBLICATION_HANDOFF_SCHEMA,
     handoffId,
     sourceExecutionTaskId: sourceExecutionTask.taskId,
+    publicationTaskId: publicationTask.taskId,
     sourceIssue: {
       repository: sourceExecutionTask.sourceIssue.repository,
       number: sourceExecutionTask.sourceIssue.number,

--- a/src/domain/publicationHandoff.ts
+++ b/src/domain/publicationHandoff.ts
@@ -18,12 +18,10 @@
 
 import {
   AGENT_TASK_SCHEMA,
-  normalizeRepoPath,
   parseAgentTaskV1,
   validateAgentTaskV1,
   type AgentTaskRiskClass,
   type AgentTaskSourceIssue,
-  type AgentTaskStopAt,
   type AgentTaskV1,
   type AgentTaskValidationResultV1,
 } from "./agentTaskContract";
@@ -39,6 +37,30 @@ import {
   type IndependentVerifyStatus,
 } from "./independentVerify";
 import type { IndependentVerifyEvidenceV1 } from "./independentVerifyAdapter";
+import {
+  PUBLICATION_HANDOFF_CANONICAL_CAPABILITY,
+  PUBLICATION_HANDOFF_CANONICAL_RISK_CLASS,
+  PUBLICATION_HANDOFF_CANONICAL_STOP_AT,
+  authorityFingerprintsEqual,
+  buildDeterministicPublicationTaskId,
+  capturePublicationHandoffAuthorityFingerprint,
+  computeVerificationFingerprint,
+  deriveCanonicalPublicationHandoffIdentities,
+  deterministicHexFromSeed,
+  serializeAuthorityFingerprint,
+  type PublicationHandoffAuthoritySeedV1,
+} from "./publicationHandoffCanonical";
+
+export {
+  authorityFingerprintsEqual,
+  buildDeterministicPublicationTaskId,
+  capturePublicationHandoffAuthorityFingerprint,
+  computeVerificationFingerprint,
+  deriveCanonicalPublicationHandoffIdentities,
+  deterministicHexFromSeed,
+  serializeAuthorityFingerprint,
+};
+export type { PublicationHandoffAuthoritySeedV1 };
 
 export const PUBLICATION_HANDOFF_VERSION = "RUNNER-PUBLISH-HANDOFF-V1" as const;
 export const PUBLICATION_HANDOFF_SCHEMA = "PUBLICATION-HANDOFF-V1" as const;
@@ -47,15 +69,14 @@ export const PUBLICATION_HANDOFF_RESULT_SCHEMA =
 
 /**
  * Publication authority constants — string-identical to DRAFT-PUBLISH-V1
- * requirements. Kept local (no draftPublish import) to avoid cycles so
- * DRAFT-PUBLISH-V1 can consume handoff provenance.
+ * requirements. Sourced from shared canonical module.
  */
 export const PUBLICATION_HANDOFF_REQUIRED_CAPABILITY =
-  "github.draft-pr.publish.v1" as const;
+  PUBLICATION_HANDOFF_CANONICAL_CAPABILITY;
 export const PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS =
-  "R2" as const satisfies AgentTaskRiskClass;
+  PUBLICATION_HANDOFF_CANONICAL_RISK_CLASS;
 export const PUBLICATION_HANDOFF_REQUIRED_STOP_AT =
-  "DRAFT_PR" as const satisfies AgentTaskStopAt;
+  PUBLICATION_HANDOFF_CANONICAL_STOP_AT;
 
 /** Frozen snapshot of runner allowlists — must never expand in this slice. */
 export const PUBLICATION_HANDOFF_RUNNER_RISK_CLASSES_SNAPSHOT = [
@@ -135,24 +156,16 @@ export interface PublicationHandoffV1 {
   verifiedChangedPaths: string[];
   verificationAttemptId: string;
   verificationFingerprint: string;
+  /** Canonical authority fingerprint — recomputed by DRAFT-PUBLISH-V1. */
+  authorityFingerprint: string;
   requestedPublicationCapability: typeof PUBLICATION_HANDOFF_REQUIRED_CAPABILITY;
   requestedRiskClass: typeof PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS;
   requestedStopAt: typeof PUBLICATION_HANDOFF_REQUIRED_STOP_AT;
   observedAt: string;
 }
 
-export interface PublicationHandoffAuthorityFingerprintV1 {
-  handoffId: string;
-  sourceExecutionTaskId: string;
-  sourceIssue: AgentTaskSourceIssue;
-  repository: string;
-  baseRevision: string;
-  verifiedChangedPaths: string[];
-  verificationAttemptId: string;
-  requestedPublicationCapability: string;
-  requestedRiskClass: string;
-  requestedStopAt: string;
-}
+export type PublicationHandoffAuthorityFingerprintV1 =
+  PublicationHandoffAuthoritySeedV1;
 
 export interface PublicationHandoffMetadataV1 {
   observedAt: string;
@@ -222,108 +235,6 @@ function hasOnlyKeys(
 
 function stableJson(value: unknown): string {
   return JSON.stringify(value);
-}
-
-function sortPathsStable(paths: string[]): string[] {
-  return [...paths]
-    .map((p) => normalizeRepoPath(p))
-    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-}
-
-/** Deterministic 40-hex token from seed (not cryptographic security). */
-export function deterministicHexFromSeed(seed: string): string {
-  let h1 = 0x811c9dc5;
-  let h2 = 0x811c9dc5 ^ 0xabcdef;
-  for (let i = 0; i < seed.length; i++) {
-    const c = seed.charCodeAt(i);
-    h1 = Math.imul(h1 ^ c, 0x01000193);
-    h2 = Math.imul(h2 ^ (c + 1), 0x01000193);
-  }
-  const hex = (n: number) => (n >>> 0).toString(16).padStart(8, "0");
-  const out = `${hex(h1)}${hex(h2)}${hex(h1 ^ h2)}${hex(~h1)}${hex(h1 + h2)}`;
-  return out.slice(0, 40);
-}
-
-export function computeVerificationFingerprint(input: {
-  verificationAttemptId: string;
-  taskId: string;
-  repository: string;
-  baseRevision: string;
-  verifiedChangedPaths: string[];
-  status: string;
-}): string {
-  const paths = sortPathsStable(input.verifiedChangedPaths);
-  return `vf:v1:${stableJson({
-    verificationAttemptId: input.verificationAttemptId,
-    taskId: input.taskId,
-    repository: input.repository,
-    baseRevision: input.baseRevision,
-    verifiedChangedPaths: paths,
-    status: input.status,
-  })}`;
-}
-
-export function capturePublicationHandoffAuthorityFingerprint(
-  input: PublicationHandoffAuthorityFingerprintV1,
-): PublicationHandoffAuthorityFingerprintV1 {
-  return {
-    handoffId: input.handoffId,
-    sourceExecutionTaskId: input.sourceExecutionTaskId,
-    sourceIssue: {
-      repository: input.sourceIssue.repository,
-      number: input.sourceIssue.number,
-    },
-    repository: input.repository,
-    baseRevision: input.baseRevision,
-    verifiedChangedPaths: sortPathsStable(input.verifiedChangedPaths),
-    verificationAttemptId: input.verificationAttemptId,
-    requestedPublicationCapability: input.requestedPublicationCapability,
-    requestedRiskClass: input.requestedRiskClass,
-    requestedStopAt: input.requestedStopAt,
-  };
-}
-
-export function serializeAuthorityFingerprint(
-  fp: PublicationHandoffAuthorityFingerprintV1,
-): string {
-  return `ah:v1:${stableJson(capturePublicationHandoffAuthorityFingerprint(fp))}`;
-}
-
-export function authorityFingerprintsEqual(
-  a: PublicationHandoffAuthorityFingerprintV1,
-  b: PublicationHandoffAuthorityFingerprintV1,
-): boolean {
-  return (
-    serializeAuthorityFingerprint(a) === serializeAuthorityFingerprint(b)
-  );
-}
-
-/**
- * Deterministic publication taskId. Seed includes handoff + source identity +
- * verified paths + requested publication authority.
- */
-export function buildDeterministicPublicationTaskId(input: {
-  handoffId: string;
-  sourceExecutionTaskId: string;
-  repository: string;
-  baseRevision: string;
-  verifiedChangedPaths: string[];
-  requestedPublicationCapability: string;
-  requestedRiskClass: string;
-  requestedStopAt: string;
-}): string {
-  const seed = stableJson({
-    handoffId: input.handoffId,
-    sourceExecutionTaskId: input.sourceExecutionTaskId,
-    repository: input.repository,
-    baseRevision: input.baseRevision,
-    verifiedChangedPaths: sortPathsStable(input.verifiedChangedPaths),
-    requestedPublicationCapability: input.requestedPublicationCapability,
-    requestedRiskClass: input.requestedRiskClass,
-    requestedStopAt: input.requestedStopAt,
-  });
-  const hex = deterministicHexFromSeed(seed);
-  return `pub-handoff-${hex}`.slice(0, 128);
 }
 
 /**
@@ -1058,28 +969,32 @@ export function createPublicationHandoffV1(
     });
   }
 
-  const verificationFingerprint = computeVerificationFingerprint({
-    verificationAttemptId,
-    taskId: sourceExecutionTask.taskId,
-    repository: sourceExecutionTask.repository,
-    baseRevision: sourceExecutionTask.baseRevision,
-    verifiedChangedPaths,
-    status: "VERIFIED",
-  });
-
-  const authorityFp = capturePublicationHandoffAuthorityFingerprint({
-    handoffId,
-    sourceExecutionTaskId: sourceExecutionTask.taskId,
-    sourceIssue: sourceExecutionTask.sourceIssue,
-    repository: sourceExecutionTask.repository,
-    baseRevision: sourceExecutionTask.baseRevision,
-    verifiedChangedPaths,
-    verificationAttemptId,
-    requestedPublicationCapability,
-    requestedRiskClass,
-    requestedStopAt,
-  });
-  const authorityFingerprint = serializeAuthorityFingerprint(authorityFp);
+  const canonical = deriveCanonicalPublicationHandoffIdentities(
+    {
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      sourceIssue: sourceExecutionTask.sourceIssue,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      verificationAttemptId,
+      requestedPublicationCapability,
+      requestedRiskClass,
+      requestedStopAt,
+    },
+    {
+      verificationAttemptId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+    },
+  );
+  const {
+    publicationTaskId,
+    authorityFingerprint,
+    verificationFingerprint,
+  } = canonical;
 
   if (registry) {
     const prior = registry.get(handoffId);
@@ -1104,17 +1019,6 @@ export function createPublicationHandoffV1(
       });
     }
   }
-
-  const publicationTaskId = buildDeterministicPublicationTaskId({
-    handoffId,
-    sourceExecutionTaskId: sourceExecutionTask.taskId,
-    repository: sourceExecutionTask.repository,
-    baseRevision: sourceExecutionTask.baseRevision,
-    verifiedChangedPaths,
-    requestedPublicationCapability,
-    requestedRiskClass,
-    requestedStopAt,
-  });
 
   if (publicationTaskId === sourceExecutionTask.taskId) {
     return buildResult({
@@ -1289,6 +1193,7 @@ export function createPublicationHandoffV1(
     verifiedChangedPaths: [...verifiedChangedPaths],
     verificationAttemptId,
     verificationFingerprint,
+    authorityFingerprint,
     requestedPublicationCapability,
     requestedRiskClass,
     requestedStopAt,

--- a/src/domain/publicationHandoff.ts
+++ b/src/domain/publicationHandoff.ts
@@ -1,0 +1,1323 @@
+/**
+ * RUNNER-PUBLISH-HANDOFF-V1
+ *
+ * Explicit execution → publication authority transition.
+ * Resolves RUNNER_PUBLISHER_AUTHORITY_INCOMPATIBLE without widening
+ * AGENT-RUNNER-V1 into R2 / GitHub publication authority.
+ *
+ * ExecutionTask (R0/R1)
+ * → IndependentVerifyResultV1 = VERIFIED
+ * → PublicationHandoffV1
+ * → distinct PublicationTask (R2 + github.draft-pr.publish.v1 + DRAFT_PR)
+ *
+ * Do NOT mutate the source execution AgentTaskV1.
+ * Do NOT call runAgentTaskV1(publicationTask).
+ * REAL PROVIDER EXECUTION = HOLD
+ * REAL GITHUB PUBLICATION = HOLD
+ */
+
+import {
+  AGENT_TASK_SCHEMA,
+  normalizeRepoPath,
+  parseAgentTaskV1,
+  validateAgentTaskV1,
+  type AgentTaskRiskClass,
+  type AgentTaskSourceIssue,
+  type AgentTaskV1,
+  type AgentTaskValidationResultV1,
+} from "./agentTaskContract";
+import {
+  AGENT_RUNNER_SUPPORTED_CAPABILITIES,
+  AGENT_RUNNER_SUPPORTED_RISK_CLASSES,
+  evaluateChangedPathsPolicy,
+} from "./agentRunner";
+import {
+  DRAFT_PUBLISH_REQUIRED_CAPABILITY,
+  DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
+  DRAFT_PUBLISH_REQUIRED_STOP_AT,
+} from "./draftPublish";
+import {
+  findDuplicateChangedPaths,
+  changedPathSetsEqual,
+  type IndependentVerifyResultV1,
+  type IndependentVerifyStatus,
+} from "./independentVerify";
+import type { IndependentVerifyEvidenceV1 } from "./independentVerifyAdapter";
+
+export const PUBLICATION_HANDOFF_VERSION = "RUNNER-PUBLISH-HANDOFF-V1" as const;
+export const PUBLICATION_HANDOFF_SCHEMA = "PUBLICATION-HANDOFF-V1" as const;
+export const PUBLICATION_HANDOFF_RESULT_SCHEMA =
+  "PUBLICATION-HANDOFF-RESULT-V1" as const;
+
+export const PUBLICATION_HANDOFF_REQUIRED_CAPABILITY =
+  DRAFT_PUBLISH_REQUIRED_CAPABILITY;
+export const PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS =
+  DRAFT_PUBLISH_REQUIRED_RISK_CLASS;
+export const PUBLICATION_HANDOFF_REQUIRED_STOP_AT =
+  DRAFT_PUBLISH_REQUIRED_STOP_AT;
+
+/** Frozen snapshot of runner allowlists — must never expand in this slice. */
+export const PUBLICATION_HANDOFF_RUNNER_RISK_CLASSES_SNAPSHOT = [
+  "R0",
+  "R1",
+] as const satisfies readonly AgentTaskRiskClass[];
+export const PUBLICATION_HANDOFF_RUNNER_CAPABILITIES_SNAPSHOT = [
+  "workspace.read.v1",
+] as const;
+
+export const PUBLICATION_HANDOFF_INPUT_ROOT_KEYS = [
+  "handoffId",
+  "sourceExecutionTask",
+  "independentVerifyResult",
+  "requestedPublicationCapability",
+  "requestedRiskClass",
+  "requestedStopAt",
+  "observedAt",
+] as const;
+
+export type PublicationHandoffStatus =
+  | "READY_FOR_PUBLICATION_TASK"
+  | "HOLD"
+  | "REJECT"
+  | "FAILED"
+  | "UNKNOWN";
+
+export type PublicationHandoffReasonCode =
+  | "READY_FOR_PUBLICATION_TASK"
+  | "HOLD_VERIFIER"
+  | "REJECT_VERIFIER"
+  | "FAILED_VERIFIER"
+  | "UNKNOWN_VERIFIER"
+  | "REJECT_INPUT"
+  | "REJECT_SOURCE_TASK"
+  | "REJECT_SOURCE_TASK_INVALID"
+  | "REJECT_IDENTITY_TASK_ID"
+  | "REJECT_IDENTITY_REPOSITORY"
+  | "REJECT_IDENTITY_BASE_REVISION"
+  | "REJECT_IDENTITY_SOURCE_ISSUE"
+  | "REJECT_VERIFIED_PATHS"
+  | "REJECT_CHANGED_PATH_DUPLICATE"
+  | "REJECT_CHANGED_PATH_UNSAFE"
+  | "FAILED_FORBIDDEN_PATH"
+  | "FAILED_CHANGED_PATH_OUT_OF_SCOPE"
+  | "REJECT_VERIFIER_METADATA"
+  | "REJECT_VERIFIER_EVIDENCE"
+  | "REJECT_PUBLICATION_CAPABILITY"
+  | "HOLD_PUBLICATION_CAPABILITY"
+  | "REJECT_PUBLICATION_RISK"
+  | "HOLD_PUBLICATION_RISK"
+  | "REJECT_PUBLICATION_STOP_AT"
+  | "HOLD_PUBLICATION_STOP_AT"
+  | "REJECT_PUBLICATION_TASK"
+  | "REJECT_HANDOFF_IDEMPOTENCY_CONFLICT"
+  | "UNKNOWN_HANDOFF_STATE";
+
+export interface PublicationHandoffInputV1 {
+  handoffId: string;
+  sourceExecutionTask: AgentTaskV1;
+  independentVerifyResult: IndependentVerifyResultV1;
+  requestedPublicationCapability: typeof PUBLICATION_HANDOFF_REQUIRED_CAPABILITY;
+  requestedRiskClass: typeof PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS;
+  requestedStopAt: typeof PUBLICATION_HANDOFF_REQUIRED_STOP_AT;
+  observedAt: string;
+}
+
+export interface PublicationHandoffV1 {
+  schemaVersion: typeof PUBLICATION_HANDOFF_SCHEMA;
+  handoffId: string;
+  sourceExecutionTaskId: string;
+  sourceIssue: AgentTaskSourceIssue;
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  verificationAttemptId: string;
+  verificationFingerprint: string;
+  requestedPublicationCapability: typeof PUBLICATION_HANDOFF_REQUIRED_CAPABILITY;
+  requestedRiskClass: typeof PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS;
+  requestedStopAt: typeof PUBLICATION_HANDOFF_REQUIRED_STOP_AT;
+  observedAt: string;
+}
+
+export interface PublicationHandoffAuthorityFingerprintV1 {
+  handoffId: string;
+  sourceExecutionTaskId: string;
+  sourceIssue: AgentTaskSourceIssue;
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  verificationAttemptId: string;
+  requestedPublicationCapability: string;
+  requestedRiskClass: string;
+  requestedStopAt: string;
+}
+
+export interface PublicationHandoffMetadataV1 {
+  observedAt: string;
+  handoffId: string;
+  authorityFingerprint: string;
+  verificationFingerprint: string;
+  realAgentProviderExecution: false;
+  realGithubPublication: false;
+  githubMutationPerformed: false;
+  networkAccess: false;
+  secretsRequired: false;
+  productionMutationPerformed: false;
+  productionMutationAuthorized: false;
+  readyAuthorized: false;
+  mergeAuthorized: false;
+  issueCloseAuthorized: false;
+  deployAuthorized: false;
+  runnerAuthorityExpanded: false;
+  draftPublishAuthorityExpanded: false;
+  sourceExecutionTaskMutated: false;
+  publicationTaskDispatchedToRunner: false;
+}
+
+export interface PublicationHandoffResultV1 {
+  schemaVersion: typeof PUBLICATION_HANDOFF_RESULT_SCHEMA;
+  handoffVersion: typeof PUBLICATION_HANDOFF_VERSION;
+  status: PublicationHandoffStatus;
+  reasonCode: PublicationHandoffReasonCode;
+  reasonMessage: string;
+  handoffId: string | null;
+  sourceExecutionTaskId: string | null;
+  publicationTaskId: string | null;
+  repository: string | null;
+  baseRevision: string | null;
+  verifiedChangedPaths: string[];
+  handoff: PublicationHandoffV1 | null;
+  publicationTask: AgentTaskV1 | null;
+  sourceTaskValidation: AgentTaskValidationResultV1 | null;
+  publicationTaskValidation: AgentTaskValidationResultV1 | null;
+  authorityFingerprint: string | null;
+  metadata: PublicationHandoffMetadataV1;
+  observedAt: string;
+}
+
+export interface PublicationHandoffAttemptRecordV1 {
+  handoffId: string;
+  authorityFingerprint: string;
+  result: PublicationHandoffResultV1;
+}
+
+export interface CreatePublicationHandoffV1Options {
+  validatedAt?: string;
+  /** Injected local registry — no external persistence in V1. */
+  attemptRegistry?: Map<string, PublicationHandoffAttemptRecordV1>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function sortPathsStable(paths: string[]): string[] {
+  return [...paths]
+    .map((p) => normalizeRepoPath(p))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** Deterministic 40-hex token from seed (not cryptographic security). */
+export function deterministicHexFromSeed(seed: string): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0x811c9dc5 ^ 0xabcdef;
+  for (let i = 0; i < seed.length; i++) {
+    const c = seed.charCodeAt(i);
+    h1 = Math.imul(h1 ^ c, 0x01000193);
+    h2 = Math.imul(h2 ^ (c + 1), 0x01000193);
+  }
+  const hex = (n: number) => (n >>> 0).toString(16).padStart(8, "0");
+  const out = `${hex(h1)}${hex(h2)}${hex(h1 ^ h2)}${hex(~h1)}${hex(h1 + h2)}`;
+  return out.slice(0, 40);
+}
+
+export function computeVerificationFingerprint(input: {
+  verificationAttemptId: string;
+  taskId: string;
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  status: string;
+}): string {
+  const paths = sortPathsStable(input.verifiedChangedPaths);
+  return `vf:v1:${stableJson({
+    verificationAttemptId: input.verificationAttemptId,
+    taskId: input.taskId,
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    verifiedChangedPaths: paths,
+    status: input.status,
+  })}`;
+}
+
+export function capturePublicationHandoffAuthorityFingerprint(
+  input: PublicationHandoffAuthorityFingerprintV1,
+): PublicationHandoffAuthorityFingerprintV1 {
+  return {
+    handoffId: input.handoffId,
+    sourceExecutionTaskId: input.sourceExecutionTaskId,
+    sourceIssue: {
+      repository: input.sourceIssue.repository,
+      number: input.sourceIssue.number,
+    },
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    verifiedChangedPaths: sortPathsStable(input.verifiedChangedPaths),
+    verificationAttemptId: input.verificationAttemptId,
+    requestedPublicationCapability: input.requestedPublicationCapability,
+    requestedRiskClass: input.requestedRiskClass,
+    requestedStopAt: input.requestedStopAt,
+  };
+}
+
+export function serializeAuthorityFingerprint(
+  fp: PublicationHandoffAuthorityFingerprintV1,
+): string {
+  return `ah:v1:${stableJson(capturePublicationHandoffAuthorityFingerprint(fp))}`;
+}
+
+export function authorityFingerprintsEqual(
+  a: PublicationHandoffAuthorityFingerprintV1,
+  b: PublicationHandoffAuthorityFingerprintV1,
+): boolean {
+  return (
+    serializeAuthorityFingerprint(a) === serializeAuthorityFingerprint(b)
+  );
+}
+
+/**
+ * Deterministic publication taskId. Seed includes handoff + source identity +
+ * verified paths + requested publication authority.
+ */
+export function buildDeterministicPublicationTaskId(input: {
+  handoffId: string;
+  sourceExecutionTaskId: string;
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  requestedPublicationCapability: string;
+  requestedRiskClass: string;
+  requestedStopAt: string;
+}): string {
+  const seed = stableJson({
+    handoffId: input.handoffId,
+    sourceExecutionTaskId: input.sourceExecutionTaskId,
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    verifiedChangedPaths: sortPathsStable(input.verifiedChangedPaths),
+    requestedPublicationCapability: input.requestedPublicationCapability,
+    requestedRiskClass: input.requestedRiskClass,
+    requestedStopAt: input.requestedStopAt,
+  });
+  const hex = deterministicHexFromSeed(seed);
+  return `pub-handoff-${hex}`.slice(0, 128);
+}
+
+/**
+ * Narrow compatibility check against existing DRAFT-PUBLISH-V1 constants.
+ * Does not invoke publishDraftPrV1.
+ */
+export function publicationTaskMeetsDraftPublishAuthority(
+  task: AgentTaskV1,
+): boolean {
+  return (
+    task.riskClass === DRAFT_PUBLISH_REQUIRED_RISK_CLASS &&
+    task.stopAt === DRAFT_PUBLISH_REQUIRED_STOP_AT &&
+    task.allowedCapabilities.length === 1 &&
+    task.allowedCapabilities[0] === DRAFT_PUBLISH_REQUIRED_CAPABILITY
+  );
+}
+
+/** Publication tasks must not be runner-dispatchable under current allowlists. */
+export function publicationTaskIsRunnerDispatchable(
+  task: AgentTaskV1,
+): boolean {
+  const riskOk = (
+    AGENT_RUNNER_SUPPORTED_RISK_CLASSES as readonly string[]
+  ).includes(task.riskClass);
+  const capsOk = task.allowedCapabilities.every((c) =>
+    (AGENT_RUNNER_SUPPORTED_CAPABILITIES as readonly string[]).includes(c),
+  );
+  return riskOk && capsOk;
+}
+
+export function assertPublicationHandoffBoundaries(): void {
+  if (
+    stableJson([...AGENT_RUNNER_SUPPORTED_RISK_CLASSES]) !==
+    stableJson([...PUBLICATION_HANDOFF_RUNNER_RISK_CLASSES_SNAPSHOT])
+  ) {
+    throw new Error(
+      "RUNNER-PUBLISH-HANDOFF-V1 forbids expanding AGENT_RUNNER_SUPPORTED_RISK_CLASSES",
+    );
+  }
+  if (
+    stableJson([...AGENT_RUNNER_SUPPORTED_CAPABILITIES]) !==
+    stableJson([...PUBLICATION_HANDOFF_RUNNER_CAPABILITIES_SNAPSHOT])
+  ) {
+    throw new Error(
+      "RUNNER-PUBLISH-HANDOFF-V1 forbids expanding AGENT_RUNNER_SUPPORTED_CAPABILITIES",
+    );
+  }
+  if (
+    (AGENT_RUNNER_SUPPORTED_CAPABILITIES as readonly string[]).includes(
+      PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+    )
+  ) {
+    throw new Error(
+      "RUNNER-PUBLISH-HANDOFF-V1 forbids adding github.draft-pr.publish.v1 to runner capabilities",
+    );
+  }
+  if (
+    (AGENT_RUNNER_SUPPORTED_RISK_CLASSES as readonly string[]).includes("R2")
+  ) {
+    throw new Error(
+      "RUNNER-PUBLISH-HANDOFF-V1 forbids adding R2 to runner risk classes",
+    );
+  }
+}
+
+function metadataBase(input: {
+  observedAt: string;
+  handoffId: string;
+  authorityFingerprint: string | null;
+  verificationFingerprint: string | null;
+}): PublicationHandoffMetadataV1 {
+  return {
+    observedAt: input.observedAt,
+    handoffId: input.handoffId,
+    authorityFingerprint: input.authorityFingerprint ?? "",
+    verificationFingerprint: input.verificationFingerprint ?? "",
+    realAgentProviderExecution: false,
+    realGithubPublication: false,
+    githubMutationPerformed: false,
+    networkAccess: false,
+    secretsRequired: false,
+    productionMutationPerformed: false,
+    productionMutationAuthorized: false,
+    readyAuthorized: false,
+    mergeAuthorized: false,
+    issueCloseAuthorized: false,
+    deployAuthorized: false,
+    runnerAuthorityExpanded: false,
+    draftPublishAuthorityExpanded: false,
+    sourceExecutionTaskMutated: false,
+    publicationTaskDispatchedToRunner: false,
+  };
+}
+
+function buildResult(input: {
+  status: PublicationHandoffStatus;
+  reasonCode: PublicationHandoffReasonCode;
+  reasonMessage: string;
+  handoffId: string | null;
+  sourceExecutionTaskId?: string | null;
+  publicationTaskId?: string | null;
+  repository?: string | null;
+  baseRevision?: string | null;
+  verifiedChangedPaths?: string[];
+  handoff?: PublicationHandoffV1 | null;
+  publicationTask?: AgentTaskV1 | null;
+  sourceTaskValidation?: AgentTaskValidationResultV1 | null;
+  publicationTaskValidation?: AgentTaskValidationResultV1 | null;
+  authorityFingerprint?: string | null;
+  verificationFingerprint?: string | null;
+  observedAt: string;
+}): PublicationHandoffResultV1 {
+  const handoffId = input.handoffId ?? "unknown";
+  return {
+    schemaVersion: PUBLICATION_HANDOFF_RESULT_SCHEMA,
+    handoffVersion: PUBLICATION_HANDOFF_VERSION,
+    status: input.status,
+    reasonCode: input.reasonCode,
+    reasonMessage: input.reasonMessage,
+    handoffId: input.handoffId,
+    sourceExecutionTaskId: input.sourceExecutionTaskId ?? null,
+    publicationTaskId: input.publicationTaskId ?? null,
+    repository: input.repository ?? null,
+    baseRevision: input.baseRevision ?? null,
+    verifiedChangedPaths: input.verifiedChangedPaths
+      ? [...input.verifiedChangedPaths]
+      : [],
+    handoff: input.handoff ?? null,
+    publicationTask: input.publicationTask ?? null,
+    sourceTaskValidation: input.sourceTaskValidation ?? null,
+    publicationTaskValidation: input.publicationTaskValidation ?? null,
+    authorityFingerprint: input.authorityFingerprint ?? null,
+    metadata: metadataBase({
+      observedAt: input.observedAt,
+      handoffId,
+      authorityFingerprint: input.authorityFingerprint ?? null,
+      verificationFingerprint: input.verificationFingerprint ?? null,
+    }),
+    observedAt: input.observedAt,
+  };
+}
+
+function isExactBooleanFalse(value: unknown): value is false {
+  return value === false;
+}
+
+function checkVerifierMetadataBoundary(
+  metadata: unknown,
+): { ok: true } | { ok: false; reasonMessage: string } {
+  if (!isPlainObject(metadata)) {
+    return { ok: false, reasonMessage: "verifier metadata must be an object." };
+  }
+  const requiredFalse = [
+    "publicationAuthorized",
+    "readyAuthorized",
+    "mergeAuthorized",
+    "githubMutationAuthorized",
+    "deployAuthorized",
+  ] as const;
+  for (const key of requiredFalse) {
+    if (!isExactBooleanFalse(metadata[key])) {
+      return {
+        ok: false,
+        reasonMessage: `independentVerifyResult.metadata.${key} must be exactly false; VERIFIED is not publication authority.`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+function checkVerifierEvidenceSafety(
+  evidence: IndependentVerifyEvidenceV1 | null,
+): { ok: true } | { ok: false; reasonMessage: string } {
+  if (evidence === null || evidence === undefined) {
+    return {
+      ok: false,
+      reasonMessage:
+        "independentVerifyResult.verificationEvidence is required for handoff safety checks; missing fails closed.",
+    };
+  }
+  const requiredFalse = [
+    "networkAccess",
+    "secretsRequired",
+    "githubMutationPerformed",
+    "productionMutationPerformed",
+  ] as const;
+  for (const key of requiredFalse) {
+    if (!isExactBooleanFalse(evidence[key])) {
+      return {
+        ok: false,
+        reasonMessage: `verificationEvidence.${key} must be exactly false; missing/contradictory fails closed.`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+function mapVerifierStatus(
+  status: IndependentVerifyStatus,
+  reasonMessage: string,
+): {
+  status: PublicationHandoffStatus;
+  reasonCode: PublicationHandoffReasonCode;
+  reasonMessage: string;
+} | null {
+  if (status === "HOLD") {
+    return {
+      status: "HOLD",
+      reasonCode: "HOLD_VERIFIER",
+      reasonMessage: `Verifier HOLD: ${reasonMessage}`,
+    };
+  }
+  if (status === "REJECT") {
+    return {
+      status: "REJECT",
+      reasonCode: "REJECT_VERIFIER",
+      reasonMessage: `Verifier REJECT: ${reasonMessage}`,
+    };
+  }
+  if (status === "FAILED") {
+    return {
+      status: "FAILED",
+      reasonCode: "FAILED_VERIFIER",
+      reasonMessage: `Verifier FAILED: ${reasonMessage}`,
+    };
+  }
+  if (status === "UNKNOWN") {
+    return {
+      status: "UNKNOWN",
+      reasonCode: "UNKNOWN_VERIFIER",
+      reasonMessage: `Verifier UNKNOWN: ${reasonMessage}`,
+    };
+  }
+  if (status === "VERIFIED") {
+    return null;
+  }
+  return {
+    status: "UNKNOWN",
+    reasonCode: "UNKNOWN_VERIFIER",
+    reasonMessage: `Unrecognized verifier status; fail closed: ${reasonMessage}`,
+  };
+}
+
+function isForbiddenGenericGithubCapability(capability: string): boolean {
+  if (capability === PUBLICATION_HANDOFF_REQUIRED_CAPABILITY) {
+    return false;
+  }
+  if (capability === "github.write" || capability === "repo.write") {
+    return true;
+  }
+  if (capability === "github.*" || capability.startsWith("github.")) {
+    return true;
+  }
+  if (capability.startsWith("repo.")) {
+    return true;
+  }
+  return false;
+}
+
+function deepCloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Create a publication handoff from a VERIFIED execution result.
+ * Never mutates sourceExecutionTask. Never dispatches publication through runner.
+ */
+export function createPublicationHandoffV1(
+  rawInput: unknown,
+  options: CreatePublicationHandoffV1Options = {},
+): PublicationHandoffResultV1 {
+  const validatedAt = options.validatedAt ?? new Date(0).toISOString();
+  const registry = options.attemptRegistry;
+
+  if (!isPlainObject(rawInput)) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "Publication handoff input must be a JSON object.",
+      handoffId: null,
+      observedAt: validatedAt,
+    });
+  }
+  if (!hasOnlyKeys(rawInput, PUBLICATION_HANDOFF_INPUT_ROOT_KEYS)) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "Publication handoff input contains unknown properties.",
+      handoffId:
+        typeof rawInput.handoffId === "string" ? rawInput.handoffId : null,
+      observedAt:
+        typeof rawInput.observedAt === "string"
+          ? rawInput.observedAt
+          : validatedAt,
+    });
+  }
+
+  if (
+    rawInput.handoffId === undefined ||
+    rawInput.handoffId === null ||
+    typeof rawInput.handoffId !== "string" ||
+    rawInput.handoffId.length < 1 ||
+    rawInput.handoffId.length > 128
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage:
+        "handoffId is required (non-empty bounded string); missing fails closed.",
+      handoffId: null,
+      observedAt:
+        typeof rawInput.observedAt === "string"
+          ? rawInput.observedAt
+          : validatedAt,
+    });
+  }
+  const handoffId = rawInput.handoffId;
+
+  if (
+    typeof rawInput.observedAt !== "string" ||
+    rawInput.observedAt.length < 1
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "observedAt must be a non-empty string.",
+      handoffId,
+      observedAt: validatedAt,
+    });
+  }
+  const observedAt = rawInput.observedAt;
+
+  if (rawInput.requestedPublicationCapability === undefined) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage:
+        "requestedPublicationCapability is required; do not default to github.draft-pr.publish.v1.",
+      handoffId,
+      observedAt,
+    });
+  }
+  if (rawInput.requestedRiskClass === undefined) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "requestedRiskClass is required; do not default to R2.",
+      handoffId,
+      observedAt,
+    });
+  }
+  if (rawInput.requestedStopAt === undefined) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "requestedStopAt is required; do not default to DRAFT_PR.",
+      handoffId,
+      observedAt,
+    });
+  }
+
+  if (typeof rawInput.requestedPublicationCapability !== "string") {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_CAPABILITY",
+      reasonMessage: "requestedPublicationCapability must be a string.",
+      handoffId,
+      observedAt,
+    });
+  }
+  if (
+    isForbiddenGenericGithubCapability(rawInput.requestedPublicationCapability)
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_CAPABILITY",
+      reasonMessage: `Generic or wildcard GitHub capability rejected: ${rawInput.requestedPublicationCapability}`,
+      handoffId,
+      observedAt,
+    });
+  }
+  if (
+    rawInput.requestedPublicationCapability !==
+    PUBLICATION_HANDOFF_REQUIRED_CAPABILITY
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_CAPABILITY",
+      reasonMessage: `requestedPublicationCapability must be exactly ${PUBLICATION_HANDOFF_REQUIRED_CAPABILITY}; got ${rawInput.requestedPublicationCapability}.`,
+      handoffId,
+      observedAt,
+    });
+  }
+
+  if (typeof rawInput.requestedRiskClass !== "string") {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_RISK",
+      reasonMessage: "requestedRiskClass must be a string.",
+      handoffId,
+      observedAt,
+    });
+  }
+  if (rawInput.requestedRiskClass !== PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_RISK",
+      reasonMessage: `requestedRiskClass must be exactly ${PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS}; got ${rawInput.requestedRiskClass}. No silent upgrade.`,
+      handoffId,
+      observedAt,
+    });
+  }
+
+  if (typeof rawInput.requestedStopAt !== "string") {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_STOP_AT",
+      reasonMessage: "requestedStopAt must be a string.",
+      handoffId,
+      observedAt,
+    });
+  }
+  if (rawInput.requestedStopAt !== PUBLICATION_HANDOFF_REQUIRED_STOP_AT) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_STOP_AT",
+      reasonMessage: `requestedStopAt must be exactly ${PUBLICATION_HANDOFF_REQUIRED_STOP_AT}; got ${rawInput.requestedStopAt}.`,
+      handoffId,
+      observedAt,
+    });
+  }
+
+  const requestedPublicationCapability =
+    PUBLICATION_HANDOFF_REQUIRED_CAPABILITY;
+  const requestedRiskClass = PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS;
+  const requestedStopAt = PUBLICATION_HANDOFF_REQUIRED_STOP_AT;
+
+  if (rawInput.sourceExecutionTask === undefined) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "sourceExecutionTask is required.",
+      handoffId,
+      observedAt,
+    });
+  }
+  const sourceParsed = parseAgentTaskV1(rawInput.sourceExecutionTask);
+  if (!sourceParsed.ok) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_SOURCE_TASK",
+      reasonMessage: `sourceExecutionTask failed structural parse: ${sourceParsed.reasonMessage}`,
+      handoffId,
+      observedAt,
+    });
+  }
+  const sourceExecutionTask = sourceParsed.task;
+  const sourceValidation = validateAgentTaskV1(sourceExecutionTask, {
+    validatedAt,
+  });
+  if (sourceValidation.status !== "VALID") {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_SOURCE_TASK_INVALID",
+      reasonMessage: `sourceExecutionTask revalidation status=${sourceValidation.status}: ${sourceValidation.reasonMessage}`,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  if (rawInput.independentVerifyResult === undefined) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "independentVerifyResult is required.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+  if (!isPlainObject(rawInput.independentVerifyResult)) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "independentVerifyResult must be an object.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  const verifiedRaw = rawInput.independentVerifyResult;
+  if (typeof verifiedRaw.status !== "string") {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "independentVerifyResult.status must be a string.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  const verifiedResult = verifiedRaw as unknown as IndependentVerifyResultV1;
+
+  const propagated = mapVerifierStatus(
+    verifiedResult.status,
+    typeof verifiedResult.reasonMessage === "string"
+      ? verifiedResult.reasonMessage
+      : "no reasonMessage",
+  );
+  if (propagated !== null) {
+    return buildResult({
+      status: propagated.status,
+      reasonCode: propagated.reasonCode,
+      reasonMessage: propagated.reasonMessage,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  if (verifiedResult.taskId !== sourceExecutionTask.taskId) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_IDENTITY_TASK_ID",
+      reasonMessage: `independentVerifyResult.taskId !== sourceExecutionTask.taskId (${String(verifiedResult.taskId)} !== ${sourceExecutionTask.taskId}).`,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+  if (verifiedResult.repository !== sourceExecutionTask.repository) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_IDENTITY_REPOSITORY",
+      reasonMessage:
+        "independentVerifyResult.repository !== sourceExecutionTask.repository.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+  if (verifiedResult.baseRevision !== sourceExecutionTask.baseRevision) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_IDENTITY_BASE_REVISION",
+      reasonMessage:
+        "independentVerifyResult.baseRevision !== sourceExecutionTask.baseRevision.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  if (
+    typeof verifiedResult.verificationAttemptId !== "string" ||
+    verifiedResult.verificationAttemptId.length < 1
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_INPUT",
+      reasonMessage: "independentVerifyResult.verificationAttemptId is required.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+  const verificationAttemptId = verifiedResult.verificationAttemptId;
+
+  if (
+    sourceExecutionTask.sourceIssue.repository !==
+      sourceExecutionTask.repository ||
+    typeof sourceExecutionTask.sourceIssue.number !== "number"
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_IDENTITY_SOURCE_ISSUE",
+      reasonMessage: "sourceExecutionTask.sourceIssue failed binding checks.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  const metaCheck = checkVerifierMetadataBoundary(verifiedResult.metadata);
+  if (!metaCheck.ok) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_VERIFIER_METADATA",
+      reasonMessage: metaCheck.reasonMessage,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  const evidenceCheck = checkVerifierEvidenceSafety(
+    verifiedResult.verificationEvidence,
+  );
+  if (!evidenceCheck.ok) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_VERIFIER_EVIDENCE",
+      reasonMessage: evidenceCheck.reasonMessage,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  if (!Array.isArray(verifiedResult.verifiedChangedPaths)) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_VERIFIED_PATHS",
+      reasonMessage: "verifiedChangedPaths must be an array.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+  if (verifiedResult.verifiedChangedPaths.length < 1) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_VERIFIED_PATHS",
+      reasonMessage:
+        "verifiedChangedPaths must be non-empty for publication handoff (publication allowedPaths minItems=1).",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+  if (
+    !verifiedResult.verifiedChangedPaths.every((p) => typeof p === "string")
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_VERIFIED_PATHS",
+      reasonMessage: "verifiedChangedPaths entries must be strings.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  const verifiedChangedPaths = [...verifiedResult.verifiedChangedPaths];
+
+  const dup = findDuplicateChangedPaths(verifiedChangedPaths);
+  if (dup !== null) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_CHANGED_PATH_DUPLICATE",
+      reasonMessage: `Duplicate verifiedChangedPaths entry fails closed: ${dup}`,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  const pathPolicy = evaluateChangedPathsPolicy(
+    sourceExecutionTask,
+    verifiedChangedPaths,
+  );
+  if (!pathPolicy.ok) {
+    const reasonCode: PublicationHandoffReasonCode =
+      pathPolicy.reasonCode === "REJECT_CHANGED_PATH_UNSAFE"
+        ? "REJECT_CHANGED_PATH_UNSAFE"
+        : pathPolicy.reasonCode === "FAILED_FORBIDDEN_PATH"
+          ? "FAILED_FORBIDDEN_PATH"
+          : "FAILED_CHANGED_PATH_OUT_OF_SCOPE";
+    return buildResult({
+      status: pathPolicy.status === "REJECT" ? "REJECT" : "FAILED",
+      reasonCode,
+      reasonMessage: pathPolicy.reasonMessage,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      sourceTaskValidation: sourceValidation,
+      observedAt,
+    });
+  }
+
+  const verificationFingerprint = computeVerificationFingerprint({
+    verificationAttemptId,
+    taskId: sourceExecutionTask.taskId,
+    repository: sourceExecutionTask.repository,
+    baseRevision: sourceExecutionTask.baseRevision,
+    verifiedChangedPaths,
+    status: "VERIFIED",
+  });
+
+  const authorityFp = capturePublicationHandoffAuthorityFingerprint({
+    handoffId,
+    sourceExecutionTaskId: sourceExecutionTask.taskId,
+    sourceIssue: sourceExecutionTask.sourceIssue,
+    repository: sourceExecutionTask.repository,
+    baseRevision: sourceExecutionTask.baseRevision,
+    verifiedChangedPaths,
+    verificationAttemptId,
+    requestedPublicationCapability,
+    requestedRiskClass,
+    requestedStopAt,
+  });
+  const authorityFingerprint = serializeAuthorityFingerprint(authorityFp);
+
+  if (registry) {
+    const prior = registry.get(handoffId);
+    if (prior) {
+      if (prior.authorityFingerprint === authorityFingerprint) {
+        return deepCloneJson(prior.result);
+      }
+      return buildResult({
+        status: "REJECT",
+        reasonCode: "REJECT_HANDOFF_IDEMPOTENCY_CONFLICT",
+        reasonMessage:
+          "same handoffId with different authority fingerprint; REJECT_HANDOFF_IDEMPOTENCY_CONFLICT.",
+        handoffId,
+        sourceExecutionTaskId: sourceExecutionTask.taskId,
+        repository: sourceExecutionTask.repository,
+        baseRevision: sourceExecutionTask.baseRevision,
+        verifiedChangedPaths,
+        sourceTaskValidation: sourceValidation,
+        authorityFingerprint,
+        verificationFingerprint,
+        observedAt,
+      });
+    }
+  }
+
+  const publicationTaskId = buildDeterministicPublicationTaskId({
+    handoffId,
+    sourceExecutionTaskId: sourceExecutionTask.taskId,
+    repository: sourceExecutionTask.repository,
+    baseRevision: sourceExecutionTask.baseRevision,
+    verifiedChangedPaths,
+    requestedPublicationCapability,
+    requestedRiskClass,
+    requestedStopAt,
+  });
+
+  if (publicationTaskId === sourceExecutionTask.taskId) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_TASK",
+      reasonMessage:
+        "publicationTask.taskId collided with sourceExecutionTask.taskId; fail closed.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      sourceTaskValidation: sourceValidation,
+      authorityFingerprint,
+      verificationFingerprint,
+      observedAt,
+    });
+  }
+
+  const publicationTaskCandidate: AgentTaskV1 = {
+    schemaVersion: AGENT_TASK_SCHEMA,
+    taskId: publicationTaskId,
+    repository: sourceExecutionTask.repository,
+    baseRevision: sourceExecutionTask.baseRevision,
+    sourceIssue: {
+      repository: sourceExecutionTask.sourceIssue.repository,
+      number: sourceExecutionTask.sourceIssue.number,
+    },
+    objective: `RUNNER-PUBLISH-HANDOFF-V1 publication task for verified execution ${sourceExecutionTask.taskId} (handoff ${handoffId}). Draft-only publication scope.`,
+    allowedPaths: [...verifiedChangedPaths],
+    forbiddenPaths: [...sourceExecutionTask.forbiddenPaths],
+    acceptanceCriteria: [
+      "Publication task derived from VERIFIED execution via PublicationHandoffV1",
+      "allowedPaths exact verifiedChangedPaths",
+      "capability exactly github.draft-pr.publish.v1; risk R2; stopAt DRAFT_PR",
+    ],
+    verificationCommands: sourceExecutionTask.verificationCommands.map(
+      (cmd) => ({
+        id: cmd.id,
+        command: cmd.command,
+        ...(cmd.workingDirectory !== undefined
+          ? { workingDirectory: cmd.workingDirectory }
+          : {}),
+        ...(cmd.description !== undefined
+          ? { description: cmd.description }
+          : {}),
+      }),
+    ),
+    allowedCapabilities: [PUBLICATION_HANDOFF_REQUIRED_CAPABILITY],
+    riskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+    stopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+  };
+
+  const pubParsed = parseAgentTaskV1(publicationTaskCandidate);
+  if (!pubParsed.ok) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_TASK",
+      reasonMessage: `publicationTask failed structural parse: ${pubParsed.reasonMessage}`,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      sourceTaskValidation: sourceValidation,
+      authorityFingerprint,
+      verificationFingerprint,
+      observedAt,
+    });
+  }
+  const publicationTask = pubParsed.task;
+  const publicationValidation = validateAgentTaskV1(publicationTask, {
+    validatedAt,
+  });
+  if (publicationValidation.status !== "VALID") {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_TASK",
+      reasonMessage: `publicationTask revalidation status=${publicationValidation.status}: ${publicationValidation.reasonMessage}`,
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      publicationTaskId: publicationTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      publicationTask,
+      sourceTaskValidation: sourceValidation,
+      publicationTaskValidation: publicationValidation,
+      authorityFingerprint,
+      verificationFingerprint,
+      observedAt,
+    });
+  }
+
+  if (
+    !changedPathSetsEqual(publicationTask.allowedPaths, verifiedChangedPaths) ||
+    publicationTask.allowedPaths.length !== verifiedChangedPaths.length
+  ) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_TASK",
+      reasonMessage:
+        "publicationTask.allowedPaths must be exactly equal to verifiedChangedPaths.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      publicationTaskId: publicationTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      publicationTask,
+      sourceTaskValidation: sourceValidation,
+      publicationTaskValidation: publicationValidation,
+      authorityFingerprint,
+      verificationFingerprint,
+      observedAt,
+    });
+  }
+
+  if (!publicationTaskMeetsDraftPublishAuthority(publicationTask)) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_TASK",
+      reasonMessage:
+        "publicationTask does not meet DRAFT-PUBLISH-V1 eligibility authority boundary.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      publicationTaskId: publicationTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      publicationTask,
+      sourceTaskValidation: sourceValidation,
+      publicationTaskValidation: publicationValidation,
+      authorityFingerprint,
+      verificationFingerprint,
+      observedAt,
+    });
+  }
+
+  if (publicationTaskIsRunnerDispatchable(publicationTask)) {
+    return buildResult({
+      status: "REJECT",
+      reasonCode: "REJECT_PUBLICATION_TASK",
+      reasonMessage:
+        "publicationTask must not be AGENT-RUNNER-V1 dispatchable; fail closed.",
+      handoffId,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      publicationTaskId: publicationTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths,
+      publicationTask,
+      sourceTaskValidation: sourceValidation,
+      publicationTaskValidation: publicationValidation,
+      authorityFingerprint,
+      verificationFingerprint,
+      observedAt,
+    });
+  }
+
+  const handoff: PublicationHandoffV1 = {
+    schemaVersion: PUBLICATION_HANDOFF_SCHEMA,
+    handoffId,
+    sourceExecutionTaskId: sourceExecutionTask.taskId,
+    sourceIssue: {
+      repository: sourceExecutionTask.sourceIssue.repository,
+      number: sourceExecutionTask.sourceIssue.number,
+    },
+    repository: sourceExecutionTask.repository,
+    baseRevision: sourceExecutionTask.baseRevision,
+    verifiedChangedPaths: [...verifiedChangedPaths],
+    verificationAttemptId,
+    verificationFingerprint,
+    requestedPublicationCapability,
+    requestedRiskClass,
+    requestedStopAt,
+    observedAt,
+  };
+
+  const result = buildResult({
+    status: "READY_FOR_PUBLICATION_TASK",
+    reasonCode: "READY_FOR_PUBLICATION_TASK",
+    reasonMessage:
+      "Verified execution bound to distinct R2 publication task via PublicationHandoffV1. Source execution task unchanged. Runner authority not expanded. Ready/Merge/IssueClose/Deploy remain unauthorized.",
+    handoffId,
+    sourceExecutionTaskId: sourceExecutionTask.taskId,
+    publicationTaskId: publicationTask.taskId,
+    repository: sourceExecutionTask.repository,
+    baseRevision: sourceExecutionTask.baseRevision,
+    verifiedChangedPaths,
+    handoff,
+    publicationTask,
+    sourceTaskValidation: sourceValidation,
+    publicationTaskValidation: publicationValidation,
+    authorityFingerprint,
+    verificationFingerprint,
+    observedAt,
+  });
+
+  if (registry) {
+    registry.set(handoffId, {
+      handoffId,
+      authorityFingerprint,
+      result: deepCloneJson(result),
+    });
+  }
+
+  return result;
+}

--- a/src/domain/publicationHandoffCanonical.ts
+++ b/src/domain/publicationHandoffCanonical.ts
@@ -1,0 +1,189 @@
+/**
+ * Shared canonical derivation for RUNNER-PUBLISH-HANDOFF-V1 /
+ * DRAFT-PUBLISH-V1 A→B binding.
+ *
+ * Pure helpers only — no I/O, no adapters, no mutation.
+ * DRAFT-PUBLISH must recompute these independently; self-asserted
+ * handoff objects are not trusted.
+ */
+
+import { normalizeRepoPath } from "./agentTaskContract";
+
+export const PUBLICATION_HANDOFF_CANONICAL_SCHEMA =
+  "PUBLICATION-HANDOFF-V1" as const;
+
+export const PUBLICATION_HANDOFF_CANONICAL_CAPABILITY =
+  "github.draft-pr.publish.v1" as const;
+export const PUBLICATION_HANDOFF_CANONICAL_RISK_CLASS = "R2" as const;
+export const PUBLICATION_HANDOFF_CANONICAL_STOP_AT = "DRAFT_PR" as const;
+
+export interface PublicationHandoffAuthoritySeedV1 {
+  handoffId: string;
+  sourceExecutionTaskId: string;
+  sourceIssue: { repository: string; number: number };
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  verificationAttemptId: string;
+  requestedPublicationCapability: string;
+  requestedRiskClass: string;
+  requestedStopAt: string;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+export function sortPublicationHandoffPathsStable(paths: string[]): string[] {
+  return [...paths]
+    .map((p) => normalizeRepoPath(p))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** Deterministic 40-hex token from seed (not cryptographic security). */
+export function deterministicHexFromSeed(seed: string): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0x811c9dc5 ^ 0xabcdef;
+  for (let i = 0; i < seed.length; i++) {
+    const c = seed.charCodeAt(i);
+    h1 = Math.imul(h1 ^ c, 0x01000193);
+    h2 = Math.imul(h2 ^ (c + 1), 0x01000193);
+  }
+  const hex = (n: number) => (n >>> 0).toString(16).padStart(8, "0");
+  const out = `${hex(h1)}${hex(h2)}${hex(h1 ^ h2)}${hex(~h1)}${hex(h1 + h2)}`;
+  return out.slice(0, 40);
+}
+
+export function computeVerificationFingerprint(input: {
+  verificationAttemptId: string;
+  taskId: string;
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  status: string;
+}): string {
+  const paths = sortPublicationHandoffPathsStable(input.verifiedChangedPaths);
+  return `vf:v1:${stableJson({
+    verificationAttemptId: input.verificationAttemptId,
+    taskId: input.taskId,
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    verifiedChangedPaths: paths,
+    status: input.status,
+  })}`;
+}
+
+export function capturePublicationHandoffAuthorityFingerprint(
+  input: PublicationHandoffAuthoritySeedV1,
+): PublicationHandoffAuthoritySeedV1 {
+  return {
+    handoffId: input.handoffId,
+    sourceExecutionTaskId: input.sourceExecutionTaskId,
+    sourceIssue: {
+      repository: input.sourceIssue.repository,
+      number: input.sourceIssue.number,
+    },
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    verifiedChangedPaths: sortPublicationHandoffPathsStable(
+      input.verifiedChangedPaths,
+    ),
+    verificationAttemptId: input.verificationAttemptId,
+    requestedPublicationCapability: input.requestedPublicationCapability,
+    requestedRiskClass: input.requestedRiskClass,
+    requestedStopAt: input.requestedStopAt,
+  };
+}
+
+export function serializeAuthorityFingerprint(
+  fp: PublicationHandoffAuthoritySeedV1,
+): string {
+  return `ah:v1:${stableJson(capturePublicationHandoffAuthorityFingerprint(fp))}`;
+}
+
+export function authorityFingerprintsEqual(
+  a: PublicationHandoffAuthoritySeedV1,
+  b: PublicationHandoffAuthoritySeedV1,
+): boolean {
+  return (
+    serializeAuthorityFingerprint(a) === serializeAuthorityFingerprint(b)
+  );
+}
+
+/**
+ * Deterministic publication taskId. Seed includes handoff + source identity +
+ * verified paths + requested publication authority.
+ */
+export function buildDeterministicPublicationTaskId(input: {
+  handoffId: string;
+  sourceExecutionTaskId: string;
+  repository: string;
+  baseRevision: string;
+  verifiedChangedPaths: string[];
+  requestedPublicationCapability: string;
+  requestedRiskClass: string;
+  requestedStopAt: string;
+}): string {
+  const seed = stableJson({
+    handoffId: input.handoffId,
+    sourceExecutionTaskId: input.sourceExecutionTaskId,
+    repository: input.repository,
+    baseRevision: input.baseRevision,
+    verifiedChangedPaths: sortPublicationHandoffPathsStable(
+      input.verifiedChangedPaths,
+    ),
+    requestedPublicationCapability: input.requestedPublicationCapability,
+    requestedRiskClass: input.requestedRiskClass,
+    requestedStopAt: input.requestedStopAt,
+  });
+  const hex = deterministicHexFromSeed(seed);
+  return `pub-handoff-${hex}`.slice(0, 128);
+}
+
+/**
+ * Independently derive canonical A→B identities from authority-bearing fields.
+ * Callers must not trust self-asserted publicationTaskId / fingerprints.
+ */
+export function deriveCanonicalPublicationHandoffIdentities(
+  seed: PublicationHandoffAuthoritySeedV1,
+  verifiedBinding: {
+    verificationAttemptId: string;
+    sourceExecutionTaskId: string;
+    repository: string;
+    baseRevision: string;
+    verifiedChangedPaths: string[];
+  },
+): {
+  publicationTaskId: string;
+  authorityFingerprint: string;
+  verificationFingerprint: string;
+  authoritySeed: PublicationHandoffAuthoritySeedV1;
+} {
+  const authoritySeed = capturePublicationHandoffAuthorityFingerprint(seed);
+  const publicationTaskId = buildDeterministicPublicationTaskId({
+    handoffId: authoritySeed.handoffId,
+    sourceExecutionTaskId: authoritySeed.sourceExecutionTaskId,
+    repository: authoritySeed.repository,
+    baseRevision: authoritySeed.baseRevision,
+    verifiedChangedPaths: authoritySeed.verifiedChangedPaths,
+    requestedPublicationCapability:
+      authoritySeed.requestedPublicationCapability,
+    requestedRiskClass: authoritySeed.requestedRiskClass,
+    requestedStopAt: authoritySeed.requestedStopAt,
+  });
+  const authorityFingerprint = serializeAuthorityFingerprint(authoritySeed);
+  const verificationFingerprint = computeVerificationFingerprint({
+    verificationAttemptId: verifiedBinding.verificationAttemptId,
+    taskId: verifiedBinding.sourceExecutionTaskId,
+    repository: verifiedBinding.repository,
+    baseRevision: verifiedBinding.baseRevision,
+    verifiedChangedPaths: verifiedBinding.verifiedChangedPaths,
+    status: "VERIFIED",
+  });
+  return {
+    publicationTaskId,
+    authorityFingerprint,
+    verificationFingerprint,
+    authoritySeed,
+  };
+}

--- a/test/draftPublish.test.ts
+++ b/test/draftPublish.test.ts
@@ -428,12 +428,12 @@ describe("DRAFT-PUBLISH-V1 verifier / task identity", () => {
     );
   });
 
-  it("10. taskId mismatch → REJECT", () => {
+  it("10. taskId mismatch without authorized handoff → REJECT", () => {
     const task = eligibleTask();
     const verified = verifiedStub(task, { taskId: "other-task" });
     const out = publish(task, { verified });
     expect(out.status).toBe("REJECT");
-    expect(out.reasonCode).toBe("REJECT_TASK_ID_MISMATCH");
+    expect(out.reasonCode).toBe("REJECT_PUBLICATION_HANDOFF_REQUIRED");
   });
 
   it("11. repository mismatch → HOLD", () => {

--- a/test/publicationHandoff.test.ts
+++ b/test/publicationHandoff.test.ts
@@ -870,4 +870,155 @@ describe("RUNNER-PUBLISH-HANDOFF-V1 → DRAFT-PUBLISH-V1 A→B binding", () => {
     expect(out.status).toBe("REJECT");
     expect(out.reasonCode).toBe("REJECT_HANDOFF_VERIFICATION_BINDING");
   });
+
+  it("P1: attacker-created R2 B + matching synthetic handoff rejected (non-canonical taskId)", () => {
+    const { sourceExecutionTask, independentVerifyResult, sourceSnapshot } =
+      realVerified();
+    const legitimate = runHandoff(sourceExecutionTask, independentVerifyResult);
+    expect(legitimate.status).toBe("READY_FOR_PUBLICATION_TASK");
+
+    // Attacker builds a separately valid R2 publication-shaped task (builder id),
+    // not the canonical pub-handoff-* derivation.
+    const attackerBuilt = buildAgentTaskFromIssue(
+      {
+        repository: REPO,
+        issueNumber: 57,
+        baseRevision: BASE,
+        issueTitle: "attacker publication task",
+        issueBody: "Forged R2 publication task outside handoff derivation.",
+        observedAt: OBSERVED_AT,
+        proposal: {
+          taskId: "attacker-r2-publication-task-not-canonical",
+          allowedPaths: [...independentVerifyResult.verifiedChangedPaths],
+          forbiddenPaths: [".github/workflows/", "migrations/"],
+          acceptanceCriteria: ["attacker"],
+          verificationCommands: [
+            { id: "verify.all", command: "npm run verify" },
+          ],
+          allowedCapabilities: [DRAFT_PUBLISH_REQUIRED_CAPABILITY],
+          riskClass: DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
+          stopAt: DRAFT_PUBLISH_REQUIRED_STOP_AT,
+        },
+      },
+      { validatedAt: VALIDATED_AT },
+    );
+    expect(attackerBuilt.status).toBe("BUILT");
+    const attackerTask = attackerBuilt.task!;
+    expect(attackerTask.taskId).toBe(
+      "attacker-r2-publication-task-not-canonical",
+    );
+    expect(attackerTask.taskId).not.toBe(sourceExecutionTask.taskId);
+    expect(attackerTask.taskId).not.toBe(legitimate.publicationTaskId);
+    expect(publicationTaskMeetsDraftPublishAuthority(attackerTask)).toBe(true);
+
+    // Synthetic handoff copies legitimate authority fields/fingerprints but
+    // asserts attackerTask.taskId as publicationTaskId (self-asserted A→B).
+    const syntheticHandoff = {
+      ...legitimate.handoff!,
+      publicationTaskId: attackerTask.taskId,
+    };
+
+    const out = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: attackerTask,
+        publicationAttemptId: "publish-57-attacker-b",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-attack",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "attacker publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-attack",
+          draft: true,
+        },
+        authorizedPublicationHandoff: syntheticHandoff,
+      },
+      { validatedAt: VALIDATED_AT, adapter: createFakeDraftPublishAdapterV1() },
+    );
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_HANDOFF_CANONICAL_TASK_ID");
+    expect(JSON.stringify(sourceExecutionTask)).toBe(sourceSnapshot);
+    expect(independentVerifyResult.taskId).toBe(sourceExecutionTask.taskId);
+  });
+
+  it("P1: missing authorityFingerprint fails closed", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const handoff = runHandoff(sourceExecutionTask, independentVerifyResult);
+    const { authorityFingerprint: _omit, ...withoutFp } = handoff.handoff!;
+    void _omit;
+    const out = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: handoff.publicationTask!,
+        publicationAttemptId: "publish-57-missing-ah",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-publish",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "handoff publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-publish",
+          draft: true,
+        },
+        authorizedPublicationHandoff: withoutFp,
+      },
+      { validatedAt: VALIDATED_AT, adapter: createFakeDraftPublishAdapterV1() },
+    );
+    expect(out.status).toBe("REJECT");
+    expect([
+      "REJECT_HANDOFF_AUTHORITY_FINGERPRINT",
+      "REJECT_PUBLICATION_HANDOFF",
+    ]).toContain(out.reasonCode);
+  });
+
+  it("P1: forged authorityFingerprint rejected", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const handoff = runHandoff(sourceExecutionTask, independentVerifyResult);
+    const forged = {
+      ...handoff.handoff!,
+      authorityFingerprint: "ah:v1:forged",
+    };
+    const out = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: handoff.publicationTask!,
+        publicationAttemptId: "publish-57-forged-ah",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-publish",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "handoff publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-publish",
+          draft: true,
+        },
+        authorizedPublicationHandoff: forged,
+      },
+      { validatedAt: VALIDATED_AT, adapter: createFakeDraftPublishAdapterV1() },
+    );
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_HANDOFF_AUTHORITY_FINGERPRINT");
+  });
 });

--- a/test/publicationHandoff.test.ts
+++ b/test/publicationHandoff.test.ts
@@ -26,6 +26,8 @@ import {
   DRAFT_PUBLISH_REQUIRED_CAPABILITY,
   DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
   DRAFT_PUBLISH_REQUIRED_STOP_AT,
+  createFakeDraftPublishAdapterV1,
+  publishDraftPrV1,
 } from "../src/domain/draftPublish";
 import {
   PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
@@ -34,6 +36,7 @@ import {
   PUBLICATION_HANDOFF_RESULT_SCHEMA,
   PUBLICATION_HANDOFF_RUNNER_CAPABILITIES_SNAPSHOT,
   PUBLICATION_HANDOFF_RUNNER_RISK_CLASSES_SNAPSHOT,
+  PUBLICATION_HANDOFF_SCHEMA,
   PUBLICATION_HANDOFF_VERSION,
   assertPublicationHandoffBoundaries,
   authorityFingerprintsEqual,
@@ -306,6 +309,8 @@ describe("RUNNER-PUBLISH-HANDOFF-V1 positive path (real VERIFIED)", () => {
     expect(out.handoff!.sourceIssue).toEqual(sourceExecutionTask.sourceIssue);
     expect(out.handoff!.verificationAttemptId).toBe(ATTEMPT);
     expect(out.handoff!.handoffId).toBe(HANDOFF_ID);
+    expect(out.handoff!.publicationTaskId).toBe(out.publicationTask!.taskId);
+    expect(out.handoff!.schemaVersion).toBe(PUBLICATION_HANDOFF_SCHEMA);
     expect(out.sourceExecutionTaskId).toBe(sourceExecutionTask.taskId);
   });
 
@@ -661,5 +666,208 @@ describe("RUNNER-PUBLISH-HANDOFF-V1 idempotency / fingerprint", () => {
       requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
     });
     expect(idDifferent).not.toBe(idA);
+  });
+});
+
+describe("RUNNER-PUBLISH-HANDOFF-V1 → DRAFT-PUBLISH-V1 A→B binding", () => {
+  it("E2E: Execution A → VERIFIED A → Handoff → PublicationTask B → PUBLISHED_DRAFT (no REJECT_TASK_ID_MISMATCH)", () => {
+    const { sourceExecutionTask, independentVerifyResult, sourceSnapshot } =
+      realVerified();
+    const handoff = runHandoff(sourceExecutionTask, independentVerifyResult);
+    expect(handoff.status).toBe("READY_FOR_PUBLICATION_TASK");
+    expect(handoff.handoff).not.toBeNull();
+    expect(handoff.publicationTask).not.toBeNull();
+    expect(handoff.publicationTask!.taskId).not.toBe(
+      independentVerifyResult.taskId,
+    );
+
+    // Without handoff, A≠B must fail closed (not by rewriting verify taskId).
+    const withoutHandoff = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: handoff.publicationTask!,
+        publicationAttemptId: "publish-57-no-handoff",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-publish",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "handoff publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-publish",
+          draft: true,
+        },
+      },
+      {
+        validatedAt: VALIDATED_AT,
+        adapter: createFakeDraftPublishAdapterV1(),
+      },
+    );
+    expect(withoutHandoff.status).toBe("REJECT");
+    expect(withoutHandoff.reasonCode).toBe(
+      "REJECT_PUBLICATION_HANDOFF_REQUIRED",
+    );
+    expect(withoutHandoff.reasonCode).not.toBe("REJECT_TASK_ID_MISMATCH");
+
+    const published = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: handoff.publicationTask!,
+        publicationAttemptId: "publish-57-with-handoff",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-publish",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "handoff publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-publish",
+          draft: true,
+        },
+        authorizedPublicationHandoff: handoff.handoff!,
+      },
+      {
+        validatedAt: VALIDATED_AT,
+        adapter: createFakeDraftPublishAdapterV1(),
+      },
+    );
+
+    expect(published.status).toBe("PUBLISHED_DRAFT");
+    expect(published.reasonCode).toBe("PUBLISHED_DRAFT");
+    expect(published.taskId).toBe(handoff.publicationTaskId);
+    expect(published.metadata.readyAuthorized).toBe(false);
+    expect(published.metadata.mergeAuthorized).toBe(false);
+    expect(published.metadata.issueCloseAuthorized).toBe(false);
+    expect(published.metadata.deployAuthorized).toBe(false);
+    expect(published.metadata.githubMutationPerformed).toBe(false);
+    expect(published.metadata.realGithubPublicationImplemented).toBe(false);
+
+    // Source execution task never mutated; verify taskId unchanged.
+    expect(JSON.stringify(sourceExecutionTask)).toBe(sourceSnapshot);
+    expect(independentVerifyResult.taskId).toBe(sourceExecutionTask.taskId);
+    expect(sourceExecutionTask.riskClass).toBe("R1");
+    expect(sourceExecutionTask.allowedCapabilities).toEqual([
+      "workspace.read.v1",
+    ]);
+  });
+
+  it("negative: forged handoff sourceExecutionTaskId rejected", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const handoff = runHandoff(sourceExecutionTask, independentVerifyResult);
+    const forged = {
+      ...handoff.handoff!,
+      sourceExecutionTaskId: "forged-source-task",
+    };
+    const out = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: handoff.publicationTask!,
+        publicationAttemptId: "publish-57-forged-source",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-publish",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "handoff publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-publish",
+          draft: true,
+        },
+        authorizedPublicationHandoff: forged,
+      },
+      { validatedAt: VALIDATED_AT, adapter: createFakeDraftPublishAdapterV1() },
+    );
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_HANDOFF_SOURCE_TASK_ID");
+  });
+
+  it("negative: forged handoff publicationTaskId rejected", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const handoff = runHandoff(sourceExecutionTask, independentVerifyResult);
+    const forged = {
+      ...handoff.handoff!,
+      publicationTaskId: "forged-publication-task",
+    };
+    const out = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: handoff.publicationTask!,
+        publicationAttemptId: "publish-57-forged-pub",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-publish",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "handoff publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-publish",
+          draft: true,
+        },
+        authorizedPublicationHandoff: forged,
+      },
+      { validatedAt: VALIDATED_AT, adapter: createFakeDraftPublishAdapterV1() },
+    );
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_HANDOFF_PUBLICATION_TASK_ID");
+  });
+
+  it("negative: forged verificationFingerprint rejected", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const handoff = runHandoff(sourceExecutionTask, independentVerifyResult);
+    const forged = {
+      ...handoff.handoff!,
+      verificationFingerprint: "vf:v1:forged",
+    };
+    const out = publishDraftPrV1(
+      {
+        verifiedResult: independentVerifyResult,
+        expectedTask: handoff.publicationTask!,
+        publicationAttemptId: "publish-57-forged-fp",
+        observedAt: OBSERVED_AT,
+        sourceArtifact: {
+          repository: sourceExecutionTask.repository,
+          baseRevision: sourceExecutionTask.baseRevision,
+          baseBranch: "main",
+          headRevision: "dddddddddddddddddddddddddddddddddddddddd",
+          branchName: "cursor/handoff-57-publish",
+          changedPaths: [...independentVerifyResult.verifiedChangedPaths],
+        },
+        proposedDraftPr: {
+          title: "handoff publish",
+          body: "fake",
+          baseBranch: "main",
+          headBranch: "cursor/handoff-57-publish",
+          draft: true,
+        },
+        authorizedPublicationHandoff: forged,
+      },
+      { validatedAt: VALIDATED_AT, adapter: createFakeDraftPublishAdapterV1() },
+    );
+    expect(out.status).toBe("REJECT");
+    expect(out.reasonCode).toBe("REJECT_HANDOFF_VERIFICATION_BINDING");
   });
 });

--- a/test/publicationHandoff.test.ts
+++ b/test/publicationHandoff.test.ts
@@ -1,0 +1,665 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentTaskFromIssue,
+  type AgentTaskBuilderResultV1,
+} from "../src/domain/agentTaskBuilder";
+import {
+  type AgentTaskV1,
+} from "../src/domain/agentTaskContract";
+import {
+  AGENT_RUNNER_SUPPORTED_CAPABILITIES,
+  AGENT_RUNNER_SUPPORTED_RISK_CLASSES,
+  createFakeAgentRunnerAdapterV1,
+  runAgentTaskV1,
+  type AgentRunnerResultV1,
+} from "../src/domain/agentRunner";
+import {
+  orchestrateAgentTaskV1,
+  type MinOrchestratorResultV1,
+} from "../src/domain/minOrchestrator";
+import {
+  createFakeIndependentVerifyAdapterV1,
+  verifyAgentRunnerResultV1,
+  type IndependentVerifyResultV1,
+} from "../src/domain/independentVerify";
+import {
+  DRAFT_PUBLISH_REQUIRED_CAPABILITY,
+  DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
+  DRAFT_PUBLISH_REQUIRED_STOP_AT,
+} from "../src/domain/draftPublish";
+import {
+  PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+  PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+  PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+  PUBLICATION_HANDOFF_RESULT_SCHEMA,
+  PUBLICATION_HANDOFF_RUNNER_CAPABILITIES_SNAPSHOT,
+  PUBLICATION_HANDOFF_RUNNER_RISK_CLASSES_SNAPSHOT,
+  PUBLICATION_HANDOFF_VERSION,
+  assertPublicationHandoffBoundaries,
+  authorityFingerprintsEqual,
+  buildDeterministicPublicationTaskId,
+  capturePublicationHandoffAuthorityFingerprint,
+  createPublicationHandoffV1,
+  publicationTaskIsRunnerDispatchable,
+  publicationTaskMeetsDraftPublishAuthority,
+  serializeAuthorityFingerprint,
+  type PublicationHandoffAttemptRecordV1,
+} from "../src/domain/publicationHandoff";
+
+const BASE = "1a494780ffb92bc6b1e27c99fbb24b39dfc1af75";
+const OTHER_BASE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OBSERVED_AT = "2026-08-12T13:40:00.000Z";
+const VALIDATED_AT = "2026-08-12T13:40:30.000Z";
+const REVALIDATED_AT = "2026-08-12T13:41:00.000Z";
+const REPO = "yasutakesougo/ai-development-control-center";
+const HANDOFF_ID = "handoff-57-1";
+const ATTEMPT = "verify-attempt-57-1";
+const RUNNER_ATTEMPT = "runner-attempt-57-1";
+
+const ALLOWED_DOC = "docs/publication-handoff/publication-handoff-v1.md";
+const ALLOWED_SRC = "src/domain/publicationHandoff.ts";
+const ALLOWED_TEST = "test/publicationHandoff.test.ts";
+
+function builtFromBuilder(
+  overrides: {
+    allowedCapabilities?: string[];
+    riskClass?: AgentTaskV1["riskClass"];
+    stopAt?: AgentTaskV1["stopAt"];
+    allowedPaths?: string[];
+    forbiddenPaths?: string[];
+    baseRevision?: string;
+    repository?: string;
+  } = {},
+): AgentTaskBuilderResultV1 {
+  return buildAgentTaskFromIssue(
+    {
+      repository: overrides.repository ?? REPO,
+      issueNumber: 57,
+      baseRevision: overrides.baseRevision ?? BASE,
+      issueTitle:
+        "RUNNER-PUBLISH-HANDOFF-V1 — explicit execution-to-publication authority transition",
+      issueBody:
+        "Handoff contract only. No real GitHub publication. No runner widening.",
+      issueLabels: ["publication-handoff"],
+      observedAt: OBSERVED_AT,
+      proposal: {
+        allowedPaths: overrides.allowedPaths ?? [
+          "docs/publication-handoff/",
+          "src/domain/publicationHandoff.ts",
+          "test/publicationHandoff.test.ts",
+        ],
+        forbiddenPaths: overrides.forbiddenPaths ?? [
+          ".github/workflows/",
+          "migrations/",
+        ],
+        acceptanceCriteria: [
+          "VERIFIED R1 execution yields READY_FOR_PUBLICATION_TASK",
+          "publication task distinct R2 + github.draft-pr.publish.v1",
+          "source execution task unchanged",
+        ],
+        verificationCommands: [
+          {
+            id: "verify.all",
+            command: "npm run verify",
+            description: "Typecheck, test, and build",
+          },
+        ],
+        allowedCapabilities: overrides.allowedCapabilities ?? [
+          "workspace.read.v1",
+        ],
+        riskClass: overrides.riskClass ?? "R1",
+        stopAt: overrides.stopAt ?? "VERIFY_COMPLETE",
+        constraints: {
+          maxChangedFiles: 16,
+          requireIndependentVerify: true,
+        },
+      },
+    },
+    { validatedAt: VALIDATED_AT },
+  );
+}
+
+function dispatchEligible(
+  overrides: Parameters<typeof builtFromBuilder>[0] = {},
+): MinOrchestratorResultV1 {
+  const built = builtFromBuilder(overrides);
+  const out = orchestrateAgentTaskV1(
+    {
+      builderResult: built,
+      observedAt: OBSERVED_AT,
+      attemptId: "orch-57",
+    },
+    { revalidatedAt: REVALIDATED_AT },
+  );
+  expect(out.decision).toBe("DISPATCH_ELIGIBLE");
+  return out;
+}
+
+function completedRunner(
+  overrides: {
+    changedPaths?: string[];
+    taskOverrides?: Parameters<typeof builtFromBuilder>[0];
+  } = {},
+): { runnerResult: AgentRunnerResultV1; expectedTask: AgentTaskV1 } {
+  const orch = dispatchEligible(overrides.taskOverrides);
+  const changedPaths = overrides.changedPaths ?? [ALLOWED_DOC, ALLOWED_SRC];
+  const runnerResult = runAgentTaskV1(
+    {
+      orchestratorResult: orch,
+      runnerAttemptId: RUNNER_ATTEMPT,
+      observedAt: OBSERVED_AT,
+      workspace: {
+        repository: REPO,
+        baseRevision: overrides.taskOverrides?.baseRevision ?? BASE,
+      },
+    },
+    {
+      adapter: createFakeAgentRunnerAdapterV1({ changedPaths }),
+      validatedAt: REVALIDATED_AT,
+    },
+  );
+  expect(runnerResult.status).toBe("COMPLETED");
+  expect(orch.task).not.toBeNull();
+  return { runnerResult, expectedTask: orch.task! };
+}
+
+function realVerified(
+  overrides: {
+    changedPaths?: string[];
+    taskOverrides?: Parameters<typeof builtFromBuilder>[0];
+  } = {},
+): {
+  sourceExecutionTask: AgentTaskV1;
+  independentVerifyResult: IndependentVerifyResultV1;
+  sourceSnapshot: string;
+} {
+  const { runnerResult, expectedTask } = completedRunner(overrides);
+  const independentVerifyResult = verifyAgentRunnerResultV1(
+    {
+      runnerResult,
+      expectedTask,
+      verificationAttemptId: ATTEMPT,
+      observedAt: OBSERVED_AT,
+    },
+    {
+      adapter: createFakeIndependentVerifyAdapterV1({
+        observedChangedPaths: runnerResult.changedPaths,
+      }),
+      validatedAt: REVALIDATED_AT,
+    },
+  );
+  expect(independentVerifyResult.status).toBe("VERIFIED");
+  expect(independentVerifyResult.verificationEvidence).not.toBeNull();
+  return {
+    sourceExecutionTask: expectedTask,
+    independentVerifyResult,
+    sourceSnapshot: JSON.stringify(expectedTask),
+  };
+}
+
+function handoffInput(
+  sourceExecutionTask: AgentTaskV1,
+  independentVerifyResult: IndependentVerifyResultV1,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    handoffId: HANDOFF_ID,
+    sourceExecutionTask,
+    independentVerifyResult,
+    requestedPublicationCapability: PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+    requestedRiskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+    requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+    observedAt: OBSERVED_AT,
+    ...overrides,
+  };
+}
+
+function runHandoff(
+  sourceExecutionTask: AgentTaskV1,
+  independentVerifyResult: IndependentVerifyResultV1,
+  overrides: Record<string, unknown> = {},
+  options: {
+    attemptRegistry?: Map<string, PublicationHandoffAttemptRecordV1>;
+  } = {},
+) {
+  return createPublicationHandoffV1(
+    handoffInput(sourceExecutionTask, independentVerifyResult, overrides),
+    {
+      validatedAt: VALIDATED_AT,
+      attemptRegistry: options.attemptRegistry,
+    },
+  );
+}
+
+describe("RUNNER-PUBLISH-HANDOFF-V1 boundaries", () => {
+  it("44-45. runner supported risk/capabilities unchanged", () => {
+    expect([...AGENT_RUNNER_SUPPORTED_RISK_CLASSES]).toEqual([
+      ...PUBLICATION_HANDOFF_RUNNER_RISK_CLASSES_SNAPSHOT,
+    ]);
+    expect([...AGENT_RUNNER_SUPPORTED_CAPABILITIES]).toEqual([
+      ...PUBLICATION_HANDOFF_RUNNER_CAPABILITIES_SNAPSHOT,
+    ]);
+    expect(AGENT_RUNNER_SUPPORTED_RISK_CLASSES).not.toContain("R2");
+    expect(AGENT_RUNNER_SUPPORTED_CAPABILITIES).not.toContain(
+      DRAFT_PUBLISH_REQUIRED_CAPABILITY,
+    );
+    assertPublicationHandoffBoundaries();
+  });
+
+  it("aligns with DRAFT-PUBLISH required constants", () => {
+    expect(PUBLICATION_HANDOFF_REQUIRED_CAPABILITY).toBe(
+      DRAFT_PUBLISH_REQUIRED_CAPABILITY,
+    );
+    expect(PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS).toBe(
+      DRAFT_PUBLISH_REQUIRED_RISK_CLASS,
+    );
+    expect(PUBLICATION_HANDOFF_REQUIRED_STOP_AT).toBe(
+      DRAFT_PUBLISH_REQUIRED_STOP_AT,
+    );
+  });
+});
+
+describe("RUNNER-PUBLISH-HANDOFF-V1 positive path (real VERIFIED)", () => {
+  it("1-14. VERIFIED exact execution → READY_FOR_PUBLICATION_TASK with distinct publication task", () => {
+    const { sourceExecutionTask, independentVerifyResult, sourceSnapshot } =
+      realVerified();
+    const sourceCaps = [...sourceExecutionTask.allowedCapabilities];
+    const sourceRisk = sourceExecutionTask.riskClass;
+    const sourceStop = sourceExecutionTask.stopAt;
+
+    const out = runHandoff(sourceExecutionTask, independentVerifyResult);
+
+    expect(out.schemaVersion).toBe(PUBLICATION_HANDOFF_RESULT_SCHEMA);
+    expect(out.handoffVersion).toBe(PUBLICATION_HANDOFF_VERSION);
+    expect(out.status).toBe("READY_FOR_PUBLICATION_TASK");
+    expect(out.reasonCode).toBe("READY_FOR_PUBLICATION_TASK");
+    expect(out.publicationTask).not.toBeNull();
+    expect(out.handoff).not.toBeNull();
+
+    // 2. distinct taskId
+    expect(out.publicationTaskId).not.toBe(sourceExecutionTask.taskId);
+    expect(out.publicationTask!.taskId).not.toBe(sourceExecutionTask.taskId);
+
+    // 3-6. source unchanged
+    expect(JSON.stringify(sourceExecutionTask)).toBe(sourceSnapshot);
+    expect(sourceExecutionTask.riskClass).toBe(sourceRisk);
+    expect(["R0", "R1"]).toContain(sourceExecutionTask.riskClass);
+    expect(sourceExecutionTask.allowedCapabilities).toEqual(sourceCaps);
+    expect(sourceExecutionTask.stopAt).toBe(sourceStop);
+
+    // 7-10. publication authority
+    expect(out.publicationTask!.riskClass).toBe("R2");
+    expect(out.publicationTask!.allowedCapabilities).toEqual([
+      "github.draft-pr.publish.v1",
+    ]);
+    expect(out.publicationTask!.stopAt).toBe("DRAFT_PR");
+    expect(out.publicationTask!.allowedPaths).toEqual(
+      independentVerifyResult.verifiedChangedPaths,
+    );
+    expect(
+      publicationTaskMeetsDraftPublishAuthority(out.publicationTask!),
+    ).toBe(true);
+
+    // 11-14. bindings
+    expect(out.repository).toBe(sourceExecutionTask.repository);
+    expect(out.baseRevision).toBe(sourceExecutionTask.baseRevision);
+    expect(out.handoff!.sourceIssue).toEqual(sourceExecutionTask.sourceIssue);
+    expect(out.handoff!.verificationAttemptId).toBe(ATTEMPT);
+    expect(out.handoff!.handoffId).toBe(HANDOFF_ID);
+    expect(out.sourceExecutionTaskId).toBe(sourceExecutionTask.taskId);
+  });
+
+  it("43. original AgentTask object not mutated", () => {
+    const { sourceExecutionTask, independentVerifyResult, sourceSnapshot } =
+      realVerified();
+    runHandoff(sourceExecutionTask, independentVerifyResult);
+    expect(JSON.stringify(sourceExecutionTask)).toBe(sourceSnapshot);
+  });
+
+  it("46. publication task is never run through AgentRunner", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const out = runHandoff(sourceExecutionTask, independentVerifyResult);
+    expect(out.metadata.publicationTaskDispatchedToRunner).toBe(false);
+    expect(publicationTaskIsRunnerDispatchable(out.publicationTask!)).toBe(
+      false,
+    );
+    // Structural: handoff module must not import runAgentTaskV1 for publication.
+    // Guaranteed by publicationTaskIsRunnerDispatchable + metadata flag.
+  });
+
+  it("47-52. authorization / mutation flags remain false", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const out = runHandoff(sourceExecutionTask, independentVerifyResult);
+    expect(out.metadata.readyAuthorized).toBe(false);
+    expect(out.metadata.mergeAuthorized).toBe(false);
+    expect(out.metadata.issueCloseAuthorized).toBe(false);
+    expect(out.metadata.deployAuthorized).toBe(false);
+    expect(out.metadata.realGithubPublication).toBe(false);
+    expect(out.metadata.githubMutationPerformed).toBe(false);
+    expect(out.metadata.productionMutationPerformed).toBe(false);
+    expect(out.metadata.productionMutationAuthorized).toBe(false);
+    expect(out.metadata.realAgentProviderExecution).toBe(false);
+    expect(out.metadata.runnerAuthorityExpanded).toBe(false);
+    expect(out.metadata.draftPublishAuthorityExpanded).toBe(false);
+    expect(out.metadata.sourceExecutionTaskMutated).toBe(false);
+  });
+
+  it("28-32. verifier auth flags and evidence safety exact false", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    expect(independentVerifyResult.metadata.publicationAuthorized).toBe(false);
+    expect(independentVerifyResult.metadata.readyAuthorized).toBe(false);
+    expect(independentVerifyResult.metadata.mergeAuthorized).toBe(false);
+    expect(independentVerifyResult.metadata.githubMutationAuthorized).toBe(
+      false,
+    );
+    expect(independentVerifyResult.metadata.deployAuthorized).toBe(false);
+    expect(
+      independentVerifyResult.verificationEvidence!.networkAccess,
+    ).toBe(false);
+    expect(
+      independentVerifyResult.verificationEvidence!.secretsRequired,
+    ).toBe(false);
+    expect(
+      independentVerifyResult.verificationEvidence!.githubMutationPerformed,
+    ).toBe(false);
+    expect(
+      independentVerifyResult.verificationEvidence!
+        .productionMutationPerformed,
+    ).toBe(false);
+    const out = runHandoff(sourceExecutionTask, independentVerifyResult);
+    expect(out.status).toBe("READY_FOR_PUBLICATION_TASK");
+  });
+
+  it("53. deterministic repeatability", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const a = runHandoff(sourceExecutionTask, independentVerifyResult);
+    const b = runHandoff(sourceExecutionTask, independentVerifyResult);
+    expect(a.status).toBe(b.status);
+    expect(a.publicationTaskId).toBe(b.publicationTaskId);
+    expect(a.authorityFingerprint).toBe(b.authorityFingerprint);
+    expect(a.publicationTask).toEqual(b.publicationTask);
+  });
+});
+
+describe("RUNNER-PUBLISH-HANDOFF-V1 input / authority fail-closed", () => {
+  it("15-16. handoffId required; missing fails closed", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const missing = createPublicationHandoffV1(
+      {
+        sourceExecutionTask,
+        independentVerifyResult,
+        requestedPublicationCapability: PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+        requestedRiskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+        requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+        observedAt: OBSERVED_AT,
+      },
+      { validatedAt: VALIDATED_AT },
+    );
+    expect(missing.status).toBe("REJECT");
+    expect(missing.reasonCode).toBe("REJECT_INPUT");
+    expect(missing.reasonMessage).toMatch(/handoffId/);
+  });
+
+  it("33-36. wrong / missing / generic github capability reject", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+
+    const wrong = runHandoff(sourceExecutionTask, independentVerifyResult, {
+      requestedPublicationCapability: "workspace.read.v1",
+    });
+    expect(wrong.status).toBe("REJECT");
+    expect(wrong.reasonCode).toBe("REJECT_PUBLICATION_CAPABILITY");
+
+    const missing = createPublicationHandoffV1(
+      {
+        handoffId: HANDOFF_ID,
+        sourceExecutionTask,
+        independentVerifyResult,
+        requestedRiskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+        requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+        observedAt: OBSERVED_AT,
+      },
+      { validatedAt: VALIDATED_AT },
+    );
+    expect(missing.status).toBe("REJECT");
+    expect(missing.reasonCode).toBe("REJECT_INPUT");
+
+    const genericWrite = runHandoff(
+      sourceExecutionTask,
+      independentVerifyResult,
+      { requestedPublicationCapability: "github.write" },
+    );
+    expect(genericWrite.status).toBe("REJECT");
+    expect(genericWrite.reasonCode).toBe("REJECT_PUBLICATION_CAPABILITY");
+
+    const wildcard = runHandoff(sourceExecutionTask, independentVerifyResult, {
+      requestedPublicationCapability: "github.*",
+    });
+    expect(wildcard.status).toBe("REJECT");
+    expect(wildcard.reasonCode).toBe("REJECT_PUBLICATION_CAPABILITY");
+  });
+
+  it("37-38. risk != R2 / stopAt != DRAFT_PR fail closed", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const risk = runHandoff(sourceExecutionTask, independentVerifyResult, {
+      requestedRiskClass: "R1",
+    });
+    expect(risk.status).toBe("REJECT");
+    expect(risk.reasonCode).toBe("REJECT_PUBLICATION_RISK");
+
+    const stop = runHandoff(sourceExecutionTask, independentVerifyResult, {
+      requestedStopAt: "VERIFY_COMPLETE",
+    });
+    expect(stop.status).toBe("REJECT");
+    expect(stop.reasonCode).toBe("REJECT_PUBLICATION_STOP_AT");
+  });
+});
+
+describe("RUNNER-PUBLISH-HANDOFF-V1 verifier propagation", () => {
+  it("17-20. verifier HOLD/REJECT/FAILED/UNKNOWN propagate", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+
+    for (const [status, reasonCode] of [
+      ["HOLD", "HOLD_VERIFIER"],
+      ["REJECT", "REJECT_VERIFIER"],
+      ["FAILED", "FAILED_VERIFIER"],
+      ["UNKNOWN", "UNKNOWN_VERIFIER"],
+    ] as const) {
+      const patched: IndependentVerifyResultV1 = {
+        ...independentVerifyResult,
+        status,
+        reasonCode: status === "HOLD" ? "HOLD_RUNNER" : "REJECT_RUNNER",
+        reasonMessage: `synthetic ${status}`,
+      };
+      const out = runHandoff(sourceExecutionTask, patched);
+      expect(out.status).toBe(status === "HOLD" ? "HOLD" : status);
+      expect(out.reasonCode).toBe(reasonCode);
+      expect(out.publicationTask).toBeNull();
+    }
+  });
+});
+
+describe("RUNNER-PUBLISH-HANDOFF-V1 identity / path fail-closed", () => {
+  it("21-23. taskId / repository / baseRevision mismatch reject", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+
+    const taskMismatch = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      taskId: "other-task-id",
+    });
+    expect(taskMismatch.status).toBe("REJECT");
+    expect(taskMismatch.reasonCode).toBe("REJECT_IDENTITY_TASK_ID");
+
+    const repoMismatch = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      repository: "other-org/other-repo",
+    });
+    expect(repoMismatch.status).toBe("REJECT");
+    expect(repoMismatch.reasonCode).toBe("REJECT_IDENTITY_REPOSITORY");
+
+    const baseMismatch = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      baseRevision: OTHER_BASE,
+    });
+    expect(baseMismatch.status).toBe("REJECT");
+    expect(baseMismatch.reasonCode).toBe("REJECT_IDENTITY_BASE_REVISION");
+  });
+
+  it("24-27. duplicate / unsafe / forbidden / empty paths fail closed", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+
+    const dup = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      verifiedChangedPaths: [ALLOWED_DOC, ALLOWED_DOC],
+    });
+    expect(dup.status).toBe("REJECT");
+    expect(dup.reasonCode).toBe("REJECT_CHANGED_PATH_DUPLICATE");
+
+    const unsafe = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      verifiedChangedPaths: ["../secret.env"],
+    });
+    expect(unsafe.status).toBe("REJECT");
+    expect(unsafe.reasonCode).toBe("REJECT_CHANGED_PATH_UNSAFE");
+
+    const forbidden = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      verifiedChangedPaths: [".github/workflows/ci.yml"],
+    });
+    expect(forbidden.status).toBe("FAILED");
+    expect(forbidden.reasonCode).toBe("FAILED_FORBIDDEN_PATH");
+
+    const empty = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      verifiedChangedPaths: [],
+    });
+    expect(empty.status).toBe("REJECT");
+    expect(empty.reasonCode).toBe("REJECT_VERIFIED_PATHS");
+
+    const outOfScope = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      verifiedChangedPaths: ["docs/other/not-allowed.md"],
+    });
+    expect(outOfScope.status).toBe("FAILED");
+    expect(outOfScope.reasonCode).toBe("FAILED_CHANGED_PATH_OUT_OF_SCOPE");
+  });
+
+  it("28b. verifier auth flag not exactly false → REJECT", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const bad = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      metadata: {
+        ...independentVerifyResult.metadata,
+        publicationAuthorized: true as unknown as false,
+      },
+    });
+    expect(bad.status).toBe("REJECT");
+    expect(bad.reasonCode).toBe("REJECT_VERIFIER_METADATA");
+  });
+
+  it("29b. missing verificationEvidence → REJECT", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const bad = runHandoff(sourceExecutionTask, {
+      ...independentVerifyResult,
+      verificationEvidence: null,
+    });
+    expect(bad.status).toBe("REJECT");
+    expect(bad.reasonCode).toBe("REJECT_VERIFIER_EVIDENCE");
+  });
+});
+
+describe("RUNNER-PUBLISH-HANDOFF-V1 idempotency / fingerprint", () => {
+  it("39-40. same handoff + same fingerprint replay; different fingerprint conflict", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const registry = new Map<string, PublicationHandoffAttemptRecordV1>();
+
+    const first = runHandoff(
+      sourceExecutionTask,
+      independentVerifyResult,
+      {},
+      { attemptRegistry: registry },
+    );
+    expect(first.status).toBe("READY_FOR_PUBLICATION_TASK");
+
+    const replay = runHandoff(
+      sourceExecutionTask,
+      independentVerifyResult,
+      { observedAt: "2026-08-12T99:00:00.000Z" },
+      { attemptRegistry: registry },
+    );
+    expect(replay.status).toBe("READY_FOR_PUBLICATION_TASK");
+    expect(replay.publicationTaskId).toBe(first.publicationTaskId);
+    expect(replay.authorityFingerprint).toBe(first.authorityFingerprint);
+
+    const conflict = runHandoff(
+      sourceExecutionTask,
+      {
+        ...independentVerifyResult,
+        verifiedChangedPaths: [ALLOWED_DOC, ALLOWED_SRC, ALLOWED_TEST],
+      },
+      {},
+      { attemptRegistry: registry },
+    );
+    expect(conflict.status).toBe("REJECT");
+    expect(conflict.reasonCode).toBe("REJECT_HANDOFF_IDEMPOTENCY_CONFLICT");
+  });
+
+  it("41-42. authority fingerprint deterministic; observedAt excluded", () => {
+    const { sourceExecutionTask, independentVerifyResult } = realVerified();
+    const a = capturePublicationHandoffAuthorityFingerprint({
+      handoffId: HANDOFF_ID,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      sourceIssue: sourceExecutionTask.sourceIssue,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths: independentVerifyResult.verifiedChangedPaths,
+      verificationAttemptId: ATTEMPT,
+      requestedPublicationCapability: PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+      requestedRiskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+      requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+    });
+    const b = capturePublicationHandoffAuthorityFingerprint({
+      ...a,
+      verifiedChangedPaths: [
+        ...independentVerifyResult.verifiedChangedPaths,
+      ].reverse(),
+    });
+    expect(authorityFingerprintsEqual(a, b)).toBe(true);
+    expect(serializeAuthorityFingerprint(a)).not.toMatch(/observedAt/);
+
+    const idA = buildDeterministicPublicationTaskId({
+      handoffId: HANDOFF_ID,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths: independentVerifyResult.verifiedChangedPaths,
+      requestedPublicationCapability: PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+      requestedRiskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+      requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+    });
+    const idB = buildDeterministicPublicationTaskId({
+      handoffId: HANDOFF_ID,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: sourceExecutionTask.baseRevision,
+      verifiedChangedPaths: [
+        ...independentVerifyResult.verifiedChangedPaths,
+      ].reverse(),
+      requestedPublicationCapability: PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+      requestedRiskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+      requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+    });
+    expect(idA).toBe(idB);
+
+    const idDifferent = buildDeterministicPublicationTaskId({
+      handoffId: HANDOFF_ID,
+      sourceExecutionTaskId: sourceExecutionTask.taskId,
+      repository: sourceExecutionTask.repository,
+      baseRevision: OTHER_BASE,
+      verifiedChangedPaths: independentVerifyResult.verifiedChangedPaths,
+      requestedPublicationCapability: PUBLICATION_HANDOFF_REQUIRED_CAPABILITY,
+      requestedRiskClass: PUBLICATION_HANDOFF_REQUIRED_RISK_CLASS,
+      requestedStopAt: PUBLICATION_HANDOFF_REQUIRED_STOP_AT,
+    });
+    expect(idDifferent).not.toBe(idA);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **RUNNER-PUBLISH-HANDOFF-V1** (Issue #57) with Fresh Review P1 fixes:

1. A→B `authorizedPublicationHandoff` binding (no verify taskId rewrite)
2. **Canonical recompute** — DRAFT-PUBLISH independently derives `publicationTaskId` + `authorityFingerprint` via shared `publicationHandoffCanonical` helpers; self-asserted handoffs fail closed

```text
ExecutionTask A (R1)
→ IndependentVerifyResult A (VERIFIED, taskId=A)
→ PublicationHandoffV1 (canonical pub-handoff-* B)
→ PublicationTask B
→ DRAFT-PUBLISH-V1 recomputes canonical identity → PUBLISHED_DRAFT (fake)
```

### P1 #2 resolution (self-asserted handoff)

Attacker-created valid R2 PublicationTask B + synthetic matching handoff → **`REJECT_HANDOFF_CANONICAL_TASK_ID`** unless B’s taskId equals the shared canonical derivation.

Also: missing/forged `authorityFingerprint` → `REJECT_HANDOFF_AUTHORITY_FINGERPRINT`.

## SHAs

| | SHA |
|---|---|
| **Base** | `1a494780ffb92bc6b1e27c99fbb24b39dfc1af75` |
| **HEAD** | `c7e115c4114f0c4120ab3a80949718e7e6f1febb` |

## Changed files

- `src/domain/publicationHandoffCanonical.ts` *(new shared pure helpers)*
- `src/domain/publicationHandoff.ts`
- `src/domain/draftPublish.ts`
- `test/publicationHandoff.test.ts`
- `test/draftPublish.test.ts`
- `docs/publication-handoff/publication-handoff-v1.md`
- `docs/draft-publish/draft-publish-v1.md`

## Verify

| Check | Result |
|---|---|
| typecheck | PASS |
| tests | **673 passed** (33 files) |
| build | PASS |
| publication-handoff tests | **25 passed** |
| E2E valid A→B | `PUBLISHED_DRAFT` (fake) |
| attacker R2 B + synthetic handoff | `REJECT_HANDOFF_CANONICAL_TASK_ID` |
| source mutated / runner widened / real GitHub / Ready-Merge-Deploy | **NO** |

## Gates

Draft → Fresh Review → **STOP**

Do not Ready / Merge / close Issue #57.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff5c1-c095-7f1b-b797-897f1d9c3c54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff5c1-c095-7f1b-b797-897f1d9c3c54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

