### PR TITLE
ISSUE-PROPOSAL-V1 — parse, validate, authority fingerprint (#62)

### DIFF
--- a/docs/issue-proposal/fixtures/issue-proposal-valid.json
+++ b/docs/issue-proposal/fixtures/issue-proposal-valid.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "ISSUE-PROPOSAL-V1",
+  "proposalId": "proposal-62-issue-decomposer-contract-v1",
+  "roadmapNodeId": "node-issue-decomposer-contract",
+  "repository": "yasutakesougo/ai-development-control-center",
+  "title": "ISSUE-DECOMPOSER-CONTRACT-V1",
+  "objective": "Define IssueProposalV1 as a machine-readable contract for later decomposition without granting GitHub Issue mutation or Agent execution authority.",
+  "dependsOn": [],
+  "allowedPaths": [
+    "docs/issue-proposal/",
+    "src/domain/issueProposalContract.ts",
+    "test/issueProposalContract.test.ts"
+  ],
+  "forbiddenPaths": [
+    ".github/workflows/",
+    "migrations/"
+  ],
+  "acceptanceCriteria": [
+    "IssueProposalV1 parse/validate/fingerprint available",
+    "Proposal validation does not grant GitHub Issue mutation authority",
+    "npm run verify passes without Planner, ISSUE-VALIDATOR-V1, Publisher, or Agent execution"
+  ],
+  "verificationCommands": [
+    {
+      "id": "typecheck",
+      "command": "npm run typecheck",
+      "description": "TypeScript contract must typecheck"
+    },
+    {
+      "id": "unit",
+      "command": "npm test -- test/issueProposalContract.test.ts",
+      "description": "IssueProposal contract tests"
+    }
+  ],
+  "allowedCapabilities": [
+    "workspace.read.v1"
+  ],
+  "riskClass": "R1",
+  "stopAt": "DRAFT_PR",
+  "estimatedChangedFiles": 8,
+  "provenance": {
+    "roadmapId": "roadmap-61-v1-2026-08-12",
+    "roadmapAuthorityFingerprint": "4030ba816276b42eaa4e6657b2ceadba9d8fcdc1e646b14ec8b65175ff4dbb7b"
+  },
+  "metadata": {
+    "createdAt": "2026-08-12T22:18:00.000Z",
+    "createdBy": "control-center-contract-v0",
+    "observedAt": "2026-08-12T22:18:00.000Z",
+    "sourceIssueUrl": "https://github.com/yasutakesougo/ai-development-control-center/issues/62",
+    "notes": [
+      "Slice: ISSUE-DECOMPOSER-CONTRACT-V1 / IssueProposalV1 only",
+      "Planner / ISSUE-VALIDATOR-V1 / Publisher / GitHub Issue mutation / Agent = NOT IMPLEMENTED"
+    ]
+  }
+}

--- a/docs/issue-proposal/issue-proposal-v1.md
+++ b/docs/issue-proposal/issue-proposal-v1.md
@@ -1,0 +1,216 @@
+# ISSUE-PROPOSAL-V1 / ISSUE-DECOMPOSER-CONTRACT-V1
+
+**Status: DESIGNED · CONTRACT ONLY · NO PLANNER · NO ISSUE-VALIDATOR-V1 · NO GITHUB ISSUE MUTATION · NO AGENT EXECUTION · NO SCHEDULER**
+
+This document defines the machine-readable **Issue Proposal Contract** — a
+bounded `IssueProposalV1` record derived from a validated `RoadmapNodeV1`,
+suitable for later ISSUE-VALIDATOR / Planner / Publisher slices.
+
+```text
+CONTRACT ONLY
+PLANNER / LLM DECOMPOSER = NOT IMPLEMENTED
+ISSUE-VALIDATOR-V1 = NOT IMPLEMENTED
+ISSUE SPLITTING = NOT IMPLEMENTED
+GITHUB ISSUE MUTATION = NOT IMPLEMENTED
+ISSUE-PUBLISHER-V1 = NOT IMPLEMENTED
+AGENT EXECUTION = NOT IMPLEMENTED
+SCHEDULER / DISPATCH = NOT IMPLEMENTED
+READY / MERGE / ISSUE CLOSE / DEPLOY = NOT AUTHORIZED BY THIS CONTRACT
+```
+
+Baseline at drafting:
+
+```text
+main = f1963021b51d09b73f4cb8f74864a18f513df552
+ROADMAP-CONTRACT-V1 / #61 = COMPLETE
+Issue #62 = OPEN (this contract)
+CHECKPOINT-2 = ACTIVE
+```
+
+---
+
+## 1. Purpose
+
+```text
+validated RoadmapContractV1 / RoadmapNodeV1
+→ IssueProposalV1
+→ structural parse
+→ deterministic semantic validation
+→ deterministic authority fingerprint
+```
+
+This slice covers **only** the IssueProposal contract foundation. It does not
+generate proposals via Planner/LLM, validate batches beyond proposal-local
+invariants, or mutate GitHub.
+
+Core principle:
+
+```text
+Do not start from an LLM prompt.
+The versioned machine-readable contract / JSON Schema is canonical.
+No silent repair of invalid proposal fields.
+```
+
+---
+
+## 2. Relationship to other modules
+
+| Module | Role vs Issue Proposal |
+|---|---|
+| ProjectContractV1 | Upstream governance. Repository / risk / prohibited capability binding. |
+| RoadmapContractV1 / RoadmapNodeV1 | Upstream DAG node authority. Exact fingerprint + nodeId binding required. |
+| IssueProposalV1 | This slice. Proposal ≠ Issue authority ≠ execution authority. |
+| ISSUE-VALIDATOR-V1 | Downstream (#63). Not implemented here. |
+| ISSUE-DECOMPOSER-V1 / Planner | Downstream (#64). Not implemented here. |
+| ISSUE-SPLITTER-V1 | Downstream (#65). Not implemented here. |
+| ISSUE-PUBLISHER-V1 | Downstream (#66). Not implemented here. |
+| AgentTaskV1 | Later execution contract. Not generated here. |
+
+Invariants:
+
+```text
+IssueProposal validation ≠ GitHub Issue mutation authority
+IssueProposal validation ≠ Agent execution authority
+IssueProposal validation ≠ scheduler / dispatch authority
+metadata / observedAt are audit-only and never silently become
+  authority-bearing fingerprint input
+allowedCapabilities are proposal data only; validation never grants them
+```
+
+---
+
+## 3. Documents
+
+| Artifact | Path |
+|---|---|
+| IssueProposalV1 schema | `schemas/issue-proposal-v1.schema.json` |
+| IssueProposalValidationResultV1 schema | `schemas/issue-proposal-validation-result-v1.schema.json` |
+| Valid fixture | `fixtures/issue-proposal-valid.json` |
+| TypeScript contract | `src/domain/issueProposalContract.ts` |
+| Tests | `test/issueProposalContract.test.ts` |
+
+---
+
+## 4. IssueProposalV1 concepts
+
+| Field | Role | Authority fingerprint |
+|---|---|---|
+| `schemaVersion` | Fixed `ISSUE-PROPOSAL-V1` | yes |
+| `proposalId` | Stable proposal identity | yes |
+| `roadmapNodeId` | Exact RoadmapNode binding | yes |
+| `repository` | Required repository binding | yes |
+| `title` / `objective` | Bounded intent | yes |
+| `dependsOn` | Explicit proposalId dependencies | yes |
+| `allowedPaths` / `forbiddenPaths` | Path scope boundaries | yes |
+| `acceptanceCriteria` | Required non-empty acceptance conditions | yes |
+| `verificationCommands` | Required non-empty verification commands | yes |
+| `allowedCapabilities` | Capability ids as proposal data | yes |
+| `riskClass` | `R0`…`R5` | yes |
+| `stopAt` | Explicit stop boundary | yes |
+| `estimatedChangedFiles` | Integer change budget | yes |
+| `provenance` | Exact RoadmapContract authority binding | yes |
+| `metadata` | Audit / observedAt (non-authority) | **no** |
+
+### Provenance
+
+| Field | Role |
+|---|---|
+| `roadmapId` | Exact RoadmapContractV1.roadmapId |
+| `roadmapAuthorityFingerprint` | Exact RoadmapContract authority fingerprint |
+
+---
+
+## 5. Semantic validation
+
+Runtime semantic validation is deterministic and fail-closed:
+
+- Unknown properties / missing required fields → `REJECTED_SCHEMA`
+- Empty `acceptanceCriteria` → `REJECTED_ACCEPTANCE_CRITERIA` / structural reject
+- Overlapping `allowedPaths` / `forbiddenPaths` → `REJECTED_PATH_CONFLICT`
+- Duplicate path / capability / dependency entries → `REJECTED_SCHEMA`
+- Self-dependency in `dependsOn` → `REJECTED_DEPENDENCY`
+- Malformed repository / capability / risk / stopAt → `REJECTED_SCHEMA`
+- `roadmapNodeId` missing from supplied RoadmapContract → `REJECTED_ROADMAP_NODE_BINDING`
+- `provenance.roadmapId` / fingerprint mismatch → `REJECTED_ROADMAP_BINDING`
+- `repository` outside ProjectContract repositories → `REJECTED_REPOSITORY_BINDING`
+- `repository` ≠ bound RoadmapNode.repository (when present) → `REJECTED_REPOSITORY_BINDING`
+- Capability prohibited by ProjectContract → `REJECTED_CAPABILITY`
+- `riskClass` above ProjectContract `maxRiskClass` → `REJECTED_RISK_CLASS`
+
+Validation never invokes an LLM, mutates GitHub, or dispatches Agents.
+
+A `VALID` result means the proposal document is structurally and semantically
+well-formed under the supplied Roadmap/Project authority. It does **not**
+authorize `github.issue.create.v1`, ISSUE-PUBLISHER-V1, or Agent execution.
+
+---
+
+## 6. Authority fingerprint
+
+Authority-bearing fields (hashed):
+
+```text
+schemaVersion, proposalId, roadmapNodeId, repository, title, objective,
+dependsOn, allowedPaths, forbiddenPaths, acceptanceCriteria,
+verificationCommands, allowedCapabilities, riskClass, stopAt,
+estimatedChangedFiles, provenance
+```
+
+Within lists, fingerprint capture sorts `dependsOn`, normalized paths,
+`acceptanceCriteria`, `allowedCapabilities`, and `verificationCommands` by `id`
+so insertion order is non-semantic.
+
+Excluded (not authority):
+
+```text
+metadata.* including metadata.observedAt — audit only
+validatedAt on validation results
+```
+
+Fingerprint algorithm:
+
+```text
+SHA-256 hex over deterministic canonical JSON
+(canonicalJson from decisionFingerprint.ts — sorted object keys)
+```
+
+Same authority facts with different `metadata.observedAt` ⇒ **same** fingerprint.
+
+Changes to scope, acceptance, verification, capability, risk, stopAt, or
+Roadmap provenance ⇒ **different** fingerprint.
+
+---
+
+## 7. Validation result statuses
+
+| Status | Meaning |
+|---|---|
+| `VALID` | Structural + proposal-local + Roadmap/Project binding passed |
+| `INVALID` | Deterministic rejection |
+| `HOLD` | Reserved for future ambiguous cases |
+| `UNKNOWN` | Reserved for insufficient information |
+
+`IssueProposalValidationResultV1.proposalId` and `roadmapNodeId` are always
+required; use `null` when unknown.
+
+---
+
+## 8. CHECKPOINT-2 context
+
+```text
+#60 PROJECT-CONTRACT-V1          COMPLETE
+#61 ROADMAP-CONTRACT-V1          COMPLETE
+#62 ISSUE-DECOMPOSER-CONTRACT-V1 ← this slice
+#63 ISSUE-VALIDATOR-V1
+#64 ISSUE-DECOMPOSER-V1
+...
+```
+
+Delivery gate for this slice:
+
+```text
+Implementation → npm run verify → Draft PR → Fresh Review → STOP
+```
+
+Do not Ready / Merge / close #62 in the implementation run.
+Do not start #63 / #64 until separate Human GO.

--- a/docs/issue-proposal/schemas/issue-proposal-v1.schema.json
+++ b/docs/issue-proposal/schemas/issue-proposal-v1.schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ai-development-control-center.local/schemas/issue-proposal-v1.json",
+  "title": "IssueProposalV1",
+  "description": "Machine-readable bounded Issue proposal derived from a RoadmapNodeV1. Runtime parser must mirror this schema (additionalProperties:false). Authority fingerprint hashes proposal authority + Roadmap provenance binding. metadata/observedAt are audit-only and excluded. Semantic Roadmap/Project binding rules are enforced at runtime. Validation does not grant GitHub Issue mutation or Agent execution authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "proposalId",
+    "roadmapNodeId",
+    "repository",
+    "title",
+    "objective",
+    "dependsOn",
+    "allowedPaths",
+    "forbiddenPaths",
+    "acceptanceCriteria",
+    "verificationCommands",
+    "allowedCapabilities",
+    "riskClass",
+    "stopAt",
+    "estimatedChangedFiles",
+    "provenance"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "ISSUE-PROPOSAL-V1" },
+    "proposalId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
+    },
+    "roadmapNodeId": {
+      "description": "Exact RoadmapNodeV1.nodeId binding. Runtime requires membership in the supplied RoadmapContractV1.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
+    },
+    "repository": {
+      "description": "Required repository binding. Runtime requires ProjectContract repository authority and equality with bound RoadmapNode.repository when that node has a repository.",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 256,
+      "pattern": "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$"
+    },
+    "title": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "objective": { "type": "string", "minLength": 1, "maxLength": 4096 },
+    "dependsOn": {
+      "description": "Authority-bearing proposalId dependencies. Runtime rejects duplicates and self-deps. Changes alter the proposal authority fingerprint.",
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128,
+        "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
+      },
+      "uniqueItems": true
+    },
+    "allowedPaths": {
+      "description": "Required non-empty repository-relative path allowlist. Changes alter the proposal authority fingerprint.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 256,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512,
+        "pattern": "^(?!/)(?!.*\\\\)(?!.*//)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*(?:^|/)\\.(?:/|$))[^\\x00\\\\]+$"
+      },
+      "uniqueItems": true
+    },
+    "forbiddenPaths": {
+      "description": "Repository-relative path denylist. Runtime rejects exact/prefix overlap with allowedPaths. Changes alter the proposal authority fingerprint.",
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512,
+        "pattern": "^(?!/)(?!.*\\\\)(?!.*//)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*(?:^|/)\\.(?:/|$))[^\\x00\\\\]+$"
+      },
+      "uniqueItems": true
+    },
+    "acceptanceCriteria": {
+      "description": "Required non-empty acceptance criteria. Changes alter the proposal authority fingerprint.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 64,
+      "items": { "type": "string", "minLength": 1, "maxLength": 2048 },
+      "uniqueItems": true
+    },
+    "verificationCommands": {
+      "description": "Required non-empty verification command objects. Changes alter the proposal authority fingerprint.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "command"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          },
+          "command": { "type": "string", "minLength": 1, "maxLength": 512 },
+          "workingDirectory": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "pattern": "^(?!/)(?!.*\\\\)(?!.*//)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*(?:^|/)\\.(?:/|$))[^\\x00\\\\]+$"
+          },
+          "description": { "type": "string", "minLength": 1, "maxLength": 512 }
+        }
+      }
+    },
+    "allowedCapabilities": {
+      "description": "Capability identifiers expressed as proposal data only. Validation never grants GitHub Issue mutation or Agent execution. Runtime rejects duplicates, malformed ids, and ProjectContract prohibitedCapabilities.",
+      "type": "array",
+      "maxItems": 32,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128,
+        "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z0-9]+(?:-[a-z0-9]+)*)+\\.v[0-9]+$"
+      },
+      "uniqueItems": true
+    },
+    "riskClass": {
+      "description": "Authority-bearing risk band. Runtime rejects values above ProjectContract maxRiskClass when present.",
+      "enum": ["R0", "R1", "R2", "R3", "R4", "R5"]
+    },
+    "stopAt": {
+      "description": "Explicit stop boundary for later execution stages. Not publication authority.",
+      "enum": ["TASK_BUILT", "AGENT_COMPLETE", "VERIFY_COMPLETE", "DRAFT_PR"]
+    },
+    "estimatedChangedFiles": {
+      "description": "Authority-bearing estimated changed-file budget (integer 1..10000).",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10000
+    },
+    "provenance": {
+      "description": "Exact RoadmapContract authority binding. Changes alter the proposal authority fingerprint.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["roadmapId", "roadmapAuthorityFingerprint"],
+      "properties": {
+        "roadmapId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
+        },
+        "roadmapAuthorityFingerprint": {
+          "description": "Exact RoadmapContractV1 authority fingerprint binding (64-char lowercase SHA-256 hex).",
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "metadata": {
+      "description": "Audit / observation fields only. observedAt and other metadata MUST NOT participate in the authority fingerprint.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "createdAt": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "createdBy": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "observedAt": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "sourceIssueUrl": { "type": "string", "minLength": 1, "maxLength": 2048 },
+        "notes": {
+          "type": "array",
+          "maxItems": 16,
+          "items": { "type": "string", "minLength": 1, "maxLength": 1024 }
+        }
+      }
+    }
+  }
+}

