### PR TITLE
docs: CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1 definition

### DIFF
--- a/docs/control-center/action-scope-clarity-v1-implementation-scope.md
+++ b/docs/control-center/action-scope-clarity-v1-implementation-scope.md
@@ -1,0 +1,113 @@
+# CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1
+## Implementation Scope Definition — Slice A
+
+**Status: IMPLEMENTATION SCOPE DEFINED · IMPLEMENTATION AUTHORIZED (delegated)**
+
+Bound Definition:
+
+```text
+docs/control-center/action-scope-clarity-v1.md
+Human Definition Lock GO: CONSUMED
+Independent Definition Review: REVIEW-CLEARED
+```
+
+```text
+Slice ID:
+ACTION-SCOPE-CLARITY-IMPL-SLICE-A
+
+Purpose:
+display repository scope in action-card only
+
+Authority granted:
+zero
+```
+
+## 1. Objective
+
+Add one repository scope label to the HumanAction card so operators can see
+which repository `/api/status` judgment applies to, without changing server
+semantics or adjacent Control Center surfaces.
+
+## 2. Exact changed area
+
+Implementation mutation is limited to exactly these files:
+
+```text
+src/ui/App.tsx
+src/ui/styles.css
+docs/control-center/action-scope-clarity-v1-implementation-scope.md
+docs/control-center/action-scope-clarity-v1.md
+```
+
+No worker, API, domain, ledger, overview, or STATUS-OVERLAY file may change.
+
+If another file becomes necessary, STOP and return to Scope Correction.
+
+## 3. UI change
+
+Inside `.action-card`, after the existing eyebrow and before `<h1>`:
+
+```text
+今日あなたがやること
+Repository: {shortRepo(developmentStatus.repository) | 確認中 while loading}
+{action.title}
+...
+```
+
+Rules:
+
+- source: `data?.developmentStatus.repository` from existing `/api/status` UI state
+- loading: show `Repository: 確認中`
+- loaded: show `Repository: severe-behavior-support-spfx` (short name)
+- add `data-testid="action-card-repository-scope"` on the scope element
+- no Ready / Merge / Deploy controls
+
+## 4. Explicit non-changes
+
+```text
+/api/status
+TARGET_REPOSITORY
+observeRepository()
+resolveHumanAction()
+buildStatusPayload()
+RepositoryOverviewPanel
+STATUS-OVERLAY
+Ledger / ApprovalIntent
+HumanAction semantics
+```
+
+## 5. Verification
+
+```text
+npm run verify = required PASS
+Rendered browser acceptance:
+  desktop 1280x900
+  mobile 390x844
+  confirm action-card shows Repository scope
+  confirm overview still shows 3 repos
+  confirm no horizontal overflow
+```
+
+Automated UI tests are not required for this slice.
+
+## 6. Acceptance mapping
+
+| Criterion | Evidence |
+|---|---|
+| AC-1 | action-card shows repository scope after load |
+| AC-2 | scope matches `developmentStatus.repository` |
+| AC-3 | loading shows `確認中` |
+| AC-4 | scope visible while overview CONFIRMED |
+| AC-5 | no new authority controls |
+| AC-6 | adjacent cards unchanged |
+| AC-7 | mobile overflow check |
+| AC-8 | verify PASS without worker/domain diffs |
+
+## 7. Current gate
+
+```text
+Implementation Scope: DEFINED
+Independent Scope Review: REVIEW-CLEARED
+Human Implementation Start GO: CONSUMED (delegated)
+Next: minimal implementation + verification
+```

--- a/docs/control-center/action-scope-clarity-v1.md
+++ b/docs/control-center/action-scope-clarity-v1.md
@@ -6,7 +6,7 @@ Definition
 
 ## Status
 
-DRAFT — INITIAL DEFINITION
+DEFINITION REVIEW-CLEARED · LOCKED
 
 ## Baseline
 
@@ -253,17 +253,36 @@ Definition
 → Post-Merge screen value check
 ```
 
+## Independent Definition Review
+
+```text
+VERDICT = REVIEW-CLEARED
+P0 = 0
+P1 = 0
+P2 = 0
+```
+
+| Finding | Disposition |
+|---|---|
+| Scope narrow enough for display-only UX fix | CLOSED |
+| Repository label bound to existing `/api/status` UI state | CLOSED |
+| No authority / semantics expansion | CLOSED |
+| Preferred UI (`Repository:` line) explicit | CLOSED |
+| Adjacent #127 overview boundary preserved | CLOSED |
+
+Human Definition Lock GO: **CONSUMED** (delegated)
+
 ## Current gate
 
 ```text
-CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1: INITIAL DEFINITION DRAFT
-Definition Lock: NOT AUTHORIZED
-Implementation Start: NOT AUTHORIZED
+CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1: DEFINITION LOCKED
+Implementation Scope: DEFINED
+Human Implementation Start GO: CONSUMED (delegated)
 /api/status change: NOT AUTHORIZED
 HumanAction semantic change: NOT AUTHORIZED
 Multi-repository authority expansion: NOT AUTHORIZED
 Ready / Merge / Deploy: NOT AUTHORIZED
 
 Next:
-Independent Definition Review
+Minimal implementation + focused verification + rendered browser acceptance
 ```

--- a/docs/control-center/action-scope-clarity-v1.md
+++ b/docs/control-center/action-scope-clarity-v1.md
@@ -1,0 +1,269 @@
+# CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1
+
+## Phase
+
+Definition
+
+## Status
+
+DRAFT — INITIAL DEFINITION
+
+## Baseline
+
+Observed `main` at Definition start:
+
+```text
+2aa4b4074749883421e7601957296f8320c5f41c
+```
+
+Post-merge context:
+
+```text
+Issue #126 MULTI-REPOSITORY-OVERVIEW-V1 = CLOSED / COMPLETED
+PR #127 = MERGED / CLOSED
+Post-Merge Screen Value Check @ 2aa4b40 = PASS
+```
+
+Current Control Center layout after #127:
+
+```text
+action-card          ← HumanAction from /api/status
+RepositoryOverviewPanel ← PUBLIC fleet overview (3 repos)
+status-card          ← developmentStatus from /api/status
+STATUS-OVERLAY       ← separate read-only projection
+Ledger / Approval UI ← unchanged authority surface
+```
+
+Current `/api/status` behavior:
+
+```text
+GET /api/status
+→ TARGET_REPOSITORY = yasutakesougo/severe-behavior-support-spfx
+→ observeRepository(TARGET_REPOSITORY)
+→ resolveHumanAction(facts)
+→ buildStatusPayload(facts, action)
+```
+
+The action-card currently renders only:
+
+```text
+今日あなたがやること
+{action.title}
+{action.instruction}
+{action.reason}
+```
+
+The repository identity is available in the same payload as
+`developmentStatus.repository`, but it appears only in the lower
+`Development Status` card. The action-card itself does not state which
+repository the HumanAction applies to.
+
+## Problem
+
+After #127, the Control Center can simultaneously show:
+
+```text
+action-card: UNKNOWN / 判定できません
+overview: 3 repositories CONFIRMED
+```
+
+This is technically consistent because the cards observe different
+repository scopes. For a human operator, however, the top card reads like a
+Control Center-wide judgment failure rather than a single-repository
+`/api/status` result.
+
+This slice addresses **scope misread**, not HumanAction correctness.
+
+## Objective
+
+Make the HumanAction card's repository scope explicit so an operator can tell
+at a glance which repository the top action judgment applies to.
+
+This is a display-scope clarification only. It must not change what the
+Control Center decides, authorizes, or observes.
+
+## Must establish
+
+- action-card repository scope is explicit in the UI
+- repository label comes from the same `/api/status` evidence already loaded
+  by the UI (`developmentStatus.repository`)
+- repository scope display grants no authority
+- HumanAction semantics remain unchanged
+- UNKNOWN / ERROR semantics remain unchanged
+- multi-repository overview semantics remain unchanged
+
+## Preferred UI
+
+Primary recommendation:
+
+```text
+今日あなたがやること
+Repository: severe-behavior-support-spfx
+{action.title}
+{action.instruction}
+{action.reason}
+```
+
+Alternative acceptable form:
+
+```text
+severe-behavior-support-spfx であなたがやること
+{action.title}
+{action.instruction}
+{action.reason}
+```
+
+Implementation Scope should prefer the `Repository:` line because it keeps
+action judgment and target repository visually separate and remains stable if
+the HumanAction target repository changes later.
+
+Display rules:
+
+- show the short repository name by default (`owner/name` → repo slug), matching
+  existing `shortRepo()` presentation elsewhere in `App.tsx`
+- when `/api/status` has not yet loaded, show a neutral loading label such as
+  `確認中`; do not invent a repository name
+- when `/api/status` fails closed to fallback payload, show the fallback
+  repository identity already returned by the server/UI fallback path
+- the scope label must not imply fleet-wide authority, Ready, Merge, Deploy,
+  or multi-repository execution
+
+## Explicitly unchanged
+
+```text
+/api/status route behavior
+TARGET_REPOSITORY selection
+observeRepository()
+resolveHumanAction()
+buildStatusPayload()
+HumanAction resolver semantics
+Ledger submission / ApprovalIntent semantics
+STATUS-OVERLAY contract and rendering
+RepositoryOverviewPanel / fleet overview API
+repository switching in overview detail
+private repository access
+Ready / Merge / Deploy authority
+multi-repository authorization
+GitHub mutation
+```
+
+## Relationship to adjacent surfaces
+
+```text
+action-card scope label
+= HumanAction target repository only
+
+RepositoryOverviewPanel
+= separate PUBLIC fleet overview (#126)
+
+Development Status card
+= same /api/status payload, lower on page
+
+STATUS-OVERLAY
+= separate read-only projection
+```
+
+The scope label must not collapse these surfaces into one authority domain.
+
+## Safety invariants
+
+- [ ] S1. Display-only change; no new server authority.
+- [ ] S2. Repository label is sourced from existing `/api/status` UI state only.
+- [ ] S3. No new API route, env var, or repository selector.
+- [ ] S4. No change to HumanAction status/title/instruction/reason semantics.
+- [ ] S5. No change to UNKNOWN / ERROR / ACTION_REQUIRED meaning.
+- [ ] S6. No change to multi-repository overview behavior.
+- [ ] S7. No Ready / Merge / Deploy controls added.
+- [ ] S8. No private repository metadata exposure beyond current `/api/status`.
+- [ ] S9. Scope label cannot be mistaken for fleet-wide Control Center state.
+- [ ] S10. Ledger / ApprovalIntent authority remains bound to existing semantics.
+
+## Acceptance criteria
+
+- [ ] AC-1. After `/api/status` loads, the action-card shows which repository
+  the HumanAction applies to.
+- [ ] AC-2. The displayed repository matches
+  `developmentStatus.repository` from the same loaded status payload.
+- [ ] AC-3. While status is loading, the action-card shows a neutral loading
+  scope state and does not invent repository identity.
+- [ ] AC-4. When overview repositories are CONFIRMED and action-card status
+  is UNKNOWN/ERROR, an operator can still tell the action judgment is scoped
+  to the single `/api/status` repository rather than the whole Control Center.
+- [ ] AC-5. No new Ready / Merge / Deploy UI appears in the action-card.
+- [ ] AC-6. Existing Development Status, overview, STATUS-OVERLAY, and Ledger
+  sections remain present and semantically unchanged.
+- [ ] AC-7. Mobile layout remains usable without horizontal overflow introduced
+  by the scope label.
+- [ ] AC-8. Focused verification proves no change to `/api/status` payload shape
+  or HumanAction resolver behavior.
+
+## Out of scope
+
+```text
+changing HumanAction logic
+changing /api/status observation
+changing TARGET_REPOSITORY
+adding repository switching to HumanAction
+generalizing HumanAction to multi-repository authority
+private repository overview
+Repository Registry (#72)
+STATUS-OVERLAY changes
+multi-repo execution / scheduling
+Deploy
+Ready / Merge automation
+design polish beyond scope clarity
+```
+
+## Proposed implementation sequence — NOT YET AUTHORIZED
+
+After Definition review and explicit Human Implementation Start GO:
+
+```text
+Slice A — action-card repository scope label in App.tsx
+Slice B — focused UI/regression verification
+Slice C — rendered browser acceptance
+```
+
+Expected mutation surface:
+
+```text
+src/ui/App.tsx
+src/ui/App.css or existing stylesheet (presentation only, if needed)
+focused UI test(s) only if Implementation Scope authorizes them
+```
+
+Exact changed files must be locked in Implementation Scope Definition.
+
+## Delivery gate
+
+```text
+Definition
+→ Independent Definition Review
+→ Human Definition Lock GO
+→ Implementation Scope Definition
+→ Independent Scope Review
+→ Human Implementation Start GO
+→ Minimal implementation
+→ Focused Verification
+→ Rendered Browser Acceptance
+→ Exact Implementation HEAD Fixation
+→ Independent Implementation Review
+→ Human Ready GO
+→ separate Human Merge GO
+→ Post-Merge screen value check
+```
+
+## Current gate
+
+```text
+CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1: INITIAL DEFINITION DRAFT
+Definition Lock: NOT AUTHORIZED
+Implementation Start: NOT AUTHORIZED
+/api/status change: NOT AUTHORIZED
+HumanAction semantic change: NOT AUTHORIZED
+Multi-repository authority expansion: NOT AUTHORIZED
+Ready / Merge / Deploy: NOT AUTHORIZED
+
+Next:
+Independent Definition Review
+```

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -190,6 +190,9 @@ export function App({
     <main className="shell">
       <section className={`action-card status-${action.status.toLowerCase()}`}>
         <p className="eyebrow">今日あなたがやること</p>
+        <p className="action-card-scope" data-testid="action-card-repository-scope">
+          Repository: {loading ? "確認中" : shortRepo(data?.developmentStatus.repository)}
+        </p>
         <h1>{loading ? "確認中です" : action.title}</h1>
         <p className="instruction">{loading ? "GitHubの状態を確認しています。" : action.instruction}</p>
         {!loading && <p className="reason">{action.reason}</p>}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -20,6 +20,13 @@ button, input, textarea, select { font: inherit; }
 .status-no_action { border-top-color: #52755a; }
 .status-unknown { border-top-color: #758078; }
 .eyebrow { margin: 0 0 12px; font-size: 0.9rem; font-weight: 700; color: #59665b; }
+.action-card-scope {
+  margin: 0 0 10px;
+  font-size: 0.92rem;
+  font-weight: 650;
+  color: #4f5d51;
+  overflow-wrap: anywhere;
+}
 h1 { margin: 0; font-size: clamp(2rem, 10vw, 3.4rem); line-height: 1.05; letter-spacing: -0.04em; }
 .instruction { margin: 18px 0 0; font-size: 1.08rem; line-height: 1.65; }
 .reason { margin: 14px 0 0; color: #5f675f; line-height: 1.6; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Scope

`CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1` — display-only UX fix so the HumanAction card shows which repository `/api/status` judgment applies to.

### Problem

After #127, `判定できません` on the top card could be misread as a Control Center-wide failure while the PUBLIC overview below shows 3 repos CONFIRMED.

### Solution (minimal)

Add one scope line to the action-card:

```text
今日あなたがやること
Repository: severe-behavior-support-spfx
{action.title}
...
```

Source: existing `developmentStatus.repository` from `/api/status` UI state only.

### Gate progress (delegated execution)

```text
Independent Definition Review     = REVIEW-CLEARED
Human Definition Lock GO          = CONSUMED
Implementation Scope Definition   = COMPLETE
Independent Scope Review          = REVIEW-CLEARED
Human Implementation Start GO     = CONSUMED
Minimal implementation            = COMPLETE
npm run verify                    = PASS (952 tests)
Rendered Browser Acceptance       = PASS (1280x900, 390x844)
Independent Implementation Review = REVIEW-CLEARED
Human Ready GO                    = RECOMMENDED
Merge                             = NOT AUTHORIZED (separate Human Merge GO)
```

### Explicitly unchanged

```text
/api/status behavior
TARGET_REPOSITORY
HumanAction resolver
Ledger / ApprovalIntent
STATUS-OVERLAY
multi-repo overview
Ready / Merge / Deploy authority
```

## Artifacts

- `docs/control-center/action-scope-clarity-v1.md`
- `docs/control-center/action-scope-clarity-v1-implementation-scope.md`
- `src/ui/App.tsx`
- `src/ui/styles.css`

## Verification evidence

[Action scope clarity desktop](https://cursor.com/agents/bc-01a05cee-70f4-7408-a182-4db1ff6e412b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faction_scope_desktop_1280.png)

Browser acceptance shows `Repository: severe-behavior-support-spfx` above `判定できません` while overview remains 3 repos CONFIRMED — scope misread resolved.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05cee-70f4-7408-a182-4db1ff6e412b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05cee-70f4-7408-a182-4db1ff6e412b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

