### PR TITLE
PERSONAL-WORKER-DEFINITION-V1 Slice A (#89)

### DIFF
--- a/docs/personal-worker-definition/fixtures/developer-valid.json
+++ b/docs/personal-worker-definition/fixtures/developer-valid.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "PERSONAL-WORKER-DEFINITION-V1",
+  "workerId": "developer-01",
+  "owner": "me",
+  "role": "DEVELOPER",
+  "lifecycle": "ACTIVE",
+  "autonomy": "A2_EXECUTE_APPROVED_ACTION",
+  "riskTier": "MEDIUM",
+  "service": "CHATGPT",
+  "model": "gpt-5.6",
+  "authority": {
+    "allow": [
+      {
+        "action": "repository.read",
+        "resource": "github:yasutakesougo/*"
+      },
+      {
+        "action": "worktree.write",
+        "resource": "local:*"
+      },
+      {
+        "action": "test.execute",
+        "resource": "local:*"
+      }
+    ],
+    "deny": [
+      {
+        "action": "secret.read",
+        "resource": "*"
+      },
+      {
+        "action": "deployment.execute",
+        "resource": "*"
+      }
+    ]
+  },
+  "humanGates": [
+    { "action": "repository.push" },
+    { "action": "pull_request.ready" },
+    { "action": "pull_request.merge" },
+    { "action": "external.send" },
+    { "action": "deployment.execute" }
+  ]
+}