--- a/docs/issue-proposal/schemas/issue-proposal-validation-result-v1.schema.json
+++ b/docs/issue-proposal/schemas/issue-proposal-validation-result-v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ai-development-control-center.local/schemas/issue-proposal-validation-result-v1.json",
+  "title": "IssueProposalValidationResultV1",
+  "description": "Deterministic validation outcome for IssueProposalV1. Runtime parser must mirror this schema including additionalProperties:false and field bounds. A VALID result is not GitHub Issue mutation authority and is not Agent execution authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "proposalId",
+    "roadmapNodeId",
+    "status",
+    "reasonCode",
+    "reasonMessage",
+    "validatedAt"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "ISSUE-PROPOSAL-VALIDATION-RESULT-V1" },
+    "proposalId": {
+      "description": "Always present. Use null when the source proposalId is unknown.",
+      "type": ["string", "null"],
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
+    },
+    "roadmapNodeId": {
+      "description": "Always present. Use null when the source roadmapNodeId is unknown.",
+      "type": ["string", "null"],
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
+    },
+    "status": { "enum": ["VALID", "INVALID", "HOLD", "UNKNOWN"] },
+    "reasonCode": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "reasonMessage": { "type": "string", "minLength": 1, "maxLength": 2048 },
+    "findings": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "code", "message", "severity"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1, "maxLength": 512 },
+          "code": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "message": { "type": "string", "minLength": 1, "maxLength": 2048 },
+          "severity": { "enum": ["ERROR", "WARNING"] }
+        }
+      }
+    },
+    "authorityFingerprint": {
+      "description": "Optional 64-char lowercase SHA-256 hex of authority facts. Absent when structural parse failed before fingerprint computation.",
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "validatedAt": { "type": "string", "minLength": 1 }
+  }
+}

