### PR TITLE
WAEP-PORTFOLIO-MAINTENANCE-MANAGER-V1 — Correction-2

### DIFF
--- a/src/domain/portfolioMaintenanceManager.ts
+++ b/src/domain/portfolioMaintenanceManager.ts
@@ -82,6 +82,11 @@ export interface AuthorityRequirement {
   state: "REQUIRED" | "UNKNOWN";
 }
 
+export interface StateSourceBinding {
+  observedStateSource: SourcePrecedence;
+  expectedOrReferencedStateSource?: SourcePrecedence;
+}
+
 export interface MaintenanceCandidate {
   candidateId: string;
   class: DetectionClass;
@@ -89,6 +94,7 @@ export interface MaintenanceCandidate {
   snapshot: ObservationSnapshot;
   observedState: Record<string, unknown>;
   expectedOrReferencedState: Record<string, unknown>;
+  stateSourceBinding: StateSourceBinding;
   decisionBasis: string;
   requiredEvidence: string[];
   evidenceRefs: EvidenceReference[];
@@ -123,7 +129,8 @@ export interface InconclusiveResult {
     | "REQUIRED_EVIDENCE_MISSING"
     | "REQUIRED_STATE_MISSING_OR_INVALID"
     | "SOURCE_CONFLICT_UNRESOLVED"
-    | "SOURCE_PRECEDENCE_INVALID";
+    | "SOURCE_PRECEDENCE_INVALID"
+    | "SOURCE_VALUE_BINDING_INVALID";
   missingEvidence: string[];
 }
 
@@ -149,6 +156,7 @@ export interface EvaluationInput {
   snapshot: ObservationSnapshot;
   observedState: Record<string, unknown>;
   expectedOrReferencedState: Record<string, unknown>;
+  stateSourceBinding?: StateSourceBinding;
   evidenceRefs: EvidenceReference[];
   sourcePrecedenceUsed: SourcePrecedence[];
   sourceConflictUnresolved?: boolean;
@@ -165,8 +173,25 @@ type EvidenceRule = {
 const evidenceIds = (input: EvaluationInput): Set<string> =>
   new Set(input.evidenceRefs.map((ref) => ref.id));
 
-const deepEqual = (left: unknown, right: unknown): boolean =>
-  JSON.stringify(left) === JSON.stringify(right);
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const deepEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) return true;
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+    return left.every((item, index) => deepEqual(item, right[index]));
+  }
+
+  if (!isRecord(left) || !isRecord(right)) return false;
+
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  if (leftKeys.length !== rightKeys.length) return false;
+  if (!leftKeys.every((key, index) => key === rightKeys[index])) return false;
+  return leftKeys.every((key) => deepEqual(left[key], right[key]));
+};
 
 const value = (record: Record<string, unknown>, key: string): unknown => record[key];
 
@@ -214,6 +239,24 @@ const hasValidSourcePrecedence = (sources: readonly SourcePrecedence[]): boolean
     previousIndex = index;
   }
   return true;
