### PR TITLE
docs: add human understanding gate v1 templates

### DIFF
--- a/docs/human-understanding/definition-discovery-v1.md
+++ b/docs/human-understanding/definition-discovery-v1.md
@@ -1,0 +1,109 @@
+# Definition Discovery / Grilling V1
+
+## Purpose
+
+Provide an optional preparatory pattern for materially ambiguous work before finalizing the existing Issue / Definition authority surface.
+
+Definition Discovery is not an authorization Gate and does not create a second specification source.
+
+```text
+Discovery output -> existing Issue / Definition authority surface
+Discovery COMPLETE != Definition Lock
+Discovery COMPLETE != implementation authority
+```
+
+## When to use
+
+Use when one or more are true:
+
+```text
+materially ambiguous Human intent
+unsettled domain terminology
+multiple reasonable product behaviors
+material or hard-to-reverse Human trade-off
+repository evidence conflicts with requested behavior
+```
+
+`NOT_REQUIRED` is valid for work such as:
+
+```text
+trivial typo/docs-only correction
+formatter-only correction
+already-locked mechanical implementation
+small deterministic maintenance with no unresolved Human decision
+```
+
+## Evidence-first classification
+
+Inspect available repository evidence before asking the Human.
+
+Classify unresolved items as:
+
+```text
+FACT
+= repository/evidence can establish the answer
+
+DECISION
+= multiple acceptable choices exist and Human intent is required
+
+UNKNOWN
+= evidence is insufficient and no authorized decision has resolved it
+```
+
+Do not ask the Human for facts that can be established from repository evidence with reasonable confidence.
+
+`UNKNOWN` must remain UNKNOWN until evidence or Human authority resolves it.
+
+## Questioning behavior
+
+Ask unresolved Human decisions incrementally and in dependency order.
+
+A question may include:
+
+```text
+question
+recommended answer
+reason for recommendation
+material alternatives
+consequence of each alternative when relevant
+```
+
+A recommendation is advisory only and must not be recorded as the Human decision until accepted.
+
+## Artifact ownership boundary
+
+```text
+Issue / Definition
+= requirements and current work authority source
+
+CONTEXT.md, when present
+= glossary/domain terminology only
+= no current Gate state
+= no implementation specification
+= no current authority
+
+ADR, when present
+= durable hard decision with material trade-off or reversal cost
+= not Slice-local implementation detail
+
+conversation-only decision
+= allowed when it has no durable project significance
+```
+
+A Discovery artifact must not compete with the reviewed Definition as the requirement source of truth.
+
+## Minimum record
+
+```text
+unit
+repositoryEvidenceReferences
+resolvedFacts
+HumanDecisions
+preservedUnknowns
+explicitNonGoals
+result = COMPLETE | HOLD | NOT_REQUIRED
+```
+
+Discovery is complete when the future Definition can distinguish resolved facts, Human decisions, preserved UNKNOWNs, and explicit non-goals.
+
+Discovery does not require every future implementation detail to be known.

--- a/docs/human-understanding/finding-disposition-v1.md
+++ b/docs/human-understanding/finding-disposition-v1.md
@@ -1,0 +1,85 @@
+# Finding Disposition V1
+
+## Purpose
+
+Keep review severity separate from the decision about whether a finding belongs in the current Slice.
+
+Every material finding records both:
+
+```text
+severity
+disposition
+```
+
+## Required record
+
+```text
+findingId
+severity = P0 | P1 | P2 when that scale is used
+disposition = MUST_FIX | SHOULD_FIX | DEFER | REJECT
+scopeRequirementOrEvidenceLink
+rationale
+followUpReference when DEFER applies
+```
+
+## Dispositions
+
+### MUST_FIX
+
+Use for a demonstrated current-Slice defect such as:
+
+```text
+locked requirement violation
+incorrect behavior
+security boundary violation
+data corruption / loss risk
+authority or mutation-boundary violation
+acceptance criterion failure
+```
+
+A blocking MUST_FIX prevents review-clearance until corrected or the governing Definition is explicitly changed by Human authority.
+
+### SHOULD_FIX
+
+Use for a realistic current-Slice maintainability, usability, reliability, or clarity problem that is not a correctness or Authority blocker.
+
+The reviewer must state why it belongs in the current Slice.
+
+### DEFER
+
+Use when the concern is plausible but does not need resolution in the current Slice.
+
+DEFER does not block current review-clearance unless the governing Definition says otherwise.
+
+The finding remains auditable and should include a concise reason and follow-up reference when useful.
+
+### REJECT
+
+Use when the proposed correction is speculative, duplicative, outside locked scope, or would add more complexity than the demonstrated risk justifies.
+
+REJECT requires a concise rationale and must not erase the original finding.
+
+## Reviewer burden of proof
+
+A finding that forces current-Slice correction must identify at least one of:
+
+```text
+locked requirement affected
+acceptance criterion affected
+current implementation behavior affected
+current realistic failure path
+current authority/security boundary affected
+```
+
+A hypothetical future concern without one of these links defaults to DEFER or REJECT rather than automatic Correction.
+
+This rule must not weaken security, data-integrity, or explicit Authority findings.
+
+## Invariants
+
+```text
+severity != disposition
+high severity alone does not invent current-Slice scope
+DEFER / REJECT findings remain visible as evidence
+reviewer recommendation != Human authority
+```