--- a/src/domain/personalWorkerDefinition.ts
+++ b/src/domain/personalWorkerDefinition.ts
@@ -1,0 +1,392 @@
+/**
+ * PERSONAL-WORKER-DEFINITION-V1 contract helpers.
+ *
+ * Slice A only: parse + validate one local worker definition.
+ * No evaluator, Human approval execution, audit writer, Agent invocation,
+ * GitHub mutation, Ready/Merge automation, Deploy, or external send.
+ */
+
+export const PERSONAL_WORKER_DEFINITION_SCHEMA =
+  "PERSONAL-WORKER-DEFINITION-V1" as const;
+
+export const PERSONAL_WORKER_ROLES = [
+  "ORCHESTRATOR",
+  "DEVELOPER",
+  "REVIEWER",
+  "VERIFIER",
+] as const;
+
+export const PERSONAL_WORKER_LIFECYCLES = ["ACTIVE", "DISABLED"] as const;
+
+export const PERSONAL_AUTONOMY_LEVELS = [
+  "A0_OBSERVE",
+  "A1_PROPOSE",
+  "A2_EXECUTE_APPROVED_ACTION",
+  "A3_EXECUTE_APPROVED_SCOPE",
+  "A4_EXECUTE_BOUNDED",
+] as const;
+
+export const PERSONAL_RISK_TIERS = ["LOW", "MEDIUM", "HIGH"] as const;
+
+export const PERSONAL_WORKER_SERVICES = [
+  "CHATGPT",
+  "CURSOR",
+  "GITHUB_COPILOT",
+  "OPENCODE",
+  "CUSTOM",
+] as const;
+
+export const PERSONAL_WORKER_ID_MAX = 128 as const;
+export const PERSONAL_WORKER_OWNER_MAX = 128 as const;
+export const PERSONAL_WORKER_MODEL_MAX = 128 as const;
+export const PERSONAL_ACTION_ID_MAX = 128 as const;
+export const PERSONAL_RESOURCE_PATTERN_MAX = 512 as const;
+export const PERSONAL_AUTHORITY_RULES_MAX = 64 as const;
+export const PERSONAL_HUMAN_GATES_MAX = 64 as const;
+
+export const PERSONAL_WORKER_ROOT_KEYS = [
+  "schemaVersion",
+  "workerId",
+  "owner",
+  "role",
+  "lifecycle",
+  "autonomy",
+  "riskTier",
+  "service",
+  "model",
+  "authority",
+  "humanGates",
+] as const;
+
+export const PERSONAL_AUTHORITY_KEYS = ["allow", "deny"] as const;
+export const PERSONAL_AUTHORITY_RULE_KEYS = ["action", "resource"] as const;
+export const PERSONAL_HUMAN_GATE_RULE_KEYS = ["action", "resource"] as const;
+
+export const PERSONAL_WORKER_EVALUATOR_IMPLEMENTED = false as const;
+export const PERSONAL_HUMAN_GATE_EXECUTION_IMPLEMENTED = false as const;
+export const PERSONAL_AUDIT_WRITER_IMPLEMENTED = false as const;
+export const PERSONAL_EXTERNAL_EXECUTION_IMPLEMENTED = false as const;
+
+export type PersonalWorkerRoleV1 = (typeof PERSONAL_WORKER_ROLES)[number];
+export type PersonalWorkerLifecycleV1 =
+  (typeof PERSONAL_WORKER_LIFECYCLES)[number];
+export type PersonalAutonomyV1 = (typeof PERSONAL_AUTONOMY_LEVELS)[number];
+export type PersonalRiskTierV1 = (typeof PERSONAL_RISK_TIERS)[number];
+export type PersonalWorkerServiceV1 =
+  (typeof PERSONAL_WORKER_SERVICES)[number];
+
+export interface PersonalAuthorityRuleV1 {
+  action: string;
+  resource: string;
+}
+
+export interface PersonalHumanGateRuleV1 {
+  action: string;
+  resource?: string;
+}
+
+export interface PersonalWorkerDefinitionV1 {
+  schemaVersion: typeof PERSONAL_WORKER_DEFINITION_SCHEMA;
+  workerId: string;
+  owner: string;
+  role: PersonalWorkerRoleV1;
+  lifecycle: PersonalWorkerLifecycleV1;
+  autonomy: PersonalAutonomyV1;
+  riskTier: PersonalRiskTierV1;
+  service: PersonalWorkerServiceV1;
+  model?: string;
+  authority: {
+    allow: PersonalAuthorityRuleV1[];
+    deny: PersonalAuthorityRuleV1[];
+  };
+  humanGates: PersonalHumanGateRuleV1[];
+}
+
+const WORKER_ID_PATTERN = /^[a-z][a-z0-9._-]{0,127}$/;
+const ACTION_ID_PATTERN =
+  /^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$/;
+
+/**
+ * Broad authority shortcuts remain forbidden even when syntactically valid.
+ * Single-segment tool names such as github/shell/browser already fail grammar.
+ */
+const FORBIDDEN_ACTION_IDS = new Set(["agent.execute"]);
+
+/** Characters reserved for pattern languages that V1 intentionally does not support. */
+const UNSUPPORTED_RESOURCE_PATTERN_CHARS = /[?\[\]{}()^$+\\]/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function isBoundedString(value: unknown, min: number, max: number): value is string {
+  return typeof value === "string" && value.length >= min && value.length <= max;
+}
+
+function isOneOf<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+): value is T[number] {
+  return typeof value === "string" && allowed.includes(value);
+}
+
+export function isPersonalActionId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length >= 3 &&
+    value.length <= PERSONAL_ACTION_ID_MAX &&
+    ACTION_ID_PATTERN.test(value) &&
+    !FORBIDDEN_ACTION_IDS.has(value)
+  );
+}
+
+/**
+ * V1 supports only exact, one bounded terminal wildcard, or global `*`.
+ * No glob library semantics, regex, normalization, or case folding are implied.
+ */
+export function isPersonalResourcePattern(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > PERSONAL_RESOURCE_PATTERN_MAX
+  ) {
+    return false;
+  }
+
+  if (value === "*") return true;
+  if (UNSUPPORTED_RESOURCE_PATTERN_CHARS.test(value)) return false;
+
+  const firstStar = value.indexOf("*");
+  if (firstStar === -1) return true;
+
+  if (firstStar !== value.length - 1) return false;
+  if (value.indexOf("*", firstStar + 1) !== -1) return false;
+  if (value.length < 2) return false;
+
+  const beforeStar = value[value.length - 2];
+  return beforeStar === "/" || beforeStar === ":";
+}
+
+function isAuthorityRule(value: unknown): value is PersonalAuthorityRuleV1 {
+  if (!isPlainObject(value)) return false;
+  if (!hasOnlyKeys(value, PERSONAL_AUTHORITY_RULE_KEYS)) return false;
+  return isPersonalActionId(value.action) && isPersonalResourcePattern(value.resource);
+}
+
+function isHumanGateRule(value: unknown): value is PersonalHumanGateRuleV1 {
+  if (!isPlainObject(value)) return false;
+  if (!hasOnlyKeys(value, PERSONAL_HUMAN_GATE_RULE_KEYS)) return false;
+  if (!isPersonalActionId(value.action)) return false;
+  if (value.resource !== undefined && !isPersonalResourcePattern(value.resource)) {
+    return false;
+  }
+  return true;
+}
+
+function hasDuplicateAuthorityRules(values: PersonalAuthorityRuleV1[]): boolean {
+  const seen = new Set<string>();
+  for (const value of values) {
+    const key = `${value.action}\u0000${value.resource}`;
+    if (seen.has(key)) return true;
+    seen.add(key);
+  }
+  return false;
+}
+
+function hasDuplicateHumanGateRules(values: PersonalHumanGateRuleV1[]): boolean {
+  const seen = new Set<string>();
+  for (const value of values) {
+    const key = `${value.action}\u0000${value.resource ?? "<ALL_RESOURCES>"}`;
+    if (seen.has(key)) return true;
+    seen.add(key);
+  }
+  return false;
+}
+
+function parseAuthority(value: unknown):
+  | {
+      ok: true;
+      authority: PersonalWorkerDefinitionV1["authority"];
+    }
+  | { ok: false; reasonMessage: string } {
+  if (!isPlainObject(value) || !hasOnlyKeys(value, PERSONAL_AUTHORITY_KEYS)) {
+    return { ok: false, reasonMessage: "authority must contain only allow and deny." };
+  }
+
+  if (!Array.isArray(value.allow) || !Array.isArray(value.deny)) {
+    return { ok: false, reasonMessage: "authority.allow and authority.deny must be arrays." };
+  }
+
+  if (
+    value.allow.length > PERSONAL_AUTHORITY_RULES_MAX ||
+    value.deny.length > PERSONAL_AUTHORITY_RULES_MAX
+  ) {
+    return { ok: false, reasonMessage: "authority rule arrays exceed the V1 maximum." };
+  }
+
+  if (!value.allow.every(isAuthorityRule) || !value.deny.every(isAuthorityRule)) {
+    return { ok: false, reasonMessage: "authority contains a malformed rule." };
+  }
+
+  const allow = value.allow as PersonalAuthorityRuleV1[];
+  const deny = value.deny as PersonalAuthorityRuleV1[];
+
+  if (hasDuplicateAuthorityRules(allow) || hasDuplicateAuthorityRules(deny)) {
+    return { ok: false, reasonMessage: "authority contains duplicate rules." };
+  }
+
+  return { ok: true, authority: { allow, deny } };
+}
+
+function parseHumanGates(value: unknown):
+  | { ok: true; humanGates: PersonalHumanGateRuleV1[] }
+  | { ok: false; reasonMessage: string } {
+  if (!Array.isArray(value)) {
+    return { ok: false, reasonMessage: "humanGates must be an array." };
+  }
+  if (value.length > PERSONAL_HUMAN_GATES_MAX) {
+    return { ok: false, reasonMessage: "humanGates exceeds the V1 maximum." };
+  }
+  if (!value.every(isHumanGateRule)) {
+    return { ok: false, reasonMessage: "humanGates contains a malformed rule." };
+  }
+
+  const humanGates = value as PersonalHumanGateRuleV1[];
+  if (hasDuplicateHumanGateRules(humanGates)) {
+    return { ok: false, reasonMessage: "humanGates contains duplicate rules." };
+  }
+
+  return { ok: true, humanGates };
+}
+
+/** JSON text adapter. YAML may later parse to an object and call the same validator. */
+export function parsePersonalWorkerJsonBody(raw: unknown):
+  | { ok: true; value: unknown }
+  | { ok: false; reasonCode: "REJECTED_SCHEMA"; reasonMessage: string } {
+  if (typeof raw !== "string") {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Personal worker body must be a UTF-8 JSON string.",
+    };
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(raw) as unknown };
+  } catch {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Personal worker body is not valid JSON syntax.",
+    };
+  }
+}
+
+/**
+ * Structural fail-closed parser for the serialization-independent V1 object.
+ * It validates declarations only and grants zero execution authority.
+ */
+export function parsePersonalWorkerDefinitionV1(value: unknown):
+  | { ok: true; worker: PersonalWorkerDefinitionV1 }
+  | { ok: false; reasonCode: "REJECTED_SCHEMA"; reasonMessage: string } {
+  if (!isPlainObject(value)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Personal worker definition must be an object.",
+    };
+  }
+
+  if (!hasOnlyKeys(value, PERSONAL_WORKER_ROOT_KEYS)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "Personal worker definition contains unknown properties.",
+    };
+  }
+
+  if (value.schemaVersion !== PERSONAL_WORKER_DEFINITION_SCHEMA) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: `schemaVersion must be ${PERSONAL_WORKER_DEFINITION_SCHEMA}.`,
+    };
+  }
+
+  if (
+    typeof value.workerId !== "string" ||
+    !WORKER_ID_PATTERN.test(value.workerId)
+  ) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "workerId is missing or malformed.",
+    };
+  }
+
+  if (!isBoundedString(value.owner, 1, PERSONAL_WORKER_OWNER_MAX)) {
+    return {
+      ok: false,
+      reasonCode: "REJECTED_SCHEMA",
+      reasonMessage: "owner must be a non-empty bounded string.",
+    };
+  }
+
+  if (!isOneOf(value.role, PERSONAL_WORKER_ROLES)) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: "role is invalid." };
+  }
+  if (!isOneOf(value.lifecycle, PERSONAL_WORKER_LIFECYCLES)) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: "lifecycle is invalid." };
+  }
+  if (!isOneOf(value.autonomy, PERSONAL_AUTONOMY_LEVELS)) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: "autonomy is invalid." };
+  }
+  if (!isOneOf(value.riskTier, PERSONAL_RISK_TIERS)) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: "riskTier is invalid." };
+  }
+  if (!isOneOf(value.service, PERSONAL_WORKER_SERVICES)) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: "service is invalid." };
+  }
+
+  const model = value.model;
+  if (
+    model !== undefined &&
+    !isBoundedString(model, 1, PERSONAL_WORKER_MODEL_MAX)
+  ) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: "model is malformed." };
+  }
+
+  const authority = parseAuthority(value.authority);
+  if (authority.ok === false) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: authority.reasonMessage };
+  }
+
+  const humanGates = parseHumanGates(value.humanGates);
+  if (humanGates.ok === false) {
+    return { ok: false, reasonCode: "REJECTED_SCHEMA", reasonMessage: humanGates.reasonMessage };
+  }
+
+  return {
+    ok: true,
+    worker: {
+      schemaVersion: PERSONAL_WORKER_DEFINITION_SCHEMA,
+      workerId: value.workerId,
+      owner: value.owner,
+      role: value.role,
+      lifecycle: value.lifecycle,
+      autonomy: value.autonomy,
+      riskTier: value.riskTier,
+      service: value.service,
+      ...(model === undefined ? {} : { model }),
+      authority: authority.authority,
+      humanGates: humanGates.humanGates,
+    },
+  };
+}