--- a/src/domain/issueProposalContract.ts
+++ b/src/domain/issueProposalContract.ts
@@ -1,0 +1,1320 @@
+/**
+ * ISSUE-PROPOSAL-V1 / ISSUE-DECOMPOSER-CONTRACT-V1 design contract helpers.
+ *
+ * DESIGNED · CONTRACT ONLY · NO PLANNER · NO ISSUE-VALIDATOR-V1 ·
+ * NO GITHUB ISSUE MUTATION · NO AGENT EXECUTION · NO SCHEDULER
+ *
+ * Pure parse / validate / fingerprint for machine-readable IssueProposalV1
+ * records bound to a validated RoadmapContractV1 / RoadmapNodeV1. Does not
+ * invoke an LLM, publish GitHub Issues, or dispatch Agents.
+ */
+
+import { canonicalJson } from "./decisionFingerprint";
+import {
+  isRepoRelativePath,
+  normalizeRepoPath,
+} from "./agentTaskContract";
+import {
+  computeProjectContractAuthorityFingerprint,
+  type ProjectContractRiskClass,
+  type ProjectContractV1,
+  PROJECT_CONTRACT_RISK_CLASSES,
+} from "./projectContract";
+import {
+  computeRoadmapContractAuthorityFingerprint,
+  type RoadmapContractV1,
+} from "./roadmapContract";
+
+export const ISSUE_PROPOSAL_SCHEMA = "ISSUE-PROPOSAL-V1" as const;
+export const ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA =
+  "ISSUE-PROPOSAL-VALIDATION-RESULT-V1" as const;
+
+/** Downstream planner / mutation / execution surfaces remain unimplemented. */
+export const ISSUE_PROPOSAL_PLANNER_IMPLEMENTED = false as const;
+export const ISSUE_PROPOSAL_VALIDATOR_V1_IMPLEMENTED = false as const;
+export const ISSUE_PROPOSAL_SPLITTER_IMPLEMENTED = false as const;
+export const ISSUE_PROPOSAL_GITHUB_ISSUE_MUTATION_IMPLEMENTED = false as const;
+export const ISSUE_PROPOSAL_PUBLISHER_IMPLEMENTED = false as const;
+export const ISSUE_PROPOSAL_AGENT_EXECUTION_IMPLEMENTED = false as const;
+export const ISSUE_PROPOSAL_SCHEDULER_IMPLEMENTED = false as const;
+
+export const ISSUE_PROPOSAL_RISK_CLASSES = [
+  "R0",
+  "R1",
+  "R2",
+  "R3",
+  "R4",
+  "R5",
+] as const;
+
+export const ISSUE_PROPOSAL_STOP_AT_VALUES = [
+  "TASK_BUILT",
+  "AGENT_COMPLETE",
+  "VERIFY_COMPLETE",
+  "DRAFT_PR",
+] as const;
+
+export const ISSUE_PROPOSAL_PROPOSAL_ID_MAX = 128 as const;
+export const ISSUE_PROPOSAL_NODE_ID_MAX = 128 as const;
+export const ISSUE_PROPOSAL_TITLE_MAX = 256 as const;
+export const ISSUE_PROPOSAL_OBJECTIVE_MAX = 4096 as const;
+export const ISSUE_PROPOSAL_DEPENDS_ON_MAX = 64 as const;
+export const ISSUE_PROPOSAL_PATHS_MAX = 256 as const;
+export const ISSUE_PROPOSAL_PATH_MAX_LEN = 512 as const;
+export const ISSUE_PROPOSAL_ACCEPTANCE_CRITERIA_MAX = 64 as const;
+export const ISSUE_PROPOSAL_ACCEPTANCE_CRITERION_MAX = 2048 as const;
+export const ISSUE_PROPOSAL_VERIFICATION_COMMANDS_MAX = 32 as const;
+export const ISSUE_PROPOSAL_VERIFICATION_COMMAND_ID_MAX = 64 as const;
+export const ISSUE_PROPOSAL_CAPABILITIES_MAX = 32 as const;
+export const ISSUE_PROPOSAL_ESTIMATED_CHANGED_FILES_MAX = 10000 as const;
+export const ISSUE_PROPOSAL_FINDINGS_MAX = 64 as const;
+export const ISSUE_PROPOSAL_FINDING_PATH_MAX = 512 as const;
+export const ISSUE_PROPOSAL_FINDING_CODE_MAX = 128 as const;
+export const ISSUE_PROPOSAL_FINDING_MESSAGE_MAX = 2048 as const;
+export const ISSUE_PROPOSAL_REASON_CODE_MAX = 128 as const;
+export const ISSUE_PROPOSAL_REASON_MESSAGE_MAX = 2048 as const;
+export const ISSUE_PROPOSAL_METADATA_NOTES_MAX = 16 as const;
+export const ISSUE_PROPOSAL_METADATA_NOTE_MAX = 1024 as const;
+
+/** Exact root keys accepted by IssueProposalV1 (additionalProperties: false). */
+export const ISSUE_PROPOSAL_ROOT_KEYS = [
+  "schemaVersion",
+  "proposalId",
+  "roadmapNodeId",
+  "repository",
+  "title",
+  "objective",
+  "dependsOn",
+  "allowedPaths",
+  "forbiddenPaths",
+  "acceptanceCriteria",
+  "verificationCommands",
+  "allowedCapabilities",
+  "riskClass",
+  "stopAt",
+  "estimatedChangedFiles",
+  "provenance",
+  "metadata",
+] as const;
+
+export const ISSUE_PROPOSAL_PROVENANCE_KEYS = [
+  "roadmapId",
+  "roadmapAuthorityFingerprint",
+] as const;
+
+export const ISSUE_PROPOSAL_VERIFICATION_COMMAND_KEYS = [
+  "id",
+  "command",
+  "workingDirectory",
+  "description",
+] as const;
+
+/**
+ * Authority fingerprint includes proposal authority facts + Roadmap binding.
+ * Audit-only metadata (including observedAt) is excluded.
+ */
+export const ISSUE_PROPOSAL_AUTHORITY_FINGERPRINT_KEYS = [
+  "schemaVersion",
+  "proposalId",
+  "roadmapNodeId",
+  "repository",
+  "title",
+  "objective",
+  "dependsOn",
+  "allowedPaths",
+  "forbiddenPaths",
+  "acceptanceCriteria",
+  "verificationCommands",
+  "allowedCapabilities",
+  "riskClass",
+  "stopAt",
+  "estimatedChangedFiles",
+  "provenance",
+] as const;
+
+export const ISSUE_PROPOSAL_METADATA_KEYS = [
+  "createdAt",
+  "createdBy",
+  "observedAt",
+  "sourceIssueUrl",
+  "notes",
+] as const;
+
+export const ISSUE_PROPOSAL_VALIDATION_RESULT_ROOT_KEYS = [
+  "schemaVersion",
+  "proposalId",
+  "roadmapNodeId",
+  "status",
+  "reasonCode",
+  "reasonMessage",
+  "findings",
+  "authorityFingerprint",
+  "validatedAt",
+] as const;
+
+export type IssueProposalRiskClass =
+  (typeof ISSUE_PROPOSAL_RISK_CLASSES)[number];
+export type IssueProposalStopAt =
+  (typeof ISSUE_PROPOSAL_STOP_AT_VALUES)[number];
+
+export type IssueProposalValidationStatus =
+  | "VALID"
+  | "INVALID"
+  | "HOLD"
+  | "UNKNOWN";
+
+export type IssueProposalRejectReason =
+  | "REJECTED_SCHEMA"
+  | "REJECTED_PROPOSAL_ID"
+  | "REJECTED_ROADMAP_NODE_BINDING"
+  | "REJECTED_ROADMAP_BINDING"
+  | "REJECTED_REPOSITORY_BINDING"
+  | "REJECTED_DEPENDENCY"
+  | "REJECTED_PATHS"
+  | "REJECTED_PATH_CONFLICT"
+  | "REJECTED_ACCEPTANCE_CRITERIA"
+  | "REJECTED_VERIFICATION_COMMANDS"
+  | "REJECTED_CAPABILITY"
+  | "REJECTED_RISK_CLASS"
+  | "REJECTED_STOP_AT"
+  | "REJECTED_ESTIMATED_CHANGED_FILES"
+  | "REJECTED_PROVENANCE"
+  | "REJECTED_METADATA";
+
+export interface IssueProposalVerificationCommandV1 {
+  id: string;
+  command: string;
+  workingDirectory?: string;
+  description?: string;
+}
+
+/**
+ * Provenance binding to RoadmapContract authority.
+ * Changes alter the proposal authority fingerprint.
+ */
+export interface IssueProposalProvenanceV1 {
+  roadmapId: string;
+  /** Exact RoadmapContractV1 authority fingerprint binding. */
+  roadmapAuthorityFingerprint: string;
+}
+
+/**
+ * Audit / observation metadata. Never part of the authority fingerprint.
+ * observedAt is explicitly audit-only.
+ */
+export interface IssueProposalMetadataV1 {
+  createdAt?: string;
+  createdBy?: string;
+  observedAt?: string;
+  sourceIssueUrl?: string;
+  notes?: string[];
+}
+
+export interface IssueProposalV1 {
+  schemaVersion: typeof ISSUE_PROPOSAL_SCHEMA;
+  proposalId: string;
+  roadmapNodeId: string;
+  repository: string;
+  title: string;
+  objective: string;
+  /** ProposalId dependencies (proposal-local; not GitHub Issue numbers). */
+  dependsOn: string[];
+  allowedPaths: string[];
+  forbiddenPaths: string[];
+  acceptanceCriteria: string[];
+  verificationCommands: IssueProposalVerificationCommandV1[];
+  allowedCapabilities: string[];
+  riskClass: IssueProposalRiskClass;
+  stopAt: IssueProposalStopAt;
+  estimatedChangedFiles: number;
+  provenance: IssueProposalProvenanceV1;
+  metadata?: IssueProposalMetadataV1;
+}
+
+export interface IssueProposalVerificationCommandAuthorityFactsV1 {
+  id: string;
+  command: string;
+  workingDirectory?: string;
+  description?: string;
+}
+
+export interface IssueProposalAuthorityFactsV1 {
+  schemaVersion: typeof ISSUE_PROPOSAL_SCHEMA;
+  proposalId: string;
+  roadmapNodeId: string;
+  repository: string;
+  title: string;
+  objective: string;
+  dependsOn: string[];
+  allowedPaths: string[];
+  forbiddenPaths: string[];
+  acceptanceCriteria: string[];
+  verificationCommands: IssueProposalVerificationCommandAuthorityFactsV1[];
+  allowedCapabilities: string[];
+  riskClass: IssueProposalRiskClass;
+  stopAt: IssueProposalStopAt;
+  estimatedChangedFiles: number;
+  provenance: IssueProposalProvenanceV1;
+}
+
+export interface IssueProposalValidationFinding {
+  path: string;
+  code: string;
+  message: string;
+  severity: "ERROR" | "WARNING";
+}
+
+export interface IssueProposalValidationResultV1 {
+  schemaVersion: typeof ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA;
+  proposalId: string | null;
+  roadmapNodeId: string | null;
+  status: IssueProposalValidationStatus;
+  reasonCode: string;
+  reasonMessage: string;
+  findings?: IssueProposalValidationFinding[];
+  /** Present only when structural parse succeeded and fingerprint was computed. */
+  authorityFingerprint?: string;
+  validatedAt: string;
+}
+
+const REPOSITORY_PATTERN = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+const PROPOSAL_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+const NODE_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+const ROADMAP_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+const AUTHORITY_FINGERPRINT_PATTERN = /^[a-f0-9]{64}$/;
+const CAPABILITY_ID_PATTERN =
+  /^[a-z][a-z0-9]*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*)+\.v[0-9]+$/;
+const VERIFICATION_COMMAND_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function isNonEmptyBoundedString(
+  value: unknown,
+  max: number,
+): value is string {
+  return typeof value === "string" && value.length >= 1 && value.length <= max;
+}
+
+function isProposalId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 1 &&
+    value.length <= ISSUE_PROPOSAL_PROPOSAL_ID_MAX &&
+    PROPOSAL_ID_PATTERN.test(value)
+  );
+}
+
+function isNodeId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 1 &&
+    value.length <= ISSUE_PROPOSAL_NODE_ID_MAX &&
+    NODE_ID_PATTERN.test(value)
+  );
+}
+
+function isRoadmapId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 1 &&
+    value.length <= 128 &&
+    ROADMAP_ID_PATTERN.test(value)
+  );
+}
+
+function isRepository(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 3 &&
+    value.length <= 256 &&
+    REPOSITORY_PATTERN.test(value)
+  );
+}
+
+function isAuthorityFingerprint(value: unknown): value is string {
+  return (
+    typeof value === "string" && AUTHORITY_FINGERPRINT_PATTERN.test(value)
+  );
+}
+
+function isCapabilityId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 1 &&
+    value.length <= 128 &&
+    CAPABILITY_ID_PATTERN.test(value)
+  );
+}
+
+function isRiskClass(value: unknown): value is IssueProposalRiskClass {
+  return (ISSUE_PROPOSAL_RISK_CLASSES as readonly string[]).includes(
+    value as string,
+  );
+}
+
+function isStopAt(value: unknown): value is IssueProposalStopAt {
+  return (ISSUE_PROPOSAL_STOP_AT_VALUES as readonly string[]).includes(
+    value as string,
+  );
+}
+
+function hasDuplicates(values: string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) duplicates.push(value);
+    seen.add(value);
+  }
+  return duplicates;
+}
+
+function riskClassRank(risk: ProjectContractRiskClass | IssueProposalRiskClass): number {
+  return (PROJECT_CONTRACT_RISK_CLASSES as readonly string[]).indexOf(risk);
+}
+
+function pathsOverlap(a: string, b: string): boolean {
+  const left = normalizeRepoPath(a);
+  const right = normalizeRepoPath(b);
+  if (left === right) return true;
+  return right.startsWith(`${left}/`) || left.startsWith(`${right}/`);
+}
+
+function findPathBoundaryConflicts(
+  allowedPaths: string[],
+  forbiddenPaths: string[],
+): { kind: "exact" | "prefix"; path: string; other: string }[] {
+  const conflicts: { kind: "exact" | "prefix"; path: string; other: string }[] =
+    [];
+  for (const allowed of allowedPaths) {
+    for (const forbidden of forbiddenPaths) {
+      if (normalizeRepoPath(allowed) === normalizeRepoPath(forbidden)) {
+        conflicts.push({ kind: "exact", path: allowed, other: forbidden });
+      } else if (pathsOverlap(allowed, forbidden)) {
+        conflicts.push({ kind: "prefix", path: allowed, other: forbidden });
+      }
+    }
+  }
+  return conflicts;
+}
+
+function parsePathArray(
+  value: unknown,
+  field: "allowedPaths" | "forbiddenPaths",
+  minItems: number,
+):
+  | { ok: true; paths: string[] }
+  | { ok: false; reasonMessage: string } {
+  if (!Array.isArray(value)) {
+    return {
+      ok: false,
+      reasonMessage: `${field} must be an array.`,
+    };
+  }
+  if (value.length < minItems || value.length > ISSUE_PROPOSAL_PATHS_MAX) {
+    return {
+      ok: false,
+      reasonMessage: `${field} must contain between ${minItems} and ${ISSUE_PROPOSAL_PATHS_MAX} paths.`,
+    };
+  }
+  if (!value.every(isRepoRelativePath)) {
+    return {
+      ok: false,
+      reasonMessage: `${field} contains malformed repository-relative paths.`,
+    };
+  }
+  const normalized = (value as string[]).map(normalizeRepoPath);
+  const duplicates = hasDuplicates(normalized);
+  if (duplicates.length > 0) {
+    return {
+      ok: false,
+      reasonMessage: `${field} contains duplicate entries after trailing-slash normalization: ${duplicates.join(", ")}.`,
+    };
+  }
+  return { ok: true, paths: value as string[] };
+}
+
+function isVerificationCommand(
+  value: unknown,
+): value is IssueProposalVerificationCommandV1 {
+  if (!isPlainObject(value)) return false;
+  if (!hasOnlyKeys(value, ISSUE_PROPOSAL_VERIFICATION_COMMAND_KEYS)) {
+    return false;
+  }
+  if (
+    typeof value.id !== "string" ||
+    value.id.length < 1 ||
+    value.id.length > ISSUE_PROPOSAL_VERIFICATION_COMMAND_ID_MAX ||
+    !VERIFICATION_COMMAND_ID_PATTERN.test(value.id)
+  ) {
+    return false;
+  }
+  if (
+    typeof value.command !== "string" ||
+    value.command.length < 1 ||
+    value.command.length > 512
+  ) {
+    return false;
+  }
+  if (
+    value.workingDirectory !== undefined &&
+    !isRepoRelativePath(value.workingDirectory)
+  ) {
+    return false;
+  }
+  if (
+    value.description !== undefined &&
+    (typeof value.description !== "string" ||
+      value.description.length < 1 ||
+      value.description.length > 512)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isProvenance(value: unknown): value is IssueProposalProvenanceV1 {
+  if (!isPlainObject(value)) return false;
+  if (!hasOnlyKeys(value, ISSUE_PROPOSAL_PROVENANCE_KEYS)) return false;
+  if (!isRoadmapId(value.roadmapId)) return false;
+  if (!isAuthorityFingerprint(value.roadmapAuthorityFingerprint)) return false;
+  return true;
+}
+
+function isMetadata(value: unknown): value is IssueProposalMetadataV1 {
+  if (!isPlainObject(value)) return false;
+  if (!hasOnlyKeys(value, ISSUE_PROPOSAL_METADATA_KEYS)) return false;
+  if (
+    value.createdAt !== undefined &&
+    !isNonEmptyBoundedString(value.createdAt, 64)
+  ) {
+    return false;
+  }
+  if (
+    value.createdBy !== undefined &&
+    !isNonEmptyBoundedString(value.createdBy, 256)
+  ) {
+    return false;
+  }
+  if (
+    value.observedAt !== undefined &&
+    !isNonEmptyBoundedString(value.observedAt, 64)
+  ) {
+    return false;
+  }
+  if (
+    value.sourceIssueUrl !== undefined &&
+    !isNonEmptyBoundedString(value.sourceIssueUrl, 2048)
+  ) {
+    return false;
+  }
+  if (value.notes !== undefined) {
+    if (
+      !Array.isArray(value.notes) ||
+      value.notes.length > ISSUE_PROPOSAL_METADATA_NOTES_MAX ||
+      !value.notes.every((note) =>
+        isNonEmptyBoundedString(note, ISSUE_PROPOSAL_METADATA_NOTE_MAX),
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sortStringsStable(values: string[]): string[] {
+  return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Raw document body → JSON value. Syntax errors become REJECTED_SCHEMA (never throw).
+ */
+export function parseIssueProposalJsonBody(raw: unknown):
+  | { ok: true; value: unknown }
+  | { ok: false; reasonCode: "REJECTED_SCHEMA"; reasonMessage: string } {
+  if (typeof raw !== "string") {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Issue proposal body must be a UTF-8 JSON string.",
+    };
+  }
+  try {
+    return { ok: true, value: JSON.parse(raw) as unknown };
+  } catch {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Issue proposal body is not valid JSON syntax.",
+    };
+  }
+}
+
+/**
+ * Structural fail-closed parse for IssueProposalV1 documents.
+ * Mirrors docs/issue-proposal/schemas/issue-proposal-v1.schema.json including
+ * additionalProperties:false on all objects.
+ */
+export function parseIssueProposalV1(
+  value: unknown,
+):
+  | { ok: true; proposal: IssueProposalV1 }
+  | { ok: false; reasonCode: "REJECTED_SCHEMA"; reasonMessage: string } {
+  if (!isPlainObject(value)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Issue proposal must be a JSON object.",
+    };
+  }
+  if (!hasOnlyKeys(value, ISSUE_PROPOSAL_ROOT_KEYS)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage:
+        "Issue proposal contains unknown properties (additionalProperties forbidden).",
+    };
+  }
+  if (value.schemaVersion !== ISSUE_PROPOSAL_SCHEMA) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: `schemaVersion must be ${ISSUE_PROPOSAL_SCHEMA}.`,
+    };
+  }
+  if (!isProposalId(value.proposalId)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "proposalId is missing or malformed.",
+    };
+  }
+  if (!isNodeId(value.roadmapNodeId)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "roadmapNodeId is missing or malformed.",
+    };
+  }
+  if (!isRepository(value.repository)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "repository is missing or malformed.",
+    };
+  }
+  if (!isNonEmptyBoundedString(value.title, ISSUE_PROPOSAL_TITLE_MAX)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "title is missing or malformed.",
+    };
+  }
+  if (
+    !isNonEmptyBoundedString(value.objective, ISSUE_PROPOSAL_OBJECTIVE_MAX)
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "objective is missing or malformed.",
+    };
+  }
+  if (
+    !Array.isArray(value.dependsOn) ||
+    value.dependsOn.length > ISSUE_PROPOSAL_DEPENDS_ON_MAX ||
+    !value.dependsOn.every(isProposalId)
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "dependsOn must be an array of well-formed proposalIds.",
+    };
+  }
+  if (hasDuplicates(value.dependsOn as string[]).length > 0) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "dependsOn contains duplicate entries.",
+    };
+  }
+
+  const allowedParsed = parsePathArray(value.allowedPaths, "allowedPaths", 1);
+  if (!allowedParsed.ok) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: allowedParsed.reasonMessage,
+    };
+  }
+  const forbiddenParsed = parsePathArray(
+    value.forbiddenPaths,
+    "forbiddenPaths",
+    0,
+  );
+  if (!forbiddenParsed.ok) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: forbiddenParsed.reasonMessage,
+    };
+  }
+
+  if (
+    !Array.isArray(value.acceptanceCriteria) ||
+    value.acceptanceCriteria.length < 1 ||
+    value.acceptanceCriteria.length > ISSUE_PROPOSAL_ACCEPTANCE_CRITERIA_MAX ||
+    !value.acceptanceCriteria.every((item) =>
+      isNonEmptyBoundedString(item, ISSUE_PROPOSAL_ACCEPTANCE_CRITERION_MAX),
+    )
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage:
+        "acceptanceCriteria must contain at least one non-empty criterion.",
+    };
+  }
+  if (hasDuplicates(value.acceptanceCriteria as string[]).length > 0) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "acceptanceCriteria contains duplicate entries.",
+    };
+  }
+
+  if (
+    !Array.isArray(value.verificationCommands) ||
+    value.verificationCommands.length < 1 ||
+    value.verificationCommands.length >
+      ISSUE_PROPOSAL_VERIFICATION_COMMANDS_MAX ||
+    !value.verificationCommands.every(isVerificationCommand)
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage:
+        "verificationCommands must contain at least one well-formed command object.",
+    };
+  }
+  const verificationIds = (
+    value.verificationCommands as IssueProposalVerificationCommandV1[]
+  ).map((command) => command.id);
+  if (hasDuplicates(verificationIds).length > 0) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "verificationCommands[].id values must be unique.",
+    };
+  }
+
+  if (
+    !Array.isArray(value.allowedCapabilities) ||
+    value.allowedCapabilities.length > ISSUE_PROPOSAL_CAPABILITIES_MAX ||
+    !value.allowedCapabilities.every(isCapabilityId)
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage:
+        "allowedCapabilities contains malformed capability identifiers.",
+    };
+  }
+  if (hasDuplicates(value.allowedCapabilities as string[]).length > 0) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "allowedCapabilities contains duplicate entries.",
+    };
+  }
+
+  if (!isRiskClass(value.riskClass)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: `riskClass must be one of ${ISSUE_PROPOSAL_RISK_CLASSES.join(", ")}.`,
+    };
+  }
+  if (!isStopAt(value.stopAt)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: `stopAt must be one of ${ISSUE_PROPOSAL_STOP_AT_VALUES.join(", ")}.`,
+    };
+  }
+  if (
+    typeof value.estimatedChangedFiles !== "number" ||
+    !Number.isInteger(value.estimatedChangedFiles) ||
+    value.estimatedChangedFiles < 1 ||
+    value.estimatedChangedFiles > ISSUE_PROPOSAL_ESTIMATED_CHANGED_FILES_MAX
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage:
+        "estimatedChangedFiles must be an integer between 1 and 10000.",
+    };
+  }
+  if (!isProvenance(value.provenance)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage:
+        "provenance must bind roadmapId and a 64-character lowercase SHA-256 roadmapAuthorityFingerprint.",
+    };
+  }
+  if (value.metadata !== undefined && !isMetadata(value.metadata)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "metadata object is malformed.",
+    };
+  }
+
+  return {
+    ok: true,
+    proposal: {
+      schemaVersion: ISSUE_PROPOSAL_SCHEMA,
+      proposalId: value.proposalId,
+      roadmapNodeId: value.roadmapNodeId,
+      repository: value.repository,
+      title: value.title,
+      objective: value.objective,
+      dependsOn: value.dependsOn as string[],
+      allowedPaths: allowedParsed.paths,
+      forbiddenPaths: forbiddenParsed.paths,
+      acceptanceCriteria: value.acceptanceCriteria as string[],
+      verificationCommands:
+        value.verificationCommands as IssueProposalVerificationCommandV1[],
+      allowedCapabilities: value.allowedCapabilities as string[],
+      riskClass: value.riskClass,
+      stopAt: value.stopAt,
+      estimatedChangedFiles: value.estimatedChangedFiles,
+      provenance: value.provenance,
+      metadata: value.metadata as IssueProposalMetadataV1 | undefined,
+    },
+  };
+}
+
+/**
+ * Authority-bearing facts only.
+ * Excludes metadata (including observedAt).
+ * Path / dependency / capability / criterion lists are sorted so insertion
+ * order does not change the fingerprint.
+ */
+export function captureIssueProposalAuthorityFacts(
+  proposal: IssueProposalV1,
+): IssueProposalAuthorityFactsV1 {
+  const verificationCommands = [...proposal.verificationCommands]
+    .map(
+      (command): IssueProposalVerificationCommandAuthorityFactsV1 => ({
+        id: command.id,
+        command: command.command,
+        ...(command.workingDirectory !== undefined
+          ? { workingDirectory: normalizeRepoPath(command.workingDirectory) }
+          : {}),
+        ...(command.description !== undefined
+          ? { description: command.description }
+          : {}),
+      }),
+    )
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  return {
+    schemaVersion: proposal.schemaVersion,
+    proposalId: proposal.proposalId,
+    roadmapNodeId: proposal.roadmapNodeId,
+    repository: proposal.repository,
+    title: proposal.title,
+    objective: proposal.objective,
+    dependsOn: sortStringsStable(proposal.dependsOn),
+    allowedPaths: sortStringsStable(
+      proposal.allowedPaths.map(normalizeRepoPath),
+    ),
+    forbiddenPaths: sortStringsStable(
+      proposal.forbiddenPaths.map(normalizeRepoPath),
+    ),
+    acceptanceCriteria: sortStringsStable(proposal.acceptanceCriteria),
+    verificationCommands,
+    allowedCapabilities: sortStringsStable(proposal.allowedCapabilities),
+    riskClass: proposal.riskClass,
+    stopAt: proposal.stopAt,
+    estimatedChangedFiles: proposal.estimatedChangedFiles,
+    provenance: {
+      roadmapId: proposal.provenance.roadmapId,
+      roadmapAuthorityFingerprint:
+        proposal.provenance.roadmapAuthorityFingerprint,
+    },
+  };
+}
+
+/**
+ * Deterministic SHA-256 hex over canonical JSON of authority facts.
+ * metadata / observedAt never participate.
+ */
+export async function computeIssueProposalAuthorityFingerprint(
+  proposal: IssueProposalV1,
+): Promise<string> {
+  const facts = captureIssueProposalAuthorityFacts(proposal);
+  const canonical = canonicalJson(facts);
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonical),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function issueProposalAuthorityFingerprintsEqual(
+  a: string,
+  b: string,
+): boolean {
+  return a === b;
+}
+
+export interface ValidateIssueProposalOptions {
+  validatedAt?: string;
+  /**
+   * Validated RoadmapContractV1 used for exact roadmapId / fingerprint /
+   * roadmapNodeId binding. Required for semantic validation.
+   */
+  roadmapContract: RoadmapContractV1;
+  /**
+   * Validated ProjectContractV1 used for repository / risk / prohibited
+   * capability authority. Required for semantic validation.
+   */
+  projectContract: ProjectContractV1;
+}
+
+function buildValidationResult(input: {
+  proposalId: string | null;
+  roadmapNodeId: string | null;
+  status: IssueProposalValidationStatus;
+  reasonCode: string;
+  reasonMessage: string;
+  findings?: IssueProposalValidationFinding[];
+  authorityFingerprint?: string;
+  validatedAt: string;
+}): IssueProposalValidationResultV1 {
+  return {
+    schemaVersion: ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA,
+    proposalId: input.proposalId,
+    roadmapNodeId: input.roadmapNodeId,
+    status: input.status,
+    reasonCode: input.reasonCode,
+    reasonMessage: input.reasonMessage,
+    findings: input.findings,
+    authorityFingerprint: input.authorityFingerprint,
+    validatedAt: input.validatedAt,
+  };
+}
+
+/**
+ * Semantic proposal-local + Roadmap/Project binding validation.
+ * Never grants GitHub Issue mutation or Agent execution authority.
+ * Does not silently repair invalid proposal fields.
+ */
+export async function validateIssueProposalV1(
+  proposal: IssueProposalV1,
+  options: ValidateIssueProposalOptions,
+): Promise<IssueProposalValidationResultV1> {
+  const validatedAt = options.validatedAt ?? new Date(0).toISOString();
+  const findings: IssueProposalValidationFinding[] = [];
+  const authorityFingerprint =
+    await computeIssueProposalAuthorityFingerprint(proposal);
+  const roadmap = options.roadmapContract;
+  const project = options.projectContract;
+
+  if (proposal.provenance.roadmapId !== roadmap.roadmapId) {
+    findings.push({
+      path: "provenance.roadmapId",
+      code: "REJECTED_ROADMAP_BINDING",
+      message: `proposal.provenance.roadmapId (${proposal.provenance.roadmapId}) must equal RoadmapContract.roadmapId (${roadmap.roadmapId}).`,
+      severity: "ERROR",
+    });
+  }
+
+  const expectedRoadmapFp =
+    await computeRoadmapContractAuthorityFingerprint(roadmap);
+  if (proposal.provenance.roadmapAuthorityFingerprint !== expectedRoadmapFp) {
+    findings.push({
+      path: "provenance.roadmapAuthorityFingerprint",
+      code: "REJECTED_ROADMAP_BINDING",
+      message:
+        "proposal.provenance.roadmapAuthorityFingerprint does not match the provided RoadmapContractV1 authority fingerprint.",
+      severity: "ERROR",
+    });
+  }
+
+  const expectedProjectFp =
+    await computeProjectContractAuthorityFingerprint(project);
+  if (roadmap.projectId !== project.projectId) {
+    findings.push({
+      path: "roadmapContract.projectId",
+      code: "REJECTED_ROADMAP_BINDING",
+      message:
+        "supplied RoadmapContract.projectId must equal ProjectContract.projectId for proposal binding.",
+      severity: "ERROR",
+    });
+  }
+  if (roadmap.projectAuthorityFingerprint !== expectedProjectFp) {
+    findings.push({
+      path: "roadmapContract.projectAuthorityFingerprint",
+      code: "REJECTED_ROADMAP_BINDING",
+      message:
+        "supplied RoadmapContract.projectAuthorityFingerprint must match ProjectContractV1 authority fingerprint.",
+      severity: "ERROR",
+    });
+  }
+
+  const node = roadmap.nodes.find(
+    (candidate) => candidate.nodeId === proposal.roadmapNodeId,
+  );
+  if (!node) {
+    findings.push({
+      path: "roadmapNodeId",
+      code: "REJECTED_ROADMAP_NODE_BINDING",
+      message: `roadmapNodeId "${proposal.roadmapNodeId}" is not present in the supplied RoadmapContractV1.`,
+      severity: "ERROR",
+    });
+  } else if (
+    node.repository !== undefined &&
+    proposal.repository !== node.repository
+  ) {
+    findings.push({
+      path: "repository",
+      code: "REJECTED_REPOSITORY_BINDING",
+      message: `proposal.repository (${proposal.repository}) must equal bound RoadmapNode.repository (${node.repository}).`,
+      severity: "ERROR",
+    });
+  }
+
+  const allowedRepositories = new Set(
+    project.repositories.map((ref) => ref.repository),
+  );
+  if (!allowedRepositories.has(proposal.repository)) {
+    findings.push({
+      path: "repository",
+      code: "REJECTED_REPOSITORY_BINDING",
+      message: `proposal.repository "${proposal.repository}" is outside ProjectContractV1 repository authority.`,
+      severity: "ERROR",
+    });
+  }
+
+  if (proposal.dependsOn.includes(proposal.proposalId)) {
+    findings.push({
+      path: "dependsOn",
+      code: "REJECTED_DEPENDENCY",
+      message: `proposal "${proposal.proposalId}" depends on itself.`,
+      severity: "ERROR",
+    });
+  }
+
+  if (proposal.acceptanceCriteria.length < 1) {
+    findings.push({
+      path: "acceptanceCriteria",
+      code: "REJECTED_ACCEPTANCE_CRITERIA",
+      message: "acceptanceCriteria requires at least one entry.",
+      severity: "ERROR",
+    });
+  }
+
+  const pathConflicts = findPathBoundaryConflicts(
+    proposal.allowedPaths,
+    proposal.forbiddenPaths,
+  );
+  for (const conflict of pathConflicts) {
+    findings.push({
+      path: "allowedPaths/forbiddenPaths",
+      code: "REJECTED_PATH_CONFLICT",
+      message:
+        conflict.kind === "exact"
+          ? `Path "${conflict.path}" appears in both allowedPaths and forbiddenPaths.`
+          : `Path "${conflict.path}" overlaps forbidden path "${conflict.other}".`,
+      severity: "ERROR",
+    });
+  }
+
+  const prohibited = new Set(project.constraints.prohibitedCapabilities ?? []);
+  for (const capability of proposal.allowedCapabilities) {
+    if (prohibited.has(capability)) {
+      findings.push({
+        path: "allowedCapabilities",
+        code: "REJECTED_CAPABILITY",
+        message: `Capability "${capability}" is prohibited by ProjectContractV1 constraints.`,
+        severity: "ERROR",
+      });
+    }
+  }
+
+  const maxRisk = project.constraints.maxRiskClass;
+  if (
+    maxRisk !== undefined &&
+    riskClassRank(proposal.riskClass) > riskClassRank(maxRisk)
+  ) {
+    findings.push({
+      path: "riskClass",
+      code: "REJECTED_RISK_CLASS",
+      message: `proposal.riskClass (${proposal.riskClass}) exceeds ProjectContract maxRiskClass (${maxRisk}).`,
+      severity: "ERROR",
+    });
+  }
+
+  const hasErrors = findings.some((f) => f.severity === "ERROR");
+  if (hasErrors) {
+    return buildValidationResult({
+      proposalId: proposal.proposalId,
+      roadmapNodeId: proposal.roadmapNodeId,
+      status: "INVALID",
+      reasonCode: findings.find((f) => f.severity === "ERROR")!.code,
+      reasonMessage: findings
+        .filter((f) => f.severity === "ERROR")
+        .map((f) => f.message)
+        .join(" "),
+      findings,
+      authorityFingerprint,
+      validatedAt,
+    });
+  }
+
+  return buildValidationResult({
+    proposalId: proposal.proposalId,
+    roadmapNodeId: proposal.roadmapNodeId,
+    status: "VALID",
+    reasonCode: "VALID",
+    reasonMessage:
+      "Issue proposal passed structural, proposal-local, and Roadmap/Project binding validation. Validation does not grant GitHub Issue mutation or Agent execution authority.",
+    authorityFingerprint,
+    validatedAt,
+  });
+}
+
+/**
+ * Parse raw value → structural parse → semantic validation in one step.
+ * Malformed documents never throw.
+ */
+export async function parseAndValidateIssueProposalV1(
+  value: unknown,
+  options: ValidateIssueProposalOptions,
+): Promise<
+  | {
+      ok: true;
+      proposal: IssueProposalV1;
+      validation: IssueProposalValidationResultV1;
+    }
+  | {
+      ok: false;
+      proposal: IssueProposalV1 | null;
+      validation: IssueProposalValidationResultV1;
+    }
+> {
+  const validatedAt = options.validatedAt ?? new Date(0).toISOString();
+  const parsed = parseIssueProposalV1(value);
+  if (!parsed.ok) {
+    const proposalId =
+      isPlainObject(value) && typeof value.proposalId === "string"
+        ? value.proposalId
+        : null;
+    const roadmapNodeId =
+      isPlainObject(value) && typeof value.roadmapNodeId === "string"
+        ? value.roadmapNodeId
+        : null;
+    return {
+      ok: false,
+      proposal: null,
+      validation: buildValidationResult({
+        proposalId,
+        roadmapNodeId,
+        status: "INVALID",
+        reasonCode: parsed.reasonCode,
+        reasonMessage: parsed.reasonMessage,
+        validatedAt,
+      }),
+    };
+  }
+
+  const validation = await validateIssueProposalV1(parsed.proposal, options);
+  if (validation.status === "VALID") {
+    return { ok: true, proposal: parsed.proposal, validation };
+  }
+  return { ok: false, proposal: parsed.proposal, validation };
+}
+
+/**
+ * Structural parse for IssueProposalValidationResultV1 documents.
+ */
+export function parseIssueProposalValidationResult(
+  value: unknown,
+):
+  | { ok: true; result: IssueProposalValidationResultV1 }
+  | { ok: false; reasonCode: "REJECTED_SCHEMA"; reasonMessage: string } {
+  if (!isPlainObject(value)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Validation result must be a JSON object.",
+    };
+  }
+  if (!hasOnlyKeys(value, ISSUE_PROPOSAL_VALIDATION_RESULT_ROOT_KEYS)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage:
+        "Validation result contains unknown properties (additionalProperties forbidden).",
+    };
+  }
+  if (value.schemaVersion !== ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: `schemaVersion must be ${ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA}.`,
+    };
+  }
+  if (!Object.prototype.hasOwnProperty.call(value, "proposalId")) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "proposalId is required (use null when unknown).",
+    };
+  }
+  if (value.proposalId !== null && !isProposalId(value.proposalId)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "proposalId is malformed when present.",
+    };
+  }
+  if (!Object.prototype.hasOwnProperty.call(value, "roadmapNodeId")) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "roadmapNodeId is required (use null when unknown).",
+    };
+  }
+  if (value.roadmapNodeId !== null && !isNodeId(value.roadmapNodeId)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "roadmapNodeId is malformed when present.",
+    };
+  }
+  const status = value.status;
+  if (
+    status !== "VALID" &&
+    status !== "INVALID" &&
+    status !== "HOLD" &&
+    status !== "UNKNOWN"
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "status must be VALID, INVALID, HOLD, or UNKNOWN.",
+    };
+  }
+  if (
+    typeof value.reasonCode !== "string" ||
+    value.reasonCode.length < 1 ||
+    value.reasonCode.length > ISSUE_PROPOSAL_REASON_CODE_MAX
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "reasonCode is missing or malformed.",
+    };
+  }
+  if (
+    typeof value.reasonMessage !== "string" ||
+    value.reasonMessage.length < 1 ||
+    value.reasonMessage.length > ISSUE_PROPOSAL_REASON_MESSAGE_MAX
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "reasonMessage is missing or malformed.",
+    };
+  }
+  if (value.findings !== undefined) {
+    if (
+      !Array.isArray(value.findings) ||
+      value.findings.length > ISSUE_PROPOSAL_FINDINGS_MAX ||
+      !value.findings.every(
+        (finding) =>
+          isPlainObject(finding) &&
+          hasOnlyKeys(finding, ["path", "code", "message", "severity"]) &&
+          typeof finding.path === "string" &&
+          finding.path.length >= 1 &&
+          finding.path.length <= ISSUE_PROPOSAL_FINDING_PATH_MAX &&
+          typeof finding.code === "string" &&
+          finding.code.length >= 1 &&
+          finding.code.length <= ISSUE_PROPOSAL_FINDING_CODE_MAX &&
+          typeof finding.message === "string" &&
+          finding.message.length >= 1 &&
+          finding.message.length <= ISSUE_PROPOSAL_FINDING_MESSAGE_MAX &&
+          (finding.severity === "ERROR" || finding.severity === "WARNING"),
+      )
+    ) {
+      return {
+        ok: false,
+        reasonCode: "REJECTED_SCHEMA",
+        reasonMessage: "findings array is malformed.",
+      };
+    }
+  }
+  if (value.authorityFingerprint !== undefined) {
+    if (!isAuthorityFingerprint(value.authorityFingerprint)) {
+      return {
+        ok: false,
+        reasonCode: "REJECTED_SCHEMA",
+        reasonMessage:
+          "authorityFingerprint must be a 64-character lowercase SHA-256 hex string when present.",
+      };
+    }
+  }
+  if (typeof value.validatedAt !== "string" || value.validatedAt.length < 1) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "validatedAt is missing or malformed.",
+    };
+  }
+
+  return {
+    ok: true,
+    result: {
+      schemaVersion: ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA,
+      proposalId: value.proposalId as string | null,
+      roadmapNodeId: value.roadmapNodeId as string | null,
+      status,
+      reasonCode: value.reasonCode,
+      reasonMessage: value.reasonMessage,
+      findings: value.findings as IssueProposalValidationFinding[] | undefined,
+      authorityFingerprint: value.authorityFingerprint as string | undefined,
+      validatedAt: value.validatedAt,
+    },
+  };
+}
+
+/** Guard that planner / mutation / execution surfaces remain disabled. */
+export function assertIssueProposalSurfacesNotImplemented(): void {
+  if (
+    ISSUE_PROPOSAL_PLANNER_IMPLEMENTED ||
+    ISSUE_PROPOSAL_VALIDATOR_V1_IMPLEMENTED ||
+    ISSUE_PROPOSAL_SPLITTER_IMPLEMENTED ||
+    ISSUE_PROPOSAL_GITHUB_ISSUE_MUTATION_IMPLEMENTED ||
+    ISSUE_PROPOSAL_PUBLISHER_IMPLEMENTED ||
+    ISSUE_PROPOSAL_AGENT_EXECUTION_IMPLEMENTED ||
+    ISSUE_PROPOSAL_SCHEDULER_IMPLEMENTED
+  ) {
+    throw new Error(
+      "ISSUE-PROPOSAL-V1 planner/validator/publisher/agent/scheduler surfaces must remain NOT IMPLEMENTED in contract-only state",
+    );
+  }
+}