+};
+
+const hasValidSourceValueBinding = (input: EvaluationInput): boolean => {
+  const binding = input.stateSourceBinding;
+  if (!binding) return false;
+
+  if (!input.sourcePrecedenceUsed.includes(binding.observedStateSource)) return false;
+
+  if (input.class === "BROKEN_REFERENCE") {
+    return binding.expectedOrReferencedStateSource === undefined;
+  }
+
+  const expectedSource = binding.expectedOrReferencedStateSource;
+  if (!expectedSource || !input.sourcePrecedenceUsed.includes(expectedSource)) return false;
+
+  const observedIndex = SOURCE_PRECEDENCE.indexOf(binding.observedStateSource);
+  const expectedIndex = SOURCE_PRECEDENCE.indexOf(expectedSource);
+  return expectedIndex <= observedIndex;
 };
 
 const rules: Record<ImplementedDetectionClass, EvidenceRule> = {
@@ -296,6 +339,7 @@ export function evaluateMaintenance(input: EvaluationInput): EvaluationResult {
   }
 
   if (!hasValidSourcePrecedence(input.sourcePrecedenceUsed)) return hold(input.class, "SOURCE_PRECEDENCE_INVALID");
+  if (!hasValidSourceValueBinding(input)) return hold(input.class, "SOURCE_VALUE_BINDING_INVALID");
   if (input.sourceConflictUnresolved === true) return hold(input.class, "SOURCE_CONFLICT_UNRESOLVED");
 
   if (!rule.evaluate(input)) {
@@ -318,6 +362,7 @@ export function evaluateMaintenance(input: EvaluationInput): EvaluationResult {
       snapshot: input.snapshot,
       observedState: input.observedState,
       expectedOrReferencedState: input.expectedOrReferencedState,
+      stateSourceBinding: input.stateSourceBinding!,
       decisionBasis: rule.decisionBasis,
       requiredEvidence: [...rule.requiredEvidence],
       evidenceRefs: input.evidenceRefs,

--- a/test/portfolioMaintenanceManager.test.ts
+++ b/test/portfolioMaintenanceManager.test.ts
@@ -32,6 +32,10 @@ const base = (overrides: Partial<EvaluationInput>): EvaluationInput => ({
   snapshot,
   observedState: {},
   expectedOrReferencedState: {},
+  stateSourceBinding: {
+    observedStateSource: "Current Repository State",
+    expectedOrReferencedStateSource: "Current Repository State",
+  },
   evidenceRefs: [],
   sourcePrecedenceUsed: ["Current Repository State"],
   ...overrides,
@@ -99,6 +103,7 @@ describe("portfolio maintenance manager slice A", () => {
       base({
         class: "BROKEN_REFERENCE",
         observedState: { lookupCompleted: "yes", targetFound: false },
+        stateSourceBinding: { observedStateSource: "Current Repository State" },
         evidenceRefs: evidence("reference-identity", "deterministic-lookup"),
       }),
       base({
@@ -155,6 +160,105 @@ describe("portfolio maintenance manager slice A", () => {
     });
   });
 
+  it("treats object insertion order as canonically equal", () => {
+    const result = evaluateMaintenance(
+      base({
+        class: "STALE_STATE",
+        observedState: { state: { alpha: 1, nested: { left: true, right: false } } },
+        expectedOrReferencedState: { state: { nested: { right: false, left: true }, alpha: 1 } },
+        evidenceRefs: evidence("current-state-identity", "live-state", "mismatch-comparison"),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "NO_FINDING",
+      verificationState: "VERIFIED",
+      dispositionState: "DISMISSED",
+      reason: "DETECTION_CONDITION_NOT_MET",
+    });
+  });
+
+  it("fails closed when state values are not bound to source identities", () => {
+    const result = evaluateMaintenance(
+      base({
+        class: "STALE_STATE",
+        observedState: { state: "OPEN" },
+        expectedOrReferencedState: { state: "CLOSED" },
+        stateSourceBinding: undefined,
+        evidenceRefs: evidence("current-state-identity", "live-state", "mismatch-comparison"),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "INCONCLUSIVE",
+      reason: "SOURCE_VALUE_BINDING_INVALID",
+      dispositionState: "HOLD",
+      autoMutationAllowed: false,
+    });
+  });
+
+  it("fails closed when expected state comes from a lower-priority source", () => {
+    const result = evaluateMaintenance(
+      base({
+        class: "AUTHORITY_DRIFT",
+        observedState: { authority: "READY_GO" },
+        expectedOrReferencedState: { authority: "NOT_AUTHORIZED" },
+        sourcePrecedenceUsed: [
+          "Current Repository State",
+          "Historical Review / Correction Evidence",
+        ],
+        stateSourceBinding: {
+          observedStateSource: "Current Repository State",
+          expectedOrReferencedStateSource: "Historical Review / Correction Evidence",
+        },
+        evidenceRefs: evidence(
+          "authority-record-identity",
+          "gate-identity",
+          "current-authority-conflict",
+        ),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "INCONCLUSIVE",
+      reason: "SOURCE_VALUE_BINDING_INVALID",
+      dispositionState: "HOLD",
+      autoMutationAllowed: false,
+    });
+  });
+
+  it("accepts explicit binding when expected state is from an equal-or-higher priority source", () => {
+    const result = evaluateMaintenance(
+      base({
+        class: "AUTHORITY_DRIFT",
+        observedState: { authority: "READY_GO" },
+        expectedOrReferencedState: { authority: "NOT_AUTHORIZED" },
+        sourcePrecedenceUsed: [
+          "Current Authority / Current Decision",
+          "Historical Review / Correction Evidence",
+        ],
+        stateSourceBinding: {
+          observedStateSource: "Historical Review / Correction Evidence",
+          expectedOrReferencedStateSource: "Current Authority / Current Decision",
+        },
+        evidenceRefs: evidence(
+          "authority-record-identity",
+          "gate-identity",
+          "current-authority-conflict",
+        ),
+      }),
+    );
+
+    expect(result.kind).toBe("CANDIDATE");
+    if (result.kind === "CANDIDATE") {
+      expect(result.candidate.stateSourceBinding).toEqual({
+        observedStateSource: "Historical Review / Correction Evidence",
+        expectedOrReferencedStateSource: "Current Authority / Current Decision",
+      });
+      expect(result.candidate.autoMutationAllowed).toBe(false);
+    }
+  });
+
   it("creates a verified stale-state candidate without mutation authority", () => {
     const result = evaluateMaintenance(
       base({
@@ -185,6 +289,7 @@ describe("portfolio maintenance manager slice A", () => {
       base({
         class: "BROKEN_REFERENCE",
         observedState: { lookupCompleted: true, targetFound: true },
+        stateSourceBinding: { observedStateSource: "Current Repository State" },
         evidenceRefs: evidence("reference-identity", "deterministic-lookup"),
       }),
     );


### PR DESCRIPTION
## Purpose

Close the two validated remaining Slice A P2 findings.

## Authority

Human Implementation Start GO recorded in the current ChatGPT session for Correction-2.

Authorized scope only:
- P2-A deepEqual canonical equality
- P2-B source/value identity binding
- regression tests only
- no authority expansion
- no automatic mutation

Ready / Merge / Deploy / LIVE WRITE remain NOT AUTHORIZED.

## Scope

- replace JSON.stringify equality with insertion-order-independent recursive structural equality while preserving array order
- bind observed / expected-or-referenced state values to explicit SourcePrecedence identities
- fail closed with SOURCE_VALUE_BINDING_INVALID when binding is absent, inconsistent with declared precedence, or expected state comes from a lower-priority source
- preserve binding in emitted candidate evidence
- add regression coverage for canonical equality and source/value binding

## Gate

DRAFT ONLY

Next:
exact diff inspection → executable verification evidence → Independent Implementation Review.