--- a/src/domain/personalWorkerDefinition.ts
+++ b/src/domain/personalWorkerDefinition.ts
@@ -203,7 +203,7 @@ function hasDuplicateAuthorityRules(values: PersonalAuthorityRuleV1[]): boolean 
 function hasDuplicateHumanGateRules(values: PersonalHumanGateRuleV1[]): boolean {
   const seen = new Set<string>();
   for (const value of values) {
-    const key = `${value.action}\u0000${value.resource ?? "<ALL_RESOURCES>"}`;
+    const key = JSON.stringify([value.action, value.resource ?? null]);
     if (seen.has(key)) return true;
     seen.add(key);
   }

--- a/test/personalWorkerDefinition.test.ts
+++ b/test/personalWorkerDefinition.test.ts
@@ -197,6 +197,13 @@ describe("PERSONAL-WORKER-DEFINITION-V1", () => {
     const duplicateGate = validWorker();
     duplicateGate.humanGates.push({ ...duplicateGate.humanGates[0] });
     expect(parsePersonalWorkerDefinitionV1(duplicateGate).ok).toBe(false);
+
+    const sentinelCollision = validWorker();
+    sentinelCollision.humanGates = [
+      { action: "repository.push" },
+      { action: "repository.push", resource: "<ALL_RESOURCES>" },
+    ];
+    expect(parsePersonalWorkerDefinitionV1(sentinelCollision).ok).toBe(true);
   });
 
   it("enforces the V1 array bounds and permits empty declarations", () => {

--- a/test/personalWorkerDefinition.test.ts
+++ b/test/personalWorkerDefinition.test.ts
@@ -1,0 +1,216 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  PERSONAL_AUDIT_WRITER_IMPLEMENTED,
+  PERSONAL_AUTONOMY_LEVELS,
+  PERSONAL_EXTERNAL_EXECUTION_IMPLEMENTED,
+  PERSONAL_HUMAN_GATE_EXECUTION_IMPLEMENTED,
+  PERSONAL_RISK_TIERS,
+  PERSONAL_WORKER_DEFINITION_SCHEMA,
+  PERSONAL_WORKER_EVALUATOR_IMPLEMENTED,
+  PERSONAL_WORKER_LIFECYCLES,
+  PERSONAL_WORKER_ROLES,
+  PERSONAL_WORKER_SERVICES,
+  isPersonalActionId,
+  isPersonalResourcePattern,
+  parsePersonalWorkerDefinitionV1,
+  parsePersonalWorkerJsonBody,
+  type PersonalWorkerDefinitionV1,
+} from "../src/domain/personalWorkerDefinition";
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../docs/personal-worker-definition/fixtures",
+);
+
+function validWorker(): PersonalWorkerDefinitionV1 {
+  return JSON.parse(
+    readFileSync(join(fixturesDir, "developer-valid.json"), "utf8"),
+  ) as PersonalWorkerDefinitionV1;
+}
+
+describe("PERSONAL-WORKER-DEFINITION-V1", () => {
+  it("keeps evaluator, Human Gate execution, audit writer, and external execution out of Slice A", () => {
+    expect(PERSONAL_WORKER_EVALUATOR_IMPLEMENTED).toBe(false);
+    expect(PERSONAL_HUMAN_GATE_EXECUTION_IMPLEMENTED).toBe(false);
+    expect(PERSONAL_AUDIT_WRITER_IMPLEMENTED).toBe(false);
+    expect(PERSONAL_EXTERNAL_EXECUTION_IMPLEMENTED).toBe(false);
+  });
+
+  it("locks the small V1 enum vocabularies", () => {
+    expect(PERSONAL_WORKER_ROLES).toEqual([
+      "ORCHESTRATOR",
+      "DEVELOPER",
+      "REVIEWER",
+      "VERIFIER",
+    ]);
+    expect(PERSONAL_WORKER_LIFECYCLES).toEqual(["ACTIVE", "DISABLED"]);
+    expect(PERSONAL_AUTONOMY_LEVELS).toEqual([
+      "A0_OBSERVE",
+      "A1_PROPOSE",
+      "A2_EXECUTE_APPROVED_ACTION",
+      "A3_EXECUTE_APPROVED_SCOPE",
+      "A4_EXECUTE_BOUNDED",
+    ]);
+    expect(PERSONAL_RISK_TIERS).toEqual(["LOW", "MEDIUM", "HIGH"]);
+    expect(PERSONAL_WORKER_SERVICES).toEqual([
+      "CHATGPT",
+      "CURSOR",
+      "GITHUB_COPILOT",
+      "OPENCODE",
+      "CUSTOM",
+    ]);
+  });
+
+  it("parses the example fixture without granting runtime execution", () => {
+    const parsed = parsePersonalWorkerDefinitionV1(validWorker());
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    expect(parsed.worker.schemaVersion).toBe(PERSONAL_WORKER_DEFINITION_SCHEMA);
+    expect(parsed.worker.workerId).toBe("developer-01");
+    expect(parsed.worker.authority.allow).toHaveLength(3);
+    expect(parsed.worker.humanGates.map((gate) => gate.action)).toContain(
+      "pull_request.ready",
+    );
+  });
+
+  it("parses JSON text then validates the same object contract", () => {
+    const body = parsePersonalWorkerJsonBody(JSON.stringify(validWorker()));
+    expect(body.ok).toBe(true);
+    if (!body.ok) return;
+    expect(parsePersonalWorkerDefinitionV1(body.value).ok).toBe(true);
+
+    expect(parsePersonalWorkerJsonBody("{").ok).toBe(false);
+    expect(parsePersonalWorkerJsonBody({}).ok).toBe(false);
+  });
+
+  it("accepts the corrected action grammar and rejects broad authority shortcuts", () => {
+    expect(isPersonalActionId("repository.read")).toBe(true);
+    expect(isPersonalActionId("pull_request.ready")).toBe(true);
+    expect(isPersonalActionId("pull_request.merge")).toBe(true);
+    expect(isPersonalActionId("repository.branch-write")).toBe(true);
+
+    expect(isPersonalActionId("github")).toBe(false);
+    expect(isPersonalActionId("shell")).toBe(false);
+    expect(isPersonalActionId("browser")).toBe(false);
+    expect(isPersonalActionId("agent.execute")).toBe(false);
+    expect(isPersonalActionId("Repository.read")).toBe(false);
+    expect(isPersonalActionId("repository..read")).toBe(false);
+  });
+
+  it("supports only exact, bounded-prefix wildcard, and global resource forms", () => {
+    expect(
+      isPersonalResourcePattern(
+        "github:yasutakesougo/ai-development-control-center",
+      ),
+    ).toBe(true);
+    expect(isPersonalResourcePattern("github:yasutakesougo/*")).toBe(true);
+    expect(isPersonalResourcePattern("local:*")).toBe(true);
+    expect(isPersonalResourcePattern("*")).toBe(true);
+
+    expect(isPersonalResourcePattern("github:*repo")).toBe(false);
+    expect(isPersonalResourcePattern("github:**")).toBe(false);
+    expect(isPersonalResourcePattern("github:owner/repo*")).toBe(false);
+    expect(isPersonalResourcePattern("github:owner/?")).toBe(false);
+    expect(isPersonalResourcePattern("github:owner/[ab]")).toBe(false);
+  });
+
+  it("fails closed on unknown root and nested keys", () => {
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), extra: true }).ok).toBe(
+      false,
+    );
+
+    const authorityExtra = validWorker();
+    expect(
+      parsePersonalWorkerDefinitionV1({
+        ...authorityExtra,
+        authority: { ...authorityExtra.authority, extra: true },
+      }).ok,
+    ).toBe(false);
+
+    const ruleExtra = validWorker();
+    expect(
+      parsePersonalWorkerDefinitionV1({
+        ...ruleExtra,
+        authority: {
+          ...ruleExtra.authority,
+          allow: [
+            ...ruleExtra.authority.allow,
+            { action: "repository.read", resource: "local:*", extra: true },
+          ],
+        },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects malformed identities, enums, model values, actions, and resources", () => {
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), workerId: "Developer" }).ok).toBe(
+      false,
+    );
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), owner: "" }).ok).toBe(false);
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), role: "ADMIN" }).ok).toBe(false);
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), lifecycle: "UNKNOWN" }).ok).toBe(
+      false,
+    );
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), autonomy: "A5" }).ok).toBe(false);
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), riskTier: "CRITICAL" }).ok).toBe(
+      false,
+    );
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), service: "OTHER" }).ok).toBe(false);
+    expect(parsePersonalWorkerDefinitionV1({ ...validWorker(), model: "" }).ok).toBe(false);
+
+    const badRule = validWorker();
+    expect(
+      parsePersonalWorkerDefinitionV1({
+        ...badRule,
+        authority: {
+          ...badRule.authority,
+          allow: [{ action: "agent.execute", resource: "local:*" }],
+        },
+      }).ok,
+    ).toBe(false);
+
+    const badResource = validWorker();
+    expect(
+      parsePersonalWorkerDefinitionV1({
+        ...badResource,
+        authority: {
+          ...badResource.authority,
+          allow: [{ action: "repository.read", resource: "github:**" }],
+        },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects exact duplicates without silently deduplicating", () => {
+    const duplicateAllow = validWorker();
+    duplicateAllow.authority.allow.push({ ...duplicateAllow.authority.allow[0] });
+    expect(parsePersonalWorkerDefinitionV1(duplicateAllow).ok).toBe(false);
+
+    const duplicateDeny = validWorker();
+    duplicateDeny.authority.deny.push({ ...duplicateDeny.authority.deny[0] });
+    expect(parsePersonalWorkerDefinitionV1(duplicateDeny).ok).toBe(false);
+
+    const duplicateGate = validWorker();
+    duplicateGate.humanGates.push({ ...duplicateGate.humanGates[0] });
+    expect(parsePersonalWorkerDefinitionV1(duplicateGate).ok).toBe(false);
+  });
+
+  it("enforces the V1 array bounds and permits empty declarations", () => {
+    const empty = validWorker();
+    empty.authority.allow = [];
+    empty.authority.deny = [];
+    empty.humanGates = [];
+    expect(parsePersonalWorkerDefinitionV1(empty).ok).toBe(true);
+
+    const tooMany = validWorker();
+    tooMany.authority.allow = Array.from({ length: 65 }, (_, index) => ({
+      action: `repository.read_${index}`,
+      resource: "local:*",
+    }));
+    expect(parsePersonalWorkerDefinitionV1(tooMany).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Scope

Implements only Slice A authorized by Human `PERSONAL-WORKER-DEFINITION-V1 Implementation Start GO`.

- strict `PersonalWorkerDefinitionV1` parser / validator
- JSON text adapter into the same object validator
- bounded `action` and `resource` declaration validation
- duplicate / unknown-key / enum / bound fail-closed checks
- example developer worker fixture
- focused contract tests

## Definition Correction-2

Issue #89 records the action-grammar repair needed so `pull_request.ready` and `pull_request.merge` are valid declared actions. `agent.execute` remains explicitly rejected as a broad authority shortcut.

## Safety boundary

This PR does **not** implement:

- ALLOW / DENY / ASK evaluator
- Human approval execution
- audit writer
- LangGraph / CrewAI / OPA
- Agent Runner service invocation
- Action Gateway expansion
- GitHub product mutation
- Ready / Merge automation
- Deploy / external send / secret access

All implementation-surface constants for those later slices remain `false`.

## Verification so far

- standalone TypeScript strict compile of the new domain module: PASS
- executable parser/action/resource smoke assertions: PASS
- fixture JSON parse: PASS
- repository-wide `npm run verify`: delegated to PR CI / pending

## Changed files

```text
src/domain/personalWorkerDefinition.ts
test/personalWorkerDefinition.test.ts
docs/personal-worker-definition/fixtures/developer-valid.json
```

Draft only. Do not Ready or Merge without separate Human GO.