--- a/test/issueProposalContract.test.ts
+++ b/test/issueProposalContract.test.ts
@@ -1,0 +1,606 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  computeProjectContractAuthorityFingerprint,
+  parseProjectContractV1,
+  type ProjectContractV1,
+} from "../src/domain/projectContract";
+import {
+  computeRoadmapContractAuthorityFingerprint,
+  parseRoadmapContractV1,
+  type RoadmapContractV1,
+} from "../src/domain/roadmapContract";
+import {
+  ISSUE_PROPOSAL_AGENT_EXECUTION_IMPLEMENTED,
+  ISSUE_PROPOSAL_AUTHORITY_FINGERPRINT_KEYS,
+  ISSUE_PROPOSAL_GITHUB_ISSUE_MUTATION_IMPLEMENTED,
+  ISSUE_PROPOSAL_METADATA_KEYS,
+  ISSUE_PROPOSAL_PLANNER_IMPLEMENTED,
+  ISSUE_PROPOSAL_PUBLISHER_IMPLEMENTED,
+  ISSUE_PROPOSAL_RISK_CLASSES,
+  ISSUE_PROPOSAL_ROOT_KEYS,
+  ISSUE_PROPOSAL_SCHEDULER_IMPLEMENTED,
+  ISSUE_PROPOSAL_SCHEMA,
+  ISSUE_PROPOSAL_SPLITTER_IMPLEMENTED,
+  ISSUE_PROPOSAL_STOP_AT_VALUES,
+  ISSUE_PROPOSAL_VALIDATION_RESULT_ROOT_KEYS,
+  ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA,
+  ISSUE_PROPOSAL_VALIDATOR_V1_IMPLEMENTED,
+  assertIssueProposalSurfacesNotImplemented,
+  captureIssueProposalAuthorityFacts,
+  computeIssueProposalAuthorityFingerprint,
+  issueProposalAuthorityFingerprintsEqual,
+  parseAndValidateIssueProposalV1,
+  parseIssueProposalJsonBody,
+  parseIssueProposalV1,
+  parseIssueProposalValidationResult,
+  validateIssueProposalV1,
+  type IssueProposalV1,
+} from "../src/domain/issueProposalContract";
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../docs/issue-proposal/fixtures",
+);
+const schemasDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../docs/issue-proposal/schemas",
+);
+const projectFixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../docs/project-contract/fixtures",
+);
+const roadmapFixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../docs/roadmap-contract/fixtures",
+);
+
+const VALIDATED_AT = "2026-08-12T22:18:00.000Z";
+
+function loadFixture<T>(dir: string, name: string): T {
+  return JSON.parse(readFileSync(join(dir, name), "utf8")) as T;
+}
+
+function loadSchema(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(schemasDir, name), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function validProject(): ProjectContractV1 {
+  const parsed = parseProjectContractV1(
+    loadFixture<ProjectContractV1>(projectFixturesDir, "project-valid.json"),
+  );
+  if (!parsed.ok) throw new Error(parsed.reasonMessage);
+  return parsed.contract;
+}
+
+function validRoadmap(): RoadmapContractV1 {
+  const parsed = parseRoadmapContractV1(
+    loadFixture<RoadmapContractV1>(roadmapFixturesDir, "roadmap-valid.json"),
+  );
+  if (!parsed.ok) throw new Error(parsed.reasonMessage);
+  return parsed.roadmap;
+}
+
+function validProposal(): IssueProposalV1 {
+  return loadFixture<IssueProposalV1>(fixturesDir, "issue-proposal-valid.json");
+}
+
+describe("ISSUE-PROPOSAL-V1 / ISSUE-DECOMPOSER-CONTRACT-V1", () => {
+  it("keeps planner / validator / publisher / agent / scheduler surfaces unimplemented", () => {
+    expect(ISSUE_PROPOSAL_PLANNER_IMPLEMENTED).toBe(false);
+    expect(ISSUE_PROPOSAL_VALIDATOR_V1_IMPLEMENTED).toBe(false);
+    expect(ISSUE_PROPOSAL_SPLITTER_IMPLEMENTED).toBe(false);
+    expect(ISSUE_PROPOSAL_GITHUB_ISSUE_MUTATION_IMPLEMENTED).toBe(false);
+    expect(ISSUE_PROPOSAL_PUBLISHER_IMPLEMENTED).toBe(false);
+    expect(ISSUE_PROPOSAL_AGENT_EXECUTION_IMPLEMENTED).toBe(false);
+    expect(ISSUE_PROPOSAL_SCHEDULER_IMPLEMENTED).toBe(false);
+    assertIssueProposalSurfacesNotImplemented();
+  });
+
+  it("reserves risk and stopAt enums", () => {
+    expect(ISSUE_PROPOSAL_RISK_CLASSES).toEqual([
+      "R0",
+      "R1",
+      "R2",
+      "R3",
+      "R4",
+      "R5",
+    ]);
+    expect(ISSUE_PROPOSAL_STOP_AT_VALUES).toEqual([
+      "TASK_BUILT",
+      "AGENT_COMPLETE",
+      "VERIFY_COMPLETE",
+      "DRAFT_PR",
+    ]);
+  });
+
+  it("parses the valid fixture", () => {
+    expect(parseIssueProposalV1(validProposal()).ok).toBe(true);
+  });
+
+  it("valid fixture provenance fingerprint matches RoadmapContract fixture", async () => {
+    const roadmap = validRoadmap();
+    const proposal = validProposal();
+    const fp = await computeRoadmapContractAuthorityFingerprint(roadmap);
+    expect(proposal.provenance.roadmapId).toBe(roadmap.roadmapId);
+    expect(proposal.provenance.roadmapAuthorityFingerprint).toBe(fp);
+  });
+
+  it("validates the valid fixture as VALID with fingerprint", async () => {
+    const proposal = validProposal();
+    const parsed = parseIssueProposalV1(proposal);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const result = await validateIssueProposalV1(parsed.proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(result.status).toBe("VALID");
+    expect(result.schemaVersion).toBe(ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA);
+    expect(result.proposalId).toBe(proposal.proposalId);
+    expect(result.roadmapNodeId).toBe(proposal.roadmapNodeId);
+    expect(result.authorityFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.reasonMessage).toContain("does not grant GitHub Issue mutation");
+  });
+
+  it("parseAndValidateIssueProposalV1 succeeds for valid fixture", async () => {
+    const outcome = await parseAndValidateIssueProposalV1(validProposal(), {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.validation.status).toBe("VALID");
+  });
+
+  it("rejects malformed JSON syntax without throwing", () => {
+    expect(parseIssueProposalJsonBody("{")).toEqual({
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Issue proposal body is not valid JSON syntax.",
+    });
+  });
+
+  it("rejects non-string JSON body input without throwing", () => {
+    expect(parseIssueProposalJsonBody({})).toEqual({
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Issue proposal body must be a UTF-8 JSON string.",
+    });
+  });
+
+  it("rejects unknown root properties (additionalProperties:false)", () => {
+    const proposal = { ...validProposal(), extraField: true };
+    const parsed = parseIssueProposalV1(proposal);
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.reasonCode).toBe("REJECTED_SCHEMA");
+    expect(parsed.reasonMessage).toContain("unknown properties");
+  });
+
+  it("rejects missing required fields", () => {
+    const proposal = validProposal();
+    const { acceptanceCriteria: _removed, ...incomplete } = proposal;
+    expect(parseIssueProposalV1(incomplete).ok).toBe(false);
+  });
+
+  it("rejects wrong schemaVersion", () => {
+    const proposal = {
+      ...validProposal(),
+      schemaVersion: "ISSUE-PROPOSAL-V0",
+    };
+    const parsed = parseIssueProposalV1(proposal);
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.reasonMessage).toContain("ISSUE-PROPOSAL-V1");
+  });
+
+  it("rejects empty acceptanceCriteria at structural parse", () => {
+    const proposal = { ...validProposal(), acceptanceCriteria: [] };
+    const parsed = parseIssueProposalV1(proposal);
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.reasonMessage).toContain("acceptanceCriteria");
+  });
+
+  it("rejects duplicate path entries after trailing-slash normalization", () => {
+    const proposal = {
+      ...validProposal(),
+      allowedPaths: ["docs/issue-proposal", "docs/issue-proposal/"],
+    };
+    const parsed = parseIssueProposalV1(proposal);
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.reasonMessage).toContain("duplicate");
+  });
+
+  it("rejects duplicate capability entries", () => {
+    const proposal = {
+      ...validProposal(),
+      allowedCapabilities: ["workspace.read.v1", "workspace.read.v1"],
+    };
+    expect(parseIssueProposalV1(proposal).ok).toBe(false);
+  });
+
+  it("rejects malformed repository / capability / risk / stopAt", () => {
+    expect(
+      parseIssueProposalV1({
+        ...validProposal(),
+        repository: "not-a-repo",
+      }).ok,
+    ).toBe(false);
+    expect(
+      parseIssueProposalV1({
+        ...validProposal(),
+        allowedCapabilities: ["github.write"],
+      }).ok,
+    ).toBe(false);
+    expect(
+      parseIssueProposalV1({
+        ...validProposal(),
+        riskClass: "R9",
+      }).ok,
+    ).toBe(false);
+    expect(
+      parseIssueProposalV1({
+        ...validProposal(),
+        stopAt: "MERGE",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects overlapping allowedPaths / forbiddenPaths", async () => {
+    const proposal = {
+      ...validProposal(),
+      allowedPaths: ["docs/issue-proposal/"],
+      forbiddenPaths: ["docs/issue-proposal/secrets/"],
+    };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_PATH_CONFLICT");
+  });
+
+  it("rejects exact path conflict between allowed and forbidden", async () => {
+    const proposal = {
+      ...validProposal(),
+      allowedPaths: ["docs/issue-proposal/"],
+      forbiddenPaths: ["docs/issue-proposal"],
+    };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_PATH_CONFLICT");
+  });
+
+  it("rejects self-dependency", async () => {
+    const proposal = validProposal();
+    const outcome = await parseAndValidateIssueProposalV1(
+      { ...proposal, dependsOn: [proposal.proposalId] },
+      {
+        roadmapContract: validRoadmap(),
+        projectContract: validProject(),
+        validatedAt: VALIDATED_AT,
+      },
+    );
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_DEPENDENCY");
+  });
+
+  it("rejects missing roadmapNodeId binding", async () => {
+    const proposal = {
+      ...validProposal(),
+      roadmapNodeId: "node-does-not-exist",
+    };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe(
+      "REJECTED_ROADMAP_NODE_BINDING",
+    );
+  });
+
+  it("rejects stale roadmapAuthorityFingerprint", async () => {
+    const proposal = {
+      ...validProposal(),
+      provenance: {
+        ...validProposal().provenance,
+        roadmapAuthorityFingerprint:
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
+    };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_ROADMAP_BINDING");
+    expect(outcome.validation.reasonMessage).toContain(
+      "roadmapAuthorityFingerprint",
+    );
+  });
+
+  it("rejects repository outside ProjectContract authority", async () => {
+    const proposal = {
+      ...validProposal(),
+      repository: "yasutakesougo/not-in-project",
+    };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_REPOSITORY_BINDING");
+  });
+
+  it("rejects repository mismatch against bound RoadmapNode.repository", async () => {
+    const project = validProject();
+    // Add a second repository to Project so repository authority alone would pass.
+    const widenedProject: ProjectContractV1 = {
+      ...project,
+      repositories: [
+        ...project.repositories,
+        {
+          repository: "yasutakesougo/other-bound-repository",
+          role: "SECONDARY",
+        },
+      ],
+    };
+    const projectFp =
+      await computeProjectContractAuthorityFingerprint(widenedProject);
+    const roadmap: RoadmapContractV1 = {
+      ...validRoadmap(),
+      projectAuthorityFingerprint: projectFp,
+    };
+    const roadmapFp = await computeRoadmapContractAuthorityFingerprint(roadmap);
+    const proposal = {
+      ...validProposal(),
+      repository: "yasutakesougo/other-bound-repository",
+      provenance: {
+        roadmapId: roadmap.roadmapId,
+        roadmapAuthorityFingerprint: roadmapFp,
+      },
+    };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: roadmap,
+      projectContract: widenedProject,
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_REPOSITORY_BINDING");
+    expect(outcome.validation.reasonMessage).toContain("RoadmapNode.repository");
+  });
+
+  it("rejects ProjectContract prohibitedCapabilities", async () => {
+    const proposal = {
+      ...validProposal(),
+      allowedCapabilities: ["github.issue.create.v1"],
+    };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_CAPABILITY");
+    expect(outcome.validation.reasonMessage).toContain(
+      "github.issue.create.v1",
+    );
+  });
+
+  it("rejects riskClass above ProjectContract maxRiskClass", async () => {
+    const proposal = { ...validProposal(), riskClass: "R2" as const };
+    const outcome = await parseAndValidateIssueProposalV1(proposal, {
+      roadmapContract: validRoadmap(),
+      projectContract: validProject(),
+      validatedAt: VALIDATED_AT,
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.validation.reasonCode).toBe("REJECTED_RISK_CLASS");
+  });
+
+  it("authority fingerprint ignores metadata.observedAt", async () => {
+    const a = validProposal();
+    const b: IssueProposalV1 = {
+      ...validProposal(),
+      metadata: {
+        ...validProposal().metadata,
+        observedAt: "2099-01-01T00:00:00.000Z",
+        notes: ["different audit note"],
+      },
+    };
+    const fpA = await computeIssueProposalAuthorityFingerprint(a);
+    const fpB = await computeIssueProposalAuthorityFingerprint(b);
+    expect(fpA).toBe(fpB);
+    expect(issueProposalAuthorityFingerprintsEqual(fpA, fpB)).toBe(true);
+  });
+
+  it("authority fingerprint changes when objective changes", async () => {
+    const a = validProposal();
+    const b: IssueProposalV1 = {
+      ...validProposal(),
+      objective: "Different objective changes authority fingerprint",
+    };
+    const fpA = await computeIssueProposalAuthorityFingerprint(a);
+    const fpB = await computeIssueProposalAuthorityFingerprint(b);
+    expect(fpA).not.toBe(fpB);
+  });
+
+  it("authority fingerprint changes when acceptanceCriteria change", async () => {
+    const a = validProposal();
+    const b: IssueProposalV1 = {
+      ...a,
+      acceptanceCriteria: [
+        ...a.acceptanceCriteria,
+        "Additional authority-bearing acceptance criterion",
+      ],
+    };
+    const fpA = await computeIssueProposalAuthorityFingerprint(a);
+    const fpB = await computeIssueProposalAuthorityFingerprint(b);
+    expect(fpA).not.toBe(fpB);
+  });
+
+  it("authority fingerprint changes when roadmap provenance changes", async () => {
+    const a = validProposal();
+    const b: IssueProposalV1 = {
+      ...a,
+      provenance: {
+        ...a.provenance,
+        roadmapAuthorityFingerprint:
+          "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      },
+    };
+    const fpA = await computeIssueProposalAuthorityFingerprint(a);
+    const fpB = await computeIssueProposalAuthorityFingerprint(b);
+    expect(fpA).not.toBe(fpB);
+  });
+
+  it("captureIssueProposalAuthorityFacts excludes metadata and sorts lists", () => {
+    const facts = captureIssueProposalAuthorityFacts(validProposal());
+    expect(Object.keys(facts).sort()).toEqual(
+      [...ISSUE_PROPOSAL_AUTHORITY_FINGERPRINT_KEYS].sort(),
+    );
+    expect(Object.prototype.hasOwnProperty.call(facts, "metadata")).toBe(false);
+    expect(ISSUE_PROPOSAL_METADATA_KEYS).toContain("observedAt");
+    expect(facts.dependsOn).toEqual([...facts.dependsOn].sort());
+    expect(facts.allowedCapabilities).toEqual(
+      [...facts.allowedCapabilities].sort(),
+    );
+    expect(facts.acceptanceCriteria).toEqual(
+      [...facts.acceptanceCriteria].sort(),
+    );
+    const commandIds = facts.verificationCommands.map((command) => command.id);
+    expect(commandIds).toEqual([...commandIds].sort());
+  });
+
+  it("authority fingerprint is stable across key and list insertion order", async () => {
+    const proposal = validProposal();
+    const shuffled: IssueProposalV1 = {
+      metadata: proposal.metadata,
+      provenance: {
+        roadmapAuthorityFingerprint:
+          proposal.provenance.roadmapAuthorityFingerprint,
+        roadmapId: proposal.provenance.roadmapId,
+      },
+      estimatedChangedFiles: proposal.estimatedChangedFiles,
+      stopAt: proposal.stopAt,
+      riskClass: proposal.riskClass,
+      allowedCapabilities: [...proposal.allowedCapabilities].reverse(),
+      verificationCommands: [...proposal.verificationCommands].reverse(),
+      acceptanceCriteria: [...proposal.acceptanceCriteria].reverse(),
+      forbiddenPaths: [...proposal.forbiddenPaths].reverse(),
+      allowedPaths: [...proposal.allowedPaths].reverse(),
+      dependsOn: [...proposal.dependsOn].reverse(),
+      objective: proposal.objective,
+      title: proposal.title,
+      repository: proposal.repository,
+      roadmapNodeId: proposal.roadmapNodeId,
+      proposalId: proposal.proposalId,
+      schemaVersion: proposal.schemaVersion,
+    };
+    const fpA = await computeIssueProposalAuthorityFingerprint(proposal);
+    const fpB = await computeIssueProposalAuthorityFingerprint(shuffled);
+    expect(fpA).toBe(fpB);
+  });
+
+  it("parseAndValidate returns INVALID without fingerprint when structural parse fails", async () => {
+    const outcome = await parseAndValidateIssueProposalV1(
+      { schemaVersion: "ISSUE-PROPOSAL-V1" },
+      {
+        roadmapContract: validRoadmap(),
+        projectContract: validProject(),
+        validatedAt: VALIDATED_AT,
+      },
+    );
+    expect(outcome.ok).toBe(false);
+    expect(outcome.proposal).toBeNull();
+    expect(outcome.validation.authorityFingerprint).toBeUndefined();
+    expect(outcome.validation.reasonCode).toBe("REJECTED_SCHEMA");
+  });
+
+  it("parses a VALID validation result document", () => {
+    const result = {
+      schemaVersion: ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA,
+      proposalId: "proposal-62-issue-decomposer-contract-v1",
+      roadmapNodeId: "node-issue-decomposer-contract",
+      status: "VALID",
+      reasonCode: "VALID",
+      reasonMessage: "ok",
+      authorityFingerprint:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      validatedAt: VALIDATED_AT,
+    };
+    expect(parseIssueProposalValidationResult(result).ok).toBe(true);
+  });
+
+  it("rejects validation results with unknown properties", () => {
+    const parsed = parseIssueProposalValidationResult({
+      schemaVersion: ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA,
+      proposalId: null,
+      roadmapNodeId: null,
+      status: "INVALID",
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "bad",
+      validatedAt: VALIDATED_AT,
+      extra: true,
+    });
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("schema required keys align with runtime root keys", () => {
+    const schema = loadSchema("issue-proposal-v1.schema.json");
+    const required = schema.required as string[];
+    for (const key of required) {
+      expect(ISSUE_PROPOSAL_ROOT_KEYS).toContain(key);
+    }
+    expect(ISSUE_PROPOSAL_ROOT_KEYS).toContain("metadata");
+  });
+
+  it("validation-result schema required keys align with runtime", () => {
+    const schema = loadSchema(
+      "issue-proposal-validation-result-v1.schema.json",
+    );
+    const required = schema.required as string[];
+    for (const key of required) {
+      expect(ISSUE_PROPOSAL_VALIDATION_RESULT_ROOT_KEYS).toContain(key);
+    }
+    expect(schema.properties).toHaveProperty("authorityFingerprint");
+  });
+
+  it("schemaVersion constants match schema const values", () => {
+    const contractSchema = loadSchema("issue-proposal-v1.schema.json");
+    const resultSchema = loadSchema(
+      "issue-proposal-validation-result-v1.schema.json",
+    );
+    const contractProps = contractSchema.properties as Record<
+      string,
+      { const?: string }
+    >;
+    const resultProps = resultSchema.properties as Record<
+      string,
+      { const?: string }
+    >;
+    expect(contractProps.schemaVersion.const).toBe(ISSUE_PROPOSAL_SCHEMA);
+    expect(resultProps.schemaVersion.const).toBe(
+      ISSUE_PROPOSAL_VALIDATION_RESULT_SCHEMA,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#62 ISSUE-DECOMPOSER-CONTRACT-V1** as a contract-only `IssueProposalV1` slice on baseline `f1963021b51d09b73f4cb8f74864a18f513df552` (#61 complete).

Authorized boundary:

```text
validated RoadmapContractV1 / RoadmapNodeV1
→ IssueProposalV1 schema + TypeScript contract
→ structural parse
→ deterministic semantic validation
→ deterministic authority fingerprint
→ tests / docs / schema
→ npm run verify
→ Draft PR
→ Fresh Review
→ STOP
```

## Out of scope (fixed)

- LLM / Planner decomposer (`ISSUE-DECOMPOSER-V1` / #64)
- `ISSUE-VALIDATOR-V1` beyond proposal-local contract validation (#63)
- Issue splitting (`ISSUE-SPLITTER-V1` / #65)
- `github.issue.create.v1` capability grant
- `ISSUE-PUBLISHER-V1` / GitHub Issue mutation (#66)
- Agent execution / scheduler / dispatch
- Ready / Merge / IssueClose / Deploy automation

## What landed

| Artifact | Path |
|---|---|
| Domain contract | `src/domain/issueProposalContract.ts` |
| Tests | `test/issueProposalContract.test.ts` (36) |
| Docs | `docs/issue-proposal/issue-proposal-v1.md` |
| Schema | `docs/issue-proposal/schemas/*` |
| Fixture | `docs/issue-proposal/fixtures/issue-proposal-valid.json` |

### Contract highlights

- Exact `roadmapNodeId` + `provenance.roadmapAuthorityFingerprint` binding to RoadmapContractV1
- Required scope / acceptance / verification / capability / risk / stopAt / estimatedChangedFiles
- Fail-closed: unknown props, empty acceptance, path overlaps, duplicate entries, malformed repository/capability/risk/stopAt
- Repository must match bound RoadmapNode (when present) and stay within ProjectContract repository authority
- Project prohibitedCapabilities / maxRiskClass enforced
- Authority fingerprint excludes `metadata` / `observedAt`
- `VALID` result explicitly does **not** grant GitHub Issue mutation or Agent execution authority

## Verification

```text
npm run verify = PASS
tests = 804 PASS (includes 36 issueProposalContract)
typecheck = PASS
build = PASS
```

## Fresh Review

Independent checklist against #62 Implementation Start GO + Implementation Boundary:

| Item | Value |
|---|---|
| Draft PR | https://github.com/yasutakesougo/ai-development-control-center/pull/86 |
| Baseline | `f1963021b51d09b73f4cb8f74864a18f513df552` |
| Branch | `cursor/issue-proposal-contract-v1-2c87` |
| HEAD | `756039ad63815526ac9e30cae088baff58265ccd` |

Changed files:

```text
docs/issue-proposal/fixtures/issue-proposal-valid.json
docs/issue-proposal/issue-proposal-v1.md
docs/issue-proposal/schemas/issue-proposal-v1.schema.json
docs/issue-proposal/schemas/issue-proposal-validation-result-v1.schema.json
src/domain/issueProposalContract.ts
test/issueProposalContract.test.ts
```

Authorized path covered: schema/contract → parse → semantic validate → authority fingerprint → docs/tests → verify → Draft PR → Fresh Review.

Out-of-scope surfaces remain unimplemented:

```text
PLANNER / VALIDATOR-V1 / SPLITTER / GITHUB ISSUE MUTATION /
PUBLISHER / AGENT EXECUTION / SCHEDULER = false
```

**Fresh Review PASS for the authorized contract-only slice.**

## STOP

```text
Keep Draft. Do not Ready. Do not Merge. Do not close #62.
Do not start #63 / #64 without separate Human GO.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff80e-770f-7976-9f30-2b848cdc2c87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff80e-770f-7976-9f30-2b848cdc2c87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