--- a/docs/human-understanding/human-understanding-check-v1.md
+++ b/docs/human-understanding/human-understanding-check-v1.md
@@ -1,0 +1,90 @@
+# Human Understanding Check V1
+
+## Purpose
+
+Confirm that the Human operator can explain the current review-cleared Implementation Scope before implementation authority is granted.
+
+This check does not itself authorize implementation.
+
+```text
+Human Understanding PASS != Human Implementation Start GO
+```
+
+## Required record
+
+```text
+unit
+scopeReference
+scopeHeadOrFingerprint
+Q1 What will change?
+Q2 Why is the change needed?
+Q3 What is the exact boundary?
+Q4 What intentionally will not change?
+Q5 What observable result means success?
+result = PASS | HOLD
+checkedAt
+Human authority reference when applicable
+```
+
+## Human-readable Plan
+
+A compact plan may be derived from the reviewed Scope using only:
+
+```text
+Purpose
+Current behavior
+Behavior after change
+Changed area
+Explicit non-changes
+Key design decisions and reasons
+Primary Slice-relevant failure modes
+Acceptance criteria
+```
+
+The plan must not add requirements absent from the reviewed Scope.
+
+## PASS
+
+```text
+PASS
+= the Human can answer Q1-Q5 from the current reviewed Scope without relying on "the AI says it passed" as the explanation.
+```
+
+## HOLD
+
+```text
+HOLD
+= one or more answers are materially unclear, contradictory, or require unstated assumptions.
+```
+
+HOLD returns to Scope clarification and does not automatically require redesign.
+
+## Scope-binding and stale evidence
+
+Human Understanding evidence is bound to the exact reviewed Scope identified by:
+
+```text
+scopeReference
+scopeHeadOrFingerprint
+```
+
+If that reviewed Scope changes materially after PASS:
+
+```text
+prior Human-readable Plan = STALE
+prior Human Understanding PASS = STALE
+STALE evidence must not satisfy the pre-Implementation-Start check
+updated Scope must complete required Scope Review / Re-Review
+Human-readable Plan must be regenerated or re-read from the updated review-cleared Scope
+Q1-Q5 must be reconfirmed against that current Scope
+```
+
+A non-material metadata-only correction may preserve the prior check only when it does not change intended behavior, changed area, explicit non-changes, design decisions, failure modes, or acceptance criteria and the Scope reference/fingerprint semantics treat it as the same reviewed Scope.
+
+## Authority boundary
+
+```text
+Understanding PASS != implementation authority
+Understanding HOLD != architecture redesign requirement
+AI-generated summary != Human GO
+```


### PR DESCRIPTION
Implements Issue #128 within the review-cleared docs-only scope.

Changed surface:
- `docs/human-understanding/human-understanding-check-v1.md`
- `docs/human-understanding/finding-disposition-v1.md`
- `docs/human-understanding/definition-discovery-v1.md`

No runtime, UI, database, Worker, GitHub automation, package, workflow, cross-repository rollout, Ready, Merge, or Deploy changes.

Focused verification:
- exact allowlist: PASS
- Definition-to-template traceability: PASS
- second authority source introduced: NO
- runtime/source/config/workflow diff: NONE

Issue #128