### PR TITLE
feat(domain): MAC Slice C shared-state binding validation

### DIFF
--- a/src/domain/multiAgentCoordination.ts
+++ b/src/domain/multiAgentCoordination.ts
@@ -97,6 +97,7 @@ const EVIDENCE_BINDING_KEYS = [
   "evidenceDigest",
   "ownerScope",
   "coordinationId",
+  "coordinationPlanFingerprint",
   "taskId",
   "kind",
   "sourceId",
@@ -280,6 +281,7 @@ export interface CoordinationEvidenceBindingV1 {
   evidenceDigest: string;
   ownerScope: CoordinationEvidenceOwnerScopeV1;
   coordinationId: string;
+  coordinationPlanFingerprint: string;
   taskId: string | null;
   kind: CoordinationEvidenceKindV1;
   sourceId: string;
@@ -1165,7 +1167,9 @@ const LIFECYCLE_MATRIX: Record<CoordinationProgressionStatusV1, LifecycleMatrixR
     workerId: "R",
     workerAuthorityFingerprint: "R",
     routingDecisionFingerprint: "R",
-    executionAuthorizationRef: "R",
+    // Base matrix allows null|present; reason-stage rules below distinguish
+    // READY_FOR_AUTHORIZATION (MUST_BE_NULL) from AUTHORIZED_NOT_INVOKED (REQUIRED).
+    executionAuthorizationRef: "O",
     executionAttemptId: "N",
     executionOutcomeRef: "N",
     resultValidationRef: "N",
@@ -1291,6 +1295,7 @@ function evidenceBindingIdentityTuple(
     binding.ref,
     binding.ownerScope,
     binding.coordinationId,
+    binding.coordinationPlanFingerprint,
     binding.taskId,
     binding.kind,
     binding.sourceId,
@@ -1307,6 +1312,7 @@ function evidenceOwnerIdentityTuple(binding: CoordinationEvidenceBindingV1): str
   return JSON.stringify([
     binding.ownerScope,
     binding.coordinationId,
+    binding.coordinationPlanFingerprint,
     binding.taskId,
     binding.kind,
     binding.sourceId,
@@ -1324,6 +1330,7 @@ export function parseCoordinationEvidenceBindingV1(
     !isFingerprint(raw.evidenceDigest) ||
     (raw.ownerScope !== "COORDINATION" && raw.ownerScope !== "TASK") ||
     !isLocalId(raw.coordinationId) ||
+    !isFingerprint(raw.coordinationPlanFingerprint) ||
     (raw.taskId !== null && !isAgentTaskId(raw.taskId)) ||
     (raw.kind !== "EVIDENCE" && raw.kind !== "AUDIT") ||
     typeof raw.sourceId !== "string" ||
@@ -1345,6 +1352,7 @@ export function parseCoordinationEvidenceBindingV1(
       evidenceDigest: raw.evidenceDigest,
       ownerScope: raw.ownerScope,
       coordinationId: raw.coordinationId,
+      coordinationPlanFingerprint: raw.coordinationPlanFingerprint,
       taskId: raw.taskId as string | null,
       kind: raw.kind,
       sourceId: raw.sourceId,
@@ -1478,15 +1486,29 @@ export async function computeCoordinationProgressionDecisionFingerprint(
   return sha256Canonical(captureCoordinationProgressionDecisionFingerprintFacts(decision));
 }
 
-type SharedStateSnapshotDigestPayloadV1 = Omit<
-  CoordinationSharedStateSnapshotV1,
-  "snapshotDigest"
->;
+type SharedStateSnapshotDigestPayloadV1 = {
+  schemaVersion: typeof MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA;
+  coordinationId: string;
+  coordinationPlanFingerprint: string;
+  taskStates: CoordinationTaskStateBindingV1[];
+  coordinationEvidenceBindings: CoordinationEvidenceBindingV1[];
+  auditBindings: CoordinationEvidenceBindingV1[];
+};
 
 export async function computeCoordinationSharedStateSnapshotDigest(
-  snapshot: SharedStateSnapshotDigestPayloadV1,
+  snapshot: SharedStateSnapshotDigestPayloadV1 | CoordinationSharedStateSnapshotV1,
 ): Promise<string> {
-  const canonical = canonicalJson(snapshot);
+  // Explicitly construct the covered payload so a full snapshot (with
+  // snapshotDigest) cannot accidentally participate in its own digest.
+  const digestPayload: SharedStateSnapshotDigestPayloadV1 = {
+    schemaVersion: snapshot.schemaVersion,
+    coordinationId: snapshot.coordinationId,
+    coordinationPlanFingerprint: snapshot.coordinationPlanFingerprint,
+    taskStates: snapshot.taskStates,
+    coordinationEvidenceBindings: snapshot.coordinationEvidenceBindings,
+    auditBindings: snapshot.auditBindings,
+  };
+  const canonical = canonicalJson(digestPayload);
   const digest = await crypto.subtle.digest(
     "SHA-256",
     new TextEncoder().encode(`${SHARED_STATE_SNAPSHOT_DIGEST_DOMAIN}${canonical}`),
@@ -1494,6 +1516,51 @@ export async function computeCoordinationSharedStateSnapshotDigest(
   return [...new Uint8Array(digest)]
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
+}
+
+function taskEvidenceContainsRef(
+  state: CoordinationTaskStateBindingV1,
+  ref: string,
+): boolean {
+  return state.evidenceBindings.some(
+    (evidence) =>
+      evidence.ref === ref &&
+      evidence.kind === "EVIDENCE" &&
+      evidence.ownerScope === "TASK" &&
+      evidence.taskId === state.taskId,
+  );
+}
+
+function terminalEvidenceRefsBound(state: CoordinationTaskStateBindingV1): boolean {
+  if (state.coordinationProgressionStatus === "FAILED") {
+    return (
+      refPresent(state.executionOutcomeRef) &&
+      taskEvidenceContainsRef(state, state.executionOutcomeRef as string)
+    );
+  }
+  if (state.coordinationProgressionStatus === "SUCCEEDED") {
+    return (
+      refPresent(state.executionOutcomeRef) &&
+      refPresent(state.resultValidationRef) &&
+      taskEvidenceContainsRef(state, state.executionOutcomeRef as string) &&
+      taskEvidenceContainsRef(state, state.resultValidationRef as string)
+    );
+  }
+  return true;
+}
+
+function readyAuthorizationStageCoherent(
+  state: CoordinationTaskStateBindingV1,
+  reason: CoordinationProgressionReasonV1,
+): boolean {
+  if (state.coordinationProgressionStatus !== "READY") return true;
+  if (reason === "READY_FOR_AUTHORIZATION") {
+    return state.executionAuthorizationRef === null;
+  }
+  if (reason === "AUTHORIZED_NOT_INVOKED") {
+    return refPresent(state.executionAuthorizationRef);
+  }
+  return true;
 }
 
 function taskStateLifecycleCoherent(state: CoordinationTaskStateBindingV1): boolean {
@@ -1554,21 +1621,25 @@ function taskStateLifecycleCoherent(state: CoordinationTaskStateBindingV1): bool
     }
   }
 
+  if (!terminalEvidenceRefsBound(state)) return false;
+
   return true;
 }
 
 function evidenceBindingAttributionCoherent(
   binding: CoordinationEvidenceBindingV1,
   snapshotCoordinationId: string,
+  snapshotPlanFingerprint: string,
   containingTaskId: string | null,
   expectedKind: CoordinationEvidenceKindV1,
 ): boolean {
   if (binding.coordinationId !== snapshotCoordinationId) return false;
+  if (binding.coordinationPlanFingerprint !== snapshotPlanFingerprint) return false;
   if (binding.kind !== expectedKind) return false;
-  if (binding.ownerScope === "TASK") {
-    return containingTaskId !== null && binding.taskId === containingTaskId;
+  if (containingTaskId !== null) {
+    return binding.ownerScope === "TASK" && binding.taskId === containingTaskId;
   }
-  return binding.taskId === null;
+  return binding.ownerScope === "COORDINATION" && binding.taskId === null;
 }
 
 function validateGlobalEvidenceCollisions(
@@ -1639,6 +1710,10 @@ export async function validateCoordinationSharedStateSnapshotV1(
   }
 
   const taskRefById = new Map(binding.plan.taskRefs.map((task) => [task.taskId, task] as const));
+  const progressionRefs = progressionDecisions.map((entry) => entry.progressionDecisionRef);
+  if (hasDuplicates(progressionRefs)) {
+    return { ok: false, reason: "REJECTED_CONTRADICTION" };
+  }
   const progressionByRef = new Map(
     progressionDecisions.map((entry) => [entry.progressionDecisionRef, entry.decision] as const),
   );
@@ -1658,6 +1733,7 @@ export async function validateCoordinationSharedStateSnapshotV1(
         !evidenceBindingAttributionCoherent(
           evidence,
           snapshot.coordinationId,
+          snapshot.coordinationPlanFingerprint,
           state.taskId,
           "EVIDENCE",
         )
@@ -1678,6 +1754,11 @@ export async function validateCoordinationSharedStateSnapshotV1(
       ) {
         return { ok: false, reason: "REJECTED_CONTRADICTION" };
       }
+      if (
+        !readyAuthorizationStageCoherent(state, boundDecision.coordinationProgressionReason)
+      ) {
+        return { ok: false, reason: "REJECTED_CONTRADICTION" };
+      }
       const expectedFingerprint =
         await computeCoordinationProgressionDecisionFingerprint(boundDecision);
       if (state.progressionDecisionFingerprint !== expectedFingerprint) {
@@ -1691,10 +1772,10 @@ export async function validateCoordinationSharedStateSnapshotV1(
       !evidenceBindingAttributionCoherent(
         evidence,
         snapshot.coordinationId,
+        snapshot.coordinationPlanFingerprint,
         null,
         "EVIDENCE",
-      ) ||
-      evidence.ownerScope !== "COORDINATION"
+      )
     ) {
       return { ok: false, reason: "REJECTED_BINDING" };
     }
@@ -1703,6 +1784,9 @@ export async function validateCoordinationSharedStateSnapshotV1(
   for (const audit of snapshot.auditBindings) {
     if (audit.kind !== "AUDIT") return { ok: false, reason: "REJECTED_BINDING" };
     if (audit.coordinationId !== snapshot.coordinationId) {
+      return { ok: false, reason: "REJECTED_BINDING" };
+    }
+    if (audit.coordinationPlanFingerprint !== snapshot.coordinationPlanFingerprint) {
       return { ok: false, reason: "REJECTED_BINDING" };
     }
     if (audit.ownerScope === "COORDINATION" && audit.taskId !== null) {

--- a/src/domain/multiAgentCoordination.ts
+++ b/src/domain/multiAgentCoordination.ts
@@ -12,6 +12,10 @@ export const MULTI_AGENT_COORDINATION_PROGRESSION_INPUT_SCHEMA =
   "MULTI-AGENT-COORDINATION-PROGRESSION-INPUT-V1" as const;
 export const MULTI_AGENT_COORDINATION_PROGRESSION_DECISION_SCHEMA =
   "MULTI-AGENT-COORDINATION-PROGRESSION-DECISION-V1" as const;
+export const MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA =
+  "MULTI-AGENT-COORDINATION-SHARED-STATE-SNAPSHOT-V1" as const;
+export const MULTI_AGENT_COORDINATION_PROGRESSION_DECISION_FINGERPRINT_SCHEMA =
+  "MULTI-AGENT-COORDINATION-PROGRESSION-DECISION-FINGERPRINT-V1" as const;
 
 export const MULTI_AGENT_COORDINATION_ID_MAX = 128 as const;
 export const MULTI_AGENT_COORDINATION_TASK_REFS_MAX = 32 as const;
@@ -25,6 +29,8 @@ export const MULTI_AGENT_COORDINATION_TIMESTAMP_MAX = 64 as const;
 
 /** Slice B implements only the pure progression evaluator. Execution surfaces remain disabled. */
 export const MULTI_AGENT_COORDINATION_PROGRESSION_EVALUATOR_IMPLEMENTED = true as const;
+/** Slice C implements only pure shared-state / evidence binding validation. Persistence remains disabled. */
+export const MULTI_AGENT_COORDINATION_SHARED_STATE_BINDING_IMPLEMENTED = true as const;
 export const MULTI_AGENT_COORDINATION_EXECUTION_IMPLEMENTED = false as const;
 export const MULTI_AGENT_COORDINATION_PROVIDER_INVOCATION_IMPLEMENTED = false as const;
 export const MULTI_AGENT_COORDINATION_HARNESS_INVOCATION_IMPLEMENTED = false as const;
@@ -85,6 +91,41 @@ const PROGRESSION_DECISION_KEYS = [
   "taskId",
   "coordinationProgressionStatus",
   "coordinationProgressionReason",
+] as const;
+const EVIDENCE_BINDING_KEYS = [
+  "ref",
+  "evidenceDigest",
+  "ownerScope",
+  "coordinationId",
+  "taskId",
+  "kind",
+  "sourceId",
+] as const;
+const TASK_STATE_BINDING_KEYS = [
+  "taskId",
+  "taskRoutingFingerprint",
+  "workerId",
+  "workerAuthorityFingerprint",
+  "routingDecisionFingerprint",
+  "humanDecisionRef",
+  "executionAuthorizationRef",
+  "executionAttemptId",
+  "executionOutcomeRef",
+  "resultValidationRef",
+  "resourceLockDecisionRef",
+  "coordinationProgressionStatus",
+  "progressionDecisionRef",
+  "progressionDecisionFingerprint",
+  "evidenceBindings",
+] as const;
+const SHARED_STATE_SNAPSHOT_KEYS = [
+  "schemaVersion",
+  "snapshotDigest",
+  "coordinationId",
+  "coordinationPlanFingerprint",
+  "taskStates",
+  "coordinationEvidenceBindings",
+  "auditBindings",
 ] as const;
 
 export type CoordinationModeV1 = "SEQUENTIAL" | "PARALLEL_ELIGIBLE";
@@ -229,6 +270,61 @@ export interface CoordinationProgressionDecisionV1 {
   taskId: string;
   coordinationProgressionStatus: CoordinationProgressionStatusV1;
   coordinationProgressionReason: CoordinationProgressionReasonV1;
+}
+
+export type CoordinationEvidenceOwnerScopeV1 = "COORDINATION" | "TASK";
+export type CoordinationEvidenceKindV1 = "EVIDENCE" | "AUDIT";
+
+export interface CoordinationEvidenceBindingV1 {
+  ref: string;
+  evidenceDigest: string;
+  ownerScope: CoordinationEvidenceOwnerScopeV1;
+  coordinationId: string;
+  taskId: string | null;
+  kind: CoordinationEvidenceKindV1;
+  sourceId: string;
+}
+
+export interface CoordinationTaskStateBindingV1 {
+  taskId: string;
+  taskRoutingFingerprint: string;
+  workerId: string | null;
+  workerAuthorityFingerprint: string | null;
+  routingDecisionFingerprint: string | null;
+  humanDecisionRef: string | null;
+  executionAuthorizationRef: string | null;
+  executionAttemptId: string | null;
+  executionOutcomeRef: string | null;
+  resultValidationRef: string | null;
+  resourceLockDecisionRef: string | null;
+  coordinationProgressionStatus: CoordinationProgressionStatusV1;
+  progressionDecisionRef: string;
+  progressionDecisionFingerprint: string;
+  evidenceBindings: CoordinationEvidenceBindingV1[];
+}
+
+export interface CoordinationSharedStateSnapshotV1 {
+  schemaVersion: typeof MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA;
+  snapshotDigest: string;
+  coordinationId: string;
+  coordinationPlanFingerprint: string;
+  taskStates: CoordinationTaskStateBindingV1[];
+  coordinationEvidenceBindings: CoordinationEvidenceBindingV1[];
+  auditBindings: CoordinationEvidenceBindingV1[];
+}
+
+export interface CoordinationProgressionDecisionFingerprintFactsV1 {
+  schemaVersion: typeof MULTI_AGENT_COORDINATION_PROGRESSION_DECISION_FINGERPRINT_SCHEMA;
+  coordinationId: string;
+  coordinationPlanFingerprint: string;
+  taskId: string;
+  coordinationProgressionStatus: CoordinationProgressionStatusV1;
+  coordinationProgressionReason: CoordinationProgressionReasonV1;
+}
+
+export interface CoordinationProgressionDecisionBindingV1 {
+  progressionDecisionRef: string;
+  decision: CoordinationProgressionDecisionV1;
 }
 
 export interface CoordinationPlanBindingV1 {
@@ -997,4 +1093,648 @@ export function parseCoordinationProgressionDecisionV1(
       coordinationProgressionReason: raw.coordinationProgressionReason,
     },
   };
+}
+
+const SHARED_STATE_SNAPSHOT_DIGEST_DOMAIN = "MAC_SHARED_STATE_SNAPSHOT_V1\n" as const;
+
+type LifecycleRefRequirementV1 = "R" | "O" | "N";
+
+interface LifecycleMatrixRowV1 {
+  workerId: LifecycleRefRequirementV1;
+  workerAuthorityFingerprint: LifecycleRefRequirementV1;
+  routingDecisionFingerprint: LifecycleRefRequirementV1;
+  executionAuthorizationRef: LifecycleRefRequirementV1;
+  executionAttemptId: LifecycleRefRequirementV1;
+  executionOutcomeRef: LifecycleRefRequirementV1;
+  resultValidationRef: LifecycleRefRequirementV1;
+  resourceLockDecisionRef: LifecycleRefRequirementV1;
+  evidenceBindings: LifecycleRefRequirementV1;
+  humanDecisionRef: LifecycleRefRequirementV1;
+}
+
+const LIFECYCLE_MATRIX: Record<CoordinationProgressionStatusV1, LifecycleMatrixRowV1> = {
+  PLANNED: {
+    workerId: "N",
+    workerAuthorityFingerprint: "N",
+    routingDecisionFingerprint: "N",
+    executionAuthorizationRef: "N",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "N",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  WAITING_DEPENDENCY: {
+    workerId: "O",
+    workerAuthorityFingerprint: "O",
+    routingDecisionFingerprint: "O",
+    executionAuthorizationRef: "N",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  WAITING_RESOURCE: {
+    workerId: "R",
+    workerAuthorityFingerprint: "R",
+    routingDecisionFingerprint: "R",
+    executionAuthorizationRef: "N",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "R",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  WAITING_HUMAN_GATE: {
+    workerId: "R",
+    workerAuthorityFingerprint: "R",
+    routingDecisionFingerprint: "R",
+    executionAuthorizationRef: "N",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "O",
+  },
+  READY: {
+    workerId: "R",
+    workerAuthorityFingerprint: "R",
+    routingDecisionFingerprint: "R",
+    executionAuthorizationRef: "R",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  RUNNING: {
+    workerId: "R",
+    workerAuthorityFingerprint: "R",
+    routingDecisionFingerprint: "R",
+    executionAuthorizationRef: "R",
+    executionAttemptId: "R",
+    executionOutcomeRef: "O",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  HOLD: {
+    workerId: "O",
+    workerAuthorityFingerprint: "O",
+    routingDecisionFingerprint: "O",
+    executionAuthorizationRef: "O",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  NOT_EXECUTED: {
+    workerId: "O",
+    workerAuthorityFingerprint: "O",
+    routingDecisionFingerprint: "O",
+    executionAuthorizationRef: "R",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  CANCELLED: {
+    workerId: "O",
+    workerAuthorityFingerprint: "O",
+    routingDecisionFingerprint: "O",
+    executionAuthorizationRef: "O",
+    executionAttemptId: "N",
+    executionOutcomeRef: "N",
+    resultValidationRef: "N",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "N",
+  },
+  FAILED: {
+    workerId: "R",
+    workerAuthorityFingerprint: "R",
+    routingDecisionFingerprint: "R",
+    executionAuthorizationRef: "R",
+    executionAttemptId: "R",
+    executionOutcomeRef: "R",
+    resultValidationRef: "O",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "R",
+    humanDecisionRef: "N",
+  },
+  SUCCEEDED: {
+    workerId: "R",
+    workerAuthorityFingerprint: "R",
+    routingDecisionFingerprint: "R",
+    executionAuthorizationRef: "R",
+    executionAttemptId: "R",
+    executionOutcomeRef: "R",
+    resultValidationRef: "R",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "R",
+    humanDecisionRef: "N",
+  },
+  UNKNOWN: {
+    workerId: "O",
+    workerAuthorityFingerprint: "O",
+    routingDecisionFingerprint: "O",
+    executionAuthorizationRef: "O",
+    executionAttemptId: "O",
+    executionOutcomeRef: "O",
+    resultValidationRef: "O",
+    resourceLockDecisionRef: "O",
+    evidenceBindings: "O",
+    humanDecisionRef: "O",
+  },
+};
+
+function refPresent(value: string | null): boolean {
+  return value !== null && isOpaqueRef(value);
+}
+
+function refAbsent(value: string | null): boolean {
+  return value === null;
+}
+
+function refRequirementSatisfied(
+  requirement: LifecycleRefRequirementV1,
+  value: string | null,
+  count?: number,
+): boolean {
+  if (requirement === "R") {
+    if (count !== undefined) return count >= 1;
+    return refPresent(value);
+  }
+  if (requirement === "N") {
+    if (count !== undefined) return count === 0;
+    return refAbsent(value);
+  }
+  if (count !== undefined) return true;
+  return value === null || refPresent(value);
+}
+
+function evidenceBindingIdentityTuple(
+  binding: CoordinationEvidenceBindingV1,
+): string {
+  return JSON.stringify([
+    binding.ref,
+    binding.ownerScope,
+    binding.coordinationId,
+    binding.taskId,
+    binding.kind,
+    binding.sourceId,
+  ]);
+}
+
+function evidenceImmutableIdentityTuple(
+  binding: CoordinationEvidenceBindingV1,
+): string {
+  return JSON.stringify([binding.ref, binding.evidenceDigest]);
+}
+
+function evidenceOwnerIdentityTuple(binding: CoordinationEvidenceBindingV1): string {
+  return JSON.stringify([
+    binding.ownerScope,
+    binding.coordinationId,
+    binding.taskId,
+    binding.kind,
+    binding.sourceId,
+  ]);
+}
+
+export function parseCoordinationEvidenceBindingV1(
+  raw: unknown,
+): CoordinationParseResultV1<CoordinationEvidenceBindingV1> {
+  if (!isPlainObject(raw) || !hasExactKeys(raw, EVIDENCE_BINDING_KEYS)) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  if (
+    !isOpaqueRef(raw.ref) ||
+    !isFingerprint(raw.evidenceDigest) ||
+    (raw.ownerScope !== "COORDINATION" && raw.ownerScope !== "TASK") ||
+    !isLocalId(raw.coordinationId) ||
+    (raw.taskId !== null && !isAgentTaskId(raw.taskId)) ||
+    (raw.kind !== "EVIDENCE" && raw.kind !== "AUDIT") ||
+    typeof raw.sourceId !== "string" ||
+    raw.sourceId.length < 1 ||
+    raw.sourceId.length > MULTI_AGENT_COORDINATION_SOURCE_ID_MAX
+  ) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  if (raw.ownerScope === "COORDINATION" && raw.taskId !== null) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  if (raw.ownerScope === "TASK" && raw.taskId === null) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  return {
+    ok: true,
+    value: {
+      ref: raw.ref,
+      evidenceDigest: raw.evidenceDigest,
+      ownerScope: raw.ownerScope,
+      coordinationId: raw.coordinationId,
+      taskId: raw.taskId as string | null,
+      kind: raw.kind,
+      sourceId: raw.sourceId,
+    },
+  };
+}
+
+function parseEvidenceBindingArray(
+  raw: unknown,
+): CoordinationParseResultV1<CoordinationEvidenceBindingV1[]> {
+  if (
+    !Array.isArray(raw) ||
+    raw.length > MULTI_AGENT_COORDINATION_REFERENCE_ARRAY_MAX
+  ) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  const bindings: CoordinationEvidenceBindingV1[] = [];
+  for (const item of raw) {
+    const parsed = parseCoordinationEvidenceBindingV1(item);
+    if (!parsed.ok) return parsed;
+    bindings.push(parsed.value);
+  }
+  return { ok: true, value: bindings };
+}
+
+export function parseCoordinationTaskStateBindingV1(
+  raw: unknown,
+): CoordinationParseResultV1<CoordinationTaskStateBindingV1> {
+  if (!isPlainObject(raw) || !hasExactKeys(raw, TASK_STATE_BINDING_KEYS)) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  if (
+    !isAgentTaskId(raw.taskId) ||
+    !isFingerprint(raw.taskRoutingFingerprint) ||
+    (raw.workerId !== null && !isLocalId(raw.workerId)) ||
+    (raw.workerAuthorityFingerprint !== null && !isFingerprint(raw.workerAuthorityFingerprint)) ||
+    (raw.routingDecisionFingerprint !== null && !isFingerprint(raw.routingDecisionFingerprint)) ||
+    (raw.humanDecisionRef !== null && !isOpaqueRef(raw.humanDecisionRef)) ||
+    (raw.executionAuthorizationRef !== null && !isOpaqueRef(raw.executionAuthorizationRef)) ||
+    (raw.executionAttemptId !== null && !isOpaqueRef(raw.executionAttemptId)) ||
+    (raw.executionOutcomeRef !== null && !isOpaqueRef(raw.executionOutcomeRef)) ||
+    (raw.resultValidationRef !== null && !isOpaqueRef(raw.resultValidationRef)) ||
+    (raw.resourceLockDecisionRef !== null && !isOpaqueRef(raw.resourceLockDecisionRef)) ||
+    !includesValue(PROGRESSION_STATUSES, raw.coordinationProgressionStatus) ||
+    !isOpaqueRef(raw.progressionDecisionRef) ||
+    !isFingerprint(raw.progressionDecisionFingerprint)
+  ) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  const evidenceBindings = parseEvidenceBindingArray(raw.evidenceBindings);
+  if (!evidenceBindings.ok) return evidenceBindings;
+  return {
+    ok: true,
+    value: {
+      taskId: raw.taskId,
+      taskRoutingFingerprint: raw.taskRoutingFingerprint,
+      workerId: raw.workerId as string | null,
+      workerAuthorityFingerprint: raw.workerAuthorityFingerprint as string | null,
+      routingDecisionFingerprint: raw.routingDecisionFingerprint as string | null,
+      humanDecisionRef: raw.humanDecisionRef as string | null,
+      executionAuthorizationRef: raw.executionAuthorizationRef as string | null,
+      executionAttemptId: raw.executionAttemptId as string | null,
+      executionOutcomeRef: raw.executionOutcomeRef as string | null,
+      resultValidationRef: raw.resultValidationRef as string | null,
+      resourceLockDecisionRef: raw.resourceLockDecisionRef as string | null,
+      coordinationProgressionStatus: raw.coordinationProgressionStatus,
+      progressionDecisionRef: raw.progressionDecisionRef,
+      progressionDecisionFingerprint: raw.progressionDecisionFingerprint,
+      evidenceBindings: evidenceBindings.value,
+    },
+  };
+}
+
+export function parseCoordinationSharedStateSnapshotV1(
+  raw: unknown,
+): CoordinationParseResultV1<CoordinationSharedStateSnapshotV1> {
+  if (!isPlainObject(raw) || !hasExactKeys(raw, SHARED_STATE_SNAPSHOT_KEYS)) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  if (
+    raw.schemaVersion !== MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA ||
+    !isFingerprint(raw.snapshotDigest) ||
+    !isLocalId(raw.coordinationId) ||
+    !isFingerprint(raw.coordinationPlanFingerprint) ||
+    !Array.isArray(raw.taskStates) ||
+    raw.taskStates.length < 1 ||
+    raw.taskStates.length > MULTI_AGENT_COORDINATION_TASK_REFS_MAX
+  ) {
+    return { ok: false, reason: "REJECTED_SCHEMA" };
+  }
+  const taskStates: CoordinationTaskStateBindingV1[] = [];
+  for (const item of raw.taskStates) {
+    const parsed = parseCoordinationTaskStateBindingV1(item);
+    if (!parsed.ok) return parsed;
+    taskStates.push(parsed.value);
+  }
+  const coordinationEvidenceBindings = parseEvidenceBindingArray(raw.coordinationEvidenceBindings);
+  if (!coordinationEvidenceBindings.ok) return coordinationEvidenceBindings;
+  const auditBindings = parseEvidenceBindingArray(raw.auditBindings);
+  if (!auditBindings.ok) return auditBindings;
+  return {
+    ok: true,
+    value: {
+      schemaVersion: MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA,
+      snapshotDigest: raw.snapshotDigest,
+      coordinationId: raw.coordinationId,
+      coordinationPlanFingerprint: raw.coordinationPlanFingerprint,
+      taskStates,
+      coordinationEvidenceBindings: coordinationEvidenceBindings.value,
+      auditBindings: auditBindings.value,
+    },
+  };
+}
+
+export function captureCoordinationProgressionDecisionFingerprintFacts(
+  decision: CoordinationProgressionDecisionV1,
+): CoordinationProgressionDecisionFingerprintFactsV1 {
+  return {
+    schemaVersion: MULTI_AGENT_COORDINATION_PROGRESSION_DECISION_FINGERPRINT_SCHEMA,
+    coordinationId: decision.coordinationId,
+    coordinationPlanFingerprint: decision.coordinationPlanFingerprint,
+    taskId: decision.taskId,
+    coordinationProgressionStatus: decision.coordinationProgressionStatus,
+    coordinationProgressionReason: decision.coordinationProgressionReason,
+  };
+}
+
+export async function computeCoordinationProgressionDecisionFingerprint(
+  decision: CoordinationProgressionDecisionV1,
+): Promise<string> {
+  return sha256Canonical(captureCoordinationProgressionDecisionFingerprintFacts(decision));
+}
+
+type SharedStateSnapshotDigestPayloadV1 = Omit<
+  CoordinationSharedStateSnapshotV1,
+  "snapshotDigest"
+>;
+
+export async function computeCoordinationSharedStateSnapshotDigest(
+  snapshot: SharedStateSnapshotDigestPayloadV1,
+): Promise<string> {
+  const canonical = canonicalJson(snapshot);
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${SHARED_STATE_SNAPSHOT_DIGEST_DOMAIN}${canonical}`),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function taskStateLifecycleCoherent(state: CoordinationTaskStateBindingV1): boolean {
+  const matrix = LIFECYCLE_MATRIX[state.coordinationProgressionStatus];
+  if (
+    !refRequirementSatisfied(matrix.workerId, state.workerId) ||
+    !refRequirementSatisfied(matrix.workerAuthorityFingerprint, state.workerAuthorityFingerprint) ||
+    !refRequirementSatisfied(matrix.routingDecisionFingerprint, state.routingDecisionFingerprint) ||
+    !refRequirementSatisfied(matrix.executionAuthorizationRef, state.executionAuthorizationRef) ||
+    !refRequirementSatisfied(matrix.executionAttemptId, state.executionAttemptId) ||
+    !refRequirementSatisfied(matrix.executionOutcomeRef, state.executionOutcomeRef) ||
+    !refRequirementSatisfied(matrix.resultValidationRef, state.resultValidationRef) ||
+    !refRequirementSatisfied(matrix.resourceLockDecisionRef, state.resourceLockDecisionRef) ||
+    !refRequirementSatisfied(matrix.humanDecisionRef, state.humanDecisionRef) ||
+    !refRequirementSatisfied(matrix.evidenceBindings, null, state.evidenceBindings.length)
+  ) {
+    return false;
+  }
+
+  const workerPresent = state.workerId !== null;
+  const workerFingerprintPresent = state.workerAuthorityFingerprint !== null;
+  const routingPresent = state.routingDecisionFingerprint !== null;
+  if (workerPresent !== workerFingerprintPresent || workerPresent !== routingPresent) {
+    return false;
+  }
+
+  if (state.executionAttemptId !== null && state.executionAuthorizationRef === null) return false;
+  if (state.executionOutcomeRef !== null && state.executionAttemptId === null) return false;
+  if (state.resultValidationRef !== null && state.executionOutcomeRef === null) return false;
+
+  if (
+    state.coordinationProgressionStatus === "RUNNING" &&
+    state.resultValidationRef !== null
+  ) {
+    return false;
+  }
+  if (state.coordinationProgressionStatus === "NOT_EXECUTED") {
+    if (
+      state.executionAttemptId !== null ||
+      state.executionOutcomeRef !== null ||
+      state.resultValidationRef !== null
+    ) {
+      return false;
+    }
+  }
+  if (state.coordinationProgressionStatus === "PLANNED") {
+    if (
+      state.workerId !== null ||
+      state.workerAuthorityFingerprint !== null ||
+      state.routingDecisionFingerprint !== null ||
+      state.executionAuthorizationRef !== null ||
+      state.executionAttemptId !== null ||
+      state.executionOutcomeRef !== null ||
+      state.resultValidationRef !== null ||
+      state.resourceLockDecisionRef !== null
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function evidenceBindingAttributionCoherent(
+  binding: CoordinationEvidenceBindingV1,
+  snapshotCoordinationId: string,
+  containingTaskId: string | null,
+  expectedKind: CoordinationEvidenceKindV1,
+): boolean {
+  if (binding.coordinationId !== snapshotCoordinationId) return false;
+  if (binding.kind !== expectedKind) return false;
+  if (binding.ownerScope === "TASK") {
+    return containingTaskId !== null && binding.taskId === containingTaskId;
+  }
+  return binding.taskId === null;
+}
+
+function validateGlobalEvidenceCollisions(
+  bindings: readonly CoordinationEvidenceBindingV1[],
+): boolean {
+  const seenIdentityTuples = new Set<string>();
+  const refToDigest = new Map<string, string>();
+  const immutableToOwner = new Map<string, string>();
+
+  for (const binding of bindings) {
+    const identityTuple = evidenceBindingIdentityTuple(binding);
+    if (seenIdentityTuples.has(identityTuple)) return false;
+    seenIdentityTuples.add(identityTuple);
+
+    const priorDigest = refToDigest.get(binding.ref);
+    if (priorDigest !== undefined && priorDigest !== binding.evidenceDigest) return false;
+    refToDigest.set(binding.ref, binding.evidenceDigest);
+
+    const immutableTuple = evidenceImmutableIdentityTuple(binding);
+    const ownerTuple = evidenceOwnerIdentityTuple(binding);
+    const priorOwner = immutableToOwner.get(immutableTuple);
+    if (priorOwner !== undefined && priorOwner !== ownerTuple) return false;
+    immutableToOwner.set(immutableTuple, ownerTuple);
+  }
+
+  return true;
+}
+
+function progressionBindingCoherent(
+  state: CoordinationTaskStateBindingV1,
+  snapshotCoordinationId: string,
+  snapshotPlanFingerprint: string,
+  decision: CoordinationProgressionDecisionV1,
+): boolean {
+  return (
+    decision.coordinationId === snapshotCoordinationId &&
+    decision.coordinationPlanFingerprint === snapshotPlanFingerprint &&
+    decision.taskId === state.taskId &&
+    decision.coordinationProgressionStatus === state.coordinationProgressionStatus
+  );
+}
+
+export async function validateCoordinationSharedStateSnapshotV1(
+  raw: unknown,
+  binding: CoordinationPlanBindingV1,
+  progressionDecisions: readonly CoordinationProgressionDecisionBindingV1[] = [],
+): Promise<CoordinationParseResultV1<CoordinationSharedStateSnapshotV1>> {
+  const parsed = parseCoordinationSharedStateSnapshotV1(raw);
+  if (!parsed.ok) return parsed;
+  const snapshot = parsed.value;
+
+  if (!bindingMatches(binding, snapshot.coordinationId, snapshot.coordinationPlanFingerprint)) {
+    return { ok: false, reason: "REJECTED_BINDING" };
+  }
+
+  const admittedTaskIds = binding.plan.taskRefs.map((task) => task.taskId);
+  const admittedTaskIdSet = new Set(admittedTaskIds);
+  const snapshotTaskIds = snapshot.taskStates.map((state) => state.taskId);
+  if (hasDuplicates(snapshotTaskIds)) {
+    return { ok: false, reason: "REJECTED_BINDING" };
+  }
+  const snapshotTaskIdSet = new Set(snapshotTaskIds);
+  if (
+    snapshotTaskIds.length !== admittedTaskIds.length ||
+    !admittedTaskIds.every((taskId) => snapshotTaskIdSet.has(taskId))
+  ) {
+    return { ok: false, reason: "REJECTED_BINDING" };
+  }
+
+  const taskRefById = new Map(binding.plan.taskRefs.map((task) => [task.taskId, task] as const));
+  const progressionByRef = new Map(
+    progressionDecisions.map((entry) => [entry.progressionDecisionRef, entry.decision] as const),
+  );
+
+  for (const state of snapshot.taskStates) {
+    const taskRef = taskRefById.get(state.taskId);
+    if (!taskRef) return { ok: false, reason: "REJECTED_BINDING" };
+    if (state.taskRoutingFingerprint !== taskRef.taskRoutingFingerprint) {
+      return { ok: false, reason: "REJECTED_BINDING" };
+    }
+    if (!taskStateLifecycleCoherent(state)) {
+      return { ok: false, reason: "REJECTED_CONTRADICTION" };
+    }
+
+    for (const evidence of state.evidenceBindings) {
+      if (
+        !evidenceBindingAttributionCoherent(
+          evidence,
+          snapshot.coordinationId,
+          state.taskId,
+          "EVIDENCE",
+        )
+      ) {
+        return { ok: false, reason: "REJECTED_BINDING" };
+      }
+    }
+
+    const boundDecision = progressionByRef.get(state.progressionDecisionRef);
+    if (boundDecision) {
+      if (
+        !progressionBindingCoherent(
+          state,
+          snapshot.coordinationId,
+          snapshot.coordinationPlanFingerprint,
+          boundDecision,
+        )
+      ) {
+        return { ok: false, reason: "REJECTED_CONTRADICTION" };
+      }
+      const expectedFingerprint =
+        await computeCoordinationProgressionDecisionFingerprint(boundDecision);
+      if (state.progressionDecisionFingerprint !== expectedFingerprint) {
+        return { ok: false, reason: "REJECTED_CONTRADICTION" };
+      }
+    }
+  }
+
+  for (const evidence of snapshot.coordinationEvidenceBindings) {
+    if (
+      !evidenceBindingAttributionCoherent(
+        evidence,
+        snapshot.coordinationId,
+        null,
+        "EVIDENCE",
+      ) ||
+      evidence.ownerScope !== "COORDINATION"
+    ) {
+      return { ok: false, reason: "REJECTED_BINDING" };
+    }
+  }
+
+  for (const audit of snapshot.auditBindings) {
+    if (audit.kind !== "AUDIT") return { ok: false, reason: "REJECTED_BINDING" };
+    if (audit.coordinationId !== snapshot.coordinationId) {
+      return { ok: false, reason: "REJECTED_BINDING" };
+    }
+    if (audit.ownerScope === "COORDINATION" && audit.taskId !== null) {
+      return { ok: false, reason: "REJECTED_BINDING" };
+    }
+    if (audit.ownerScope === "TASK") {
+      if (audit.taskId === null || !admittedTaskIdSet.has(audit.taskId)) {
+        return { ok: false, reason: "REJECTED_BINDING" };
+      }
+    }
+  }
+
+  const allEvidenceBindings = [
+    ...snapshot.taskStates.flatMap((state) => state.evidenceBindings),
+    ...snapshot.coordinationEvidenceBindings,
+    ...snapshot.auditBindings,
+  ];
+  if (!validateGlobalEvidenceCollisions(allEvidenceBindings)) {
+    return { ok: false, reason: "REJECTED_CONTRADICTION" };
+  }
+
+  const expectedDigest = await computeCoordinationSharedStateSnapshotDigest({
+    schemaVersion: snapshot.schemaVersion,
+    coordinationId: snapshot.coordinationId,
+    coordinationPlanFingerprint: snapshot.coordinationPlanFingerprint,
+    taskStates: snapshot.taskStates,
+    coordinationEvidenceBindings: snapshot.coordinationEvidenceBindings,
+    auditBindings: snapshot.auditBindings,
+  });
+  if (snapshot.snapshotDigest !== expectedDigest) {
+    return { ok: false, reason: "REJECTED_CONTRADICTION" };
+  }
+
+  return { ok: true, value: snapshot };
 }

--- a/test/multiAgentCoordination.test.ts
+++ b/test/multiAgentCoordination.test.ts
@@ -951,13 +951,24 @@ const FPE = "e".repeat(64);
 const FPW = "f".repeat(64);
 
 function evidenceBinding(
-  overrides: Partial<CoordinationEvidenceBindingV1> = {},
+  planOrOverrides?: CoordinationPlanBindingV1 | Partial<CoordinationEvidenceBindingV1>,
+  maybeOverrides: Partial<CoordinationEvidenceBindingV1> = {},
 ): CoordinationEvidenceBindingV1 {
+  const isPlan =
+    planOrOverrides !== undefined &&
+    typeof planOrOverrides === "object" &&
+    "plan" in planOrOverrides &&
+    "coordinationPlanFingerprint" in planOrOverrides;
+  const planBinding = isPlan ? (planOrOverrides as CoordinationPlanBindingV1) : undefined;
+  const overrides = isPlan
+    ? maybeOverrides
+    : ((planOrOverrides as Partial<CoordinationEvidenceBindingV1> | undefined) ?? {});
   return {
     ref: "evidence://task/1",
     evidenceDigest: FPD,
     ownerScope: "TASK",
-    coordinationId: "coordination-1",
+    coordinationId: planBinding?.plan.coordinationId ?? "coordination-1",
+    coordinationPlanFingerprint: planBinding?.coordinationPlanFingerprint ?? FPA,
     taskId: "task-a",
     kind: "EVIDENCE",
     sourceId: "source-1",
@@ -1184,7 +1195,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
       taskStates: [
         plannedTaskState(current, {
           progressionDecisionFingerprint: fingerprint,
-          evidenceBindings: [evidenceBinding({ taskId: "task-other" })],
+          evidenceBindings: [evidenceBinding(current, { taskId: "task-other" })],
         }),
       ],
     });
@@ -1202,7 +1213,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
     const snap = await snapshotPayload(current, {
       taskStates: [plannedTaskState(current, { progressionDecisionFingerprint: fingerprint })],
       coordinationEvidenceBindings: [
-        evidenceBinding({ ownerScope: "TASK", taskId: "task-a", kind: "EVIDENCE" }),
+        evidenceBinding(current, { ownerScope: "TASK", taskId: "task-a", kind: "EVIDENCE" }),
       ],
     });
     expect(
@@ -1219,7 +1230,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
     const snap = await snapshotPayload(current, {
       taskStates: [plannedTaskState(current, { progressionDecisionFingerprint: fingerprint })],
       auditBindings: [
-        evidenceBinding({
+        evidenceBinding(current, {
           ownerScope: "TASK",
           taskId: "task-unknown",
           kind: "AUDIT",
@@ -1238,7 +1249,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
     const current = await binding();
     const decision = progressionDecision(current);
     const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
-    const duplicate = evidenceBinding();
+    const duplicate = evidenceBinding(current);
     const snap = await snapshotPayload(current, {
       taskStates: [
         plannedTaskState(current, {
@@ -1256,8 +1267,8 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
 
   it("C15 array order preserved; no sort/dedupe/repair", async () => {
     const current = await binding();
-    const first = evidenceBinding({ ref: "evidence://first", sourceId: "source-a" });
-    const second = evidenceBinding({ ref: "evidence://second", sourceId: "source-b" });
+    const first = evidenceBinding(current, { ref: "evidence://first", sourceId: "source-a" });
+    const second = evidenceBinding(current, { ref: "evidence://second", sourceId: "source-b" });
     const decision = progressionDecision(current);
     const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
     const snap = await snapshotPayload(current, {
@@ -1355,7 +1366,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
           executionOutcomeRef: "evidence://outcome",
           resultValidationRef: null,
           progressionDecisionFingerprint: fingerprint,
-          evidenceBindings: [evidenceBinding()],
+          evidenceBindings: [evidenceBinding(current)],
         }),
       ],
     });
@@ -1559,6 +1570,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
         ref: "evidence://task/1",
         ownerScope: "TASK",
         coordinationId: "coordination-1",
+        coordinationPlanFingerprint: FPA,
         taskId: "task-a",
         kind: "EVIDENCE",
         sourceId: "source-1",
@@ -1574,11 +1586,11 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
       taskStates: [
         plannedTaskState(current, {
           progressionDecisionFingerprint: fingerprint,
-          evidenceBindings: [evidenceBinding({ ref: "evidence://shared", evidenceDigest: FPD })],
+          evidenceBindings: [evidenceBinding(current, { ref: "evidence://shared", evidenceDigest: FPD })],
         }),
       ],
       coordinationEvidenceBindings: [
-        evidenceBinding({
+        evidenceBinding(current, {
           ref: "evidence://shared",
           evidenceDigest: FPE,
           ownerScope: "COORDINATION",
@@ -1638,7 +1650,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
     const current = await binding();
     const decision = progressionDecision(current);
     const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
-    const shared = evidenceBinding();
+    const shared = evidenceBinding(current);
     const snap = await snapshotPayload(current, {
       taskStates: [
         plannedTaskState(current, {
@@ -1648,7 +1660,7 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
       ],
       auditBindings: [{ ...shared, kind: "AUDIT", ref: "audit://dup" }],
     });
-    const duplicateAudit = evidenceBinding({ kind: "AUDIT", ref: "audit://1" });
+    const duplicateAudit = evidenceBinding(current, { kind: "AUDIT", ref: "audit://1" });
     snap.auditBindings = [duplicateAudit, { ...duplicateAudit }];
     snap.snapshotDigest = await computeCoordinationSharedStateSnapshotDigest({
       schemaVersion: snap.schemaVersion,
@@ -1669,8 +1681,8 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
     const current = await binding();
     const decision = progressionDecision(current);
     const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
-    const taskEvidence = evidenceBinding({ ref: "evidence://task", sourceId: "source-task" });
-    const auditEvidence = evidenceBinding({
+    const taskEvidence = evidenceBinding(current, { ref: "evidence://task", sourceId: "source-task" });
+    const auditEvidence = evidenceBinding(current, {
       ref: "audit://1",
       kind: "AUDIT",
       sourceId: "source-audit",
@@ -1691,5 +1703,244 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
     if (!result.ok) throw new Error(result.reason);
     expect(result.value.auditBindings[0].ref).toBe("audit://1");
     expect(result.value.taskStates[0].evidenceBindings[0].ref).toBe("evidence://task");
+  });
+
+  it("C37 READY/READY_FOR_AUTHORIZATION with null executionAuthorizationRef passes", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "READY",
+      coordinationProgressionReason: "READY_FOR_AUTHORIZATION",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "READY",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: null,
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(snap, current, [
+          { progressionDecisionRef: "progression://decision/1", decision },
+        ])
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("C38 READY/AUTHORIZED_NOT_INVOKED with null executionAuthorizationRef rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "READY",
+      coordinationProgressionReason: "AUTHORIZED_NOT_INVOKED",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "READY",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: null,
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(snap, current, [
+          { progressionDecisionRef: "progression://decision/1", decision },
+        ])
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("C39 evidence binding plan fingerprint mismatch rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [
+            evidenceBinding(current, { coordinationPlanFingerprint: FPA }),
+          ],
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(snap, current, [
+          { progressionDecisionRef: "progression://decision/1", decision },
+        ])
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("C40 FAILED/SUCCEEDED require lifecycle refs bound to task evidence records", async () => {
+    const current = await binding();
+    const failedDecision = progressionDecision(current, {
+      coordinationProgressionStatus: "FAILED",
+      coordinationProgressionReason: "EXECUTION_FAILED",
+    });
+    const failedFingerprint =
+      await computeCoordinationProgressionDecisionFingerprint(failedDecision);
+    const failedSnap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "FAILED",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: "evidence://auth",
+          executionAttemptId: "attempt-1",
+          executionOutcomeRef: "evidence://outcome",
+          progressionDecisionFingerprint: failedFingerprint,
+          evidenceBindings: [
+            evidenceBinding(current, { ref: "evidence://unrelated" }),
+          ],
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(failedSnap, current, [
+          { progressionDecisionRef: "progression://decision/1", decision: failedDecision },
+        ])
+      ).ok,
+    ).toBe(false);
+
+    const succeededDecision = progressionDecision(current, {
+      coordinationProgressionStatus: "SUCCEEDED",
+      coordinationProgressionReason: "EXECUTION_AND_RESULT_VALID",
+    });
+    const succeededFingerprint =
+      await computeCoordinationProgressionDecisionFingerprint(succeededDecision);
+    const succeededSnap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "SUCCEEDED",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: "evidence://auth",
+          executionAttemptId: "attempt-1",
+          executionOutcomeRef: "evidence://outcome",
+          resultValidationRef: "evidence://result",
+          progressionDecisionFingerprint: succeededFingerprint,
+          evidenceBindings: [
+            evidenceBinding(current, { ref: "evidence://outcome" }),
+            // resultValidationRef unbound — only outcome bound
+          ],
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(succeededSnap, current, [
+          {
+            progressionDecisionRef: "progression://decision/1",
+            decision: succeededDecision,
+          },
+        ])
+      ).ok,
+    ).toBe(false);
+
+    const succeededOk = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "SUCCEEDED",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: "evidence://auth",
+          executionAttemptId: "attempt-1",
+          executionOutcomeRef: "evidence://outcome",
+          resultValidationRef: "evidence://result",
+          progressionDecisionFingerprint: succeededFingerprint,
+          evidenceBindings: [
+            evidenceBinding(current, { ref: "evidence://outcome", sourceId: "source-outcome" }),
+            evidenceBinding(current, { ref: "evidence://result", sourceId: "source-result" }),
+          ],
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(succeededOk, current, [
+          {
+            progressionDecisionRef: "progression://decision/1",
+            decision: succeededDecision,
+          },
+        ])
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("C41 task evidenceBindings reject COORDINATION-owned records", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [
+            evidenceBinding(current, {
+              ownerScope: "COORDINATION",
+              taskId: null,
+            }),
+          ],
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(snap, current, [
+          { progressionDecisionRef: "progression://decision/1", decision },
+        ])
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("C42 snapshotDigest recomputation excludes pre-existing digest; duplicate progressionDecisionRef rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, { progressionDecisionFingerprint: fingerprint }),
+      ],
+    });
+    const recomputed = await computeCoordinationSharedStateSnapshotDigest(snap);
+    expect(recomputed).toBe(snap.snapshotDigest);
+    const mutated = {
+      ...snap,
+      snapshotDigest: FPA,
+    };
+    const recomputedFromMutated = await computeCoordinationSharedStateSnapshotDigest(mutated);
+    expect(recomputedFromMutated).toBe(snap.snapshotDigest);
+
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(snap, current, [
+          { progressionDecisionRef: "progression://decision/1", decision },
+          {
+            progressionDecisionRef: "progression://decision/1",
+            decision: progressionDecision(current, {
+              coordinationProgressionStatus: "READY",
+              coordinationProgressionReason: "READY_FOR_AUTHORIZATION",
+            }),
+          },
+        ])
+      ).ok,
+    ).toBe(false);
   });
 });

--- a/test/multiAgentCoordination.test.ts
+++ b/test/multiAgentCoordination.test.ts
@@ -11,19 +11,32 @@ import {
   MULTI_AGENT_COORDINATION_PROGRESSION_EVALUATOR_IMPLEMENTED,
   MULTI_AGENT_COORDINATION_PROGRESSION_INPUT_SCHEMA,
   MULTI_AGENT_COORDINATION_PROVIDER_INVOCATION_IMPLEMENTED,
+  MULTI_AGENT_COORDINATION_SHARED_STATE_BINDING_IMPLEMENTED,
+  MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA,
   captureCoordinationPlanFingerprintFacts,
   computeCoordinationPlanFingerprint,
+  computeCoordinationProgressionDecisionFingerprint,
+  computeCoordinationSharedStateSnapshotDigest,
   computeCoordinationTaskRoutingFingerprint,
   computeEffectiveConcurrencyCeiling,
   parseCoordinationCancellationRequestV1,
   parseCoordinationConcurrencyCeilingRefV1,
+  parseCoordinationEvidenceBindingV1,
   parseCoordinationPlanV1,
   parseCoordinationProgressionDecisionV1,
   parseCoordinationProgressionInputV1,
+  parseCoordinationSharedStateSnapshotV1,
+  parseCoordinationTaskStateBindingV1,
+  validateCoordinationSharedStateSnapshotV1,
   type CoordinationCancellationRequestV1,
+  type CoordinationEvidenceBindingV1,
   type CoordinationPlanBindingV1,
   type CoordinationPlanV1,
+  type CoordinationProgressionDecisionBindingV1,
+  type CoordinationProgressionDecisionV1,
   type CoordinationProgressionInputV1,
+  type CoordinationSharedStateSnapshotV1,
+  type CoordinationTaskStateBindingV1,
 } from "../src/domain/multiAgentCoordination";
 
 const FPA = "a".repeat(64);
@@ -930,5 +943,753 @@ describe("MULTI-AGENT-COORDINATION-V1 Slice B", () => {
         current,
       ),
     ).toEqual({ ok: false, reason: "REJECTED_CONTRADICTION" });
+  });
+});
+
+const FPD = "d".repeat(64);
+const FPE = "e".repeat(64);
+const FPW = "f".repeat(64);
+
+function evidenceBinding(
+  overrides: Partial<CoordinationEvidenceBindingV1> = {},
+): CoordinationEvidenceBindingV1 {
+  return {
+    ref: "evidence://task/1",
+    evidenceDigest: FPD,
+    ownerScope: "TASK",
+    coordinationId: "coordination-1",
+    taskId: "task-a",
+    kind: "EVIDENCE",
+    sourceId: "source-1",
+    ...overrides,
+  };
+}
+
+function progressionDecision(
+  planBinding: CoordinationPlanBindingV1,
+  overrides: Partial<CoordinationProgressionDecisionV1> = {},
+): CoordinationProgressionDecisionV1 {
+  return {
+    schemaVersion: MULTI_AGENT_COORDINATION_PROGRESSION_DECISION_SCHEMA,
+    coordinationId: planBinding.plan.coordinationId,
+    coordinationPlanFingerprint: planBinding.coordinationPlanFingerprint,
+    taskId: planBinding.plan.taskRefs[0].taskId,
+    coordinationProgressionStatus: "PLANNED",
+    coordinationProgressionReason: "PLAN_ADMITTED",
+    ...overrides,
+  };
+}
+
+async function progressionBinding(
+  planBinding: CoordinationPlanBindingV1,
+  ref = "progression://decision/1",
+  overrides: Partial<CoordinationProgressionDecisionV1> = {},
+): Promise<CoordinationProgressionDecisionBindingV1> {
+  const decision = progressionDecision(planBinding, overrides);
+  return {
+    progressionDecisionRef: ref,
+    decision,
+  };
+}
+
+function plannedTaskState(
+  planBinding: CoordinationPlanBindingV1,
+  overrides: Partial<CoordinationTaskStateBindingV1> = {},
+): CoordinationTaskStateBindingV1 {
+  return {
+    taskId: planBinding.plan.taskRefs[0].taskId,
+    taskRoutingFingerprint: planBinding.plan.taskRefs[0].taskRoutingFingerprint,
+    workerId: null,
+    workerAuthorityFingerprint: null,
+    routingDecisionFingerprint: null,
+    humanDecisionRef: null,
+    executionAuthorizationRef: null,
+    executionAttemptId: null,
+    executionOutcomeRef: null,
+    resultValidationRef: null,
+    resourceLockDecisionRef: null,
+    coordinationProgressionStatus: "PLANNED",
+    progressionDecisionRef: "progression://decision/1",
+    progressionDecisionFingerprint: FPD,
+    evidenceBindings: [],
+    ...overrides,
+  };
+}
+
+async function snapshotPayload(
+  planBinding: CoordinationPlanBindingV1,
+  overrides: {
+    taskStates?: CoordinationTaskStateBindingV1[];
+    coordinationEvidenceBindings?: CoordinationEvidenceBindingV1[];
+    auditBindings?: CoordinationEvidenceBindingV1[];
+    coordinationId?: string;
+    coordinationPlanFingerprint?: string;
+  } = {},
+): Promise<CoordinationSharedStateSnapshotV1> {
+  const payload = {
+    schemaVersion: MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA,
+    coordinationId: overrides.coordinationId ?? planBinding.plan.coordinationId,
+    coordinationPlanFingerprint:
+      overrides.coordinationPlanFingerprint ?? planBinding.coordinationPlanFingerprint,
+    taskStates: overrides.taskStates ?? [plannedTaskState(planBinding)],
+    coordinationEvidenceBindings: overrides.coordinationEvidenceBindings ?? [],
+    auditBindings: overrides.auditBindings ?? [],
+  };
+  const snapshotDigest = await computeCoordinationSharedStateSnapshotDigest(payload);
+  return { ...payload, snapshotDigest };
+}
+
+describe("MULTI-AGENT-COORDINATION-V1 Slice C", () => {
+  it("C01 valid FULL snapshot bound to exact plan identity passes", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    const result = await validateCoordinationSharedStateSnapshotV1(snap, current, [
+      {
+        progressionDecisionRef: "progression://decision/1",
+        decision,
+      },
+    ]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("C02 coordinationId mismatch fails closed", async () => {
+    const current = await binding();
+    const snap = await snapshotPayload(current, { coordinationId: "coordination-other" });
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(false);
+  });
+
+  it("C03 plan fingerprint mismatch fails closed", async () => {
+    const current = await binding();
+    const snap = await snapshotPayload(current, { coordinationPlanFingerprint: FPA });
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(false);
+  });
+
+  it("C04 unknown taskId fails closed", async () => {
+    const current = await binding();
+    const snap = await snapshotPayload(current, {
+      taskStates: [plannedTaskState(current, { taskId: "task-unknown" })],
+    });
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(false);
+  });
+
+  it("C05 duplicate task binding fails closed", async () => {
+    const current = await binding();
+    const state = plannedTaskState(current);
+    const snap = await snapshotPayload(current, { taskStates: [state, { ...state }] });
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(false);
+  });
+
+  it("C06 taskRoutingFingerprint mismatch fails closed", async () => {
+    const current = await binding();
+    const snap = await snapshotPayload(current, {
+      taskStates: [plannedTaskState(current, { taskRoutingFingerprint: FPB })],
+    });
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(false);
+  });
+
+  it("C07 lifecycle matrix accepts OPTIONAL null refs", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "WAITING_DEPENDENCY",
+      coordinationProgressionReason: "DEPENDENCY_PENDING",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "WAITING_DEPENDENCY",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(true);
+  });
+
+  it("C08 lifecycle matrix rejects missing REQUIRED ref", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "READY",
+      coordinationProgressionReason: "AUTHORIZED_NOT_INVOKED",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "READY",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C09 lifecycle matrix rejects MUST_BE_NULL contradiction", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C10 partial snapshot rejects", async () => {
+    const current = await binding(plan({
+      taskRefs: [
+        plan().taskRefs[0],
+        {
+          taskId: "task-b",
+          taskRoutingFingerprint: FPB,
+          dependencyTaskIds: [],
+          coordinationMode: "SEQUENTIAL",
+        },
+      ],
+    }));
+    const snap = await snapshotPayload(current);
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(false);
+  });
+
+  it("C11 task evidence owner mismatch rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [evidenceBinding({ taskId: "task-other" })],
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C12 coordination evidence with task owner rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [plannedTaskState(current, { progressionDecisionFingerprint: fingerprint })],
+      coordinationEvidenceBindings: [
+        evidenceBinding({ ownerScope: "TASK", taskId: "task-a", kind: "EVIDENCE" }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C13 audit binding unknown task rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [plannedTaskState(current, { progressionDecisionFingerprint: fingerprint })],
+      auditBindings: [
+        evidenceBinding({
+          ownerScope: "TASK",
+          taskId: "task-unknown",
+          kind: "AUDIT",
+          ref: "audit://1",
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C14 duplicate evidence identity tuple rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const duplicate = evidenceBinding();
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [duplicate, { ...duplicate }],
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C15 array order preserved; no sort/dedupe/repair", async () => {
+    const current = await binding();
+    const first = evidenceBinding({ ref: "evidence://first", sourceId: "source-a" });
+    const second = evidenceBinding({ ref: "evidence://second", sourceId: "source-b" });
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [first, second],
+        }),
+      ],
+    });
+    const result = await validateCoordinationSharedStateSnapshotV1(snap, current, [
+      { progressionDecisionRef: "progression://decision/1", decision },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.value.taskStates[0].evidenceBindings.map((item) => item.ref)).toEqual([
+      "evidence://first",
+      "evidence://second",
+    ]);
+  });
+
+  it("C16 bare ref cannot substitute for bounded attribution record", () => {
+    expect(parseCoordinationEvidenceBindingV1("evidence://only-a-ref").ok).toBe(false);
+  });
+
+  it("C17 progression identity mismatch fails closed", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "READY",
+      coordinationProgressionReason: "AUTHORIZED_NOT_INVOKED",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "PLANNED",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C18 snapshot validation changes no canonical execution/routing/policy result", async () => {
+    const current = await binding();
+    const raw = progressionInput(current);
+    const before = coordinationModule.evaluateCoordinationProgressionV1(raw, current);
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [plannedTaskState(current, { progressionDecisionFingerprint: fingerprint })],
+    });
+    await validateCoordinationSharedStateSnapshotV1(snap, current, [
+      { progressionDecisionRef: "progression://decision/1", decision },
+    ]);
+    const after = coordinationModule.evaluateCoordinationProgressionV1(raw, current);
+    expect(after).toEqual(before);
+  });
+
+  it("C19 no exported persistence / dispatch / invoke / approve / merge / deploy API", () => {
+    const prohibited = /^(execute|dispatch|invoke|approve|merge|deploy|persist)/i;
+    expect(Object.keys(coordinationModule).filter((key) => prohibited.test(key))).toEqual([]);
+    expect(coordinationModule.MULTI_AGENT_COORDINATION_SHARED_STATE_BINDING_IMPLEMENTED).toBe(true);
+    expect(coordinationModule.MULTI_AGENT_COORDINATION_EXECUTION_IMPLEMENTED).toBe(false);
+  });
+
+  it("C20 existing Slice B progression evaluator behavior unchanged", async () => {
+    const current = await binding();
+    expect(evaluatedDecision(current)).toMatchObject({
+      coordinationProgressionStatus: "PLANNED",
+      coordinationProgressionReason: "PLAN_ADMITTED",
+    });
+  });
+
+  it("C21 SUCCEEDED missing resultValidationRef rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "SUCCEEDED",
+      coordinationProgressionReason: "EXECUTION_AND_RESULT_VALID",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "SUCCEEDED",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: "evidence://auth",
+          executionAttemptId: "attempt-1",
+          executionOutcomeRef: "evidence://outcome",
+          resultValidationRef: null,
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [evidenceBinding()],
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C22 FAILED missing executionOutcomeRef/evidence rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "FAILED",
+      coordinationProgressionReason: "EXECUTION_FAILED",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "FAILED",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: "evidence://auth",
+          executionAttemptId: "attempt-1",
+          executionOutcomeRef: null,
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [],
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C23 NOT_EXECUTED with executionAttemptId rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "NOT_EXECUTED",
+      coordinationProgressionReason: "AUTHORIZATION_DENIED",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "NOT_EXECUTED",
+          executionAuthorizationRef: "evidence://auth",
+          executionAttemptId: "attempt-1",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C24 PLANNED with routing/execution/resource ref rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          resourceLockDecisionRef: "evidence://lock",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C25 WAITING_HUMAN_GATE with executionAuthorizationRef rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "WAITING_HUMAN_GATE",
+      coordinationProgressionReason: "HUMAN_GATE_WAIT",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "WAITING_HUMAN_GATE",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: "evidence://auth",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C26 WAITING_HUMAN_GATE without executionAuthorizationRef accepts when other requirements hold", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "WAITING_HUMAN_GATE",
+      coordinationProgressionReason: "HUMAN_GATE_WAIT",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "WAITING_HUMAN_GATE",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          humanDecisionRef: "evidence://human-gate",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(true);
+  });
+
+  it("C27 humanDecisionRef never substitutes for executionAuthorizationRef", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "READY",
+      coordinationProgressionReason: "AUTHORIZED_NOT_INVOKED",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "READY",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          humanDecisionRef: "evidence://human-gate",
+          executionAuthorizationRef: null,
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C28 valid exact snapshotDigest passes", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [plannedTaskState(current, { progressionDecisionFingerprint: fingerprint })],
+    });
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(true);
+  });
+
+  it("C29 snapshotDigest mismatch rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [plannedTaskState(current, { progressionDecisionFingerprint: fingerprint })],
+    });
+    snap.snapshotDigest = FPA;
+    expect((await validateCoordinationSharedStateSnapshotV1(snap, current)).ok).toBe(false);
+  });
+
+  it("C30 identical payload deterministically reproduces snapshotDigest", async () => {
+    const current = await binding();
+    const payload = {
+      schemaVersion: MULTI_AGENT_COORDINATION_SHARED_STATE_SNAPSHOT_SCHEMA,
+      coordinationId: current.plan.coordinationId,
+      coordinationPlanFingerprint: current.coordinationPlanFingerprint,
+      taskStates: [plannedTaskState(current)],
+      coordinationEvidenceBindings: [] as CoordinationEvidenceBindingV1[],
+      auditBindings: [] as CoordinationEvidenceBindingV1[],
+    };
+    const first = await computeCoordinationSharedStateSnapshotDigest(payload);
+    const second = await computeCoordinationSharedStateSnapshotDigest(payload);
+    expect(first).toBe(second);
+  });
+
+  it("C31 evidence binding missing evidenceDigest rejects", () => {
+    expect(
+      parseCoordinationEvidenceBindingV1({
+        ref: "evidence://task/1",
+        ownerScope: "TASK",
+        coordinationId: "coordination-1",
+        taskId: "task-a",
+        kind: "EVIDENCE",
+        sourceId: "source-1",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("C32 same ref + conflicting evidenceDigest rejects snapshot-wide", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [evidenceBinding({ ref: "evidence://shared", evidenceDigest: FPD })],
+        }),
+      ],
+      coordinationEvidenceBindings: [
+        evidenceBinding({
+          ref: "evidence://shared",
+          evidenceDigest: FPE,
+          ownerScope: "COORDINATION",
+          taskId: null,
+        }),
+      ],
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C33 progression status missing progressionDecisionRef/fingerprint rejects", async () => {
+    const current = await binding();
+    expect(
+      parseCoordinationTaskStateBindingV1({
+        ...plannedTaskState(current),
+        progressionDecisionRef: "",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("C34 progression binding identity mismatch rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current, {
+      coordinationProgressionStatus: "READY",
+      coordinationProgressionReason: "AUTHORIZED_NOT_INVOKED",
+    });
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          coordinationProgressionStatus: "READY",
+          workerId: "worker-1",
+          workerAuthorityFingerprint: FPW,
+          routingDecisionFingerprint: FPE,
+          executionAuthorizationRef: "evidence://auth",
+          progressionDecisionFingerprint: fingerprint,
+        }),
+      ],
+    });
+    expect(
+      (
+        await validateCoordinationSharedStateSnapshotV1(snap, current, [
+          {
+            progressionDecisionRef: "progression://decision/1",
+            decision: progressionDecision(current, { taskId: "task-other" }),
+          },
+        ])
+      ).ok,
+    ).toBe(false);
+  });
+
+  it("C35 duplicate evidence tuple across different arrays rejects", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const shared = evidenceBinding();
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [shared],
+        }),
+      ],
+      auditBindings: [{ ...shared, kind: "AUDIT", ref: "audit://dup" }],
+    });
+    const duplicateAudit = evidenceBinding({ kind: "AUDIT", ref: "audit://1" });
+    snap.auditBindings = [duplicateAudit, { ...duplicateAudit }];
+    snap.snapshotDigest = await computeCoordinationSharedStateSnapshotDigest({
+      schemaVersion: snap.schemaVersion,
+      coordinationId: snap.coordinationId,
+      coordinationPlanFingerprint: snap.coordinationPlanFingerprint,
+      taskStates: snap.taskStates,
+      coordinationEvidenceBindings: snap.coordinationEvidenceBindings,
+      auditBindings: snap.auditBindings,
+    });
+    expect(
+      (await validateCoordinationSharedStateSnapshotV1(snap, current, [
+        { progressionDecisionRef: "progression://decision/1", decision },
+      ])).ok,
+    ).toBe(false);
+  });
+
+  it("C36 global collision validation preserves original order", async () => {
+    const current = await binding();
+    const decision = progressionDecision(current);
+    const fingerprint = await computeCoordinationProgressionDecisionFingerprint(decision);
+    const taskEvidence = evidenceBinding({ ref: "evidence://task", sourceId: "source-task" });
+    const auditEvidence = evidenceBinding({
+      ref: "audit://1",
+      kind: "AUDIT",
+      sourceId: "source-audit",
+    });
+    const snap = await snapshotPayload(current, {
+      taskStates: [
+        plannedTaskState(current, {
+          progressionDecisionFingerprint: fingerprint,
+          evidenceBindings: [taskEvidence],
+        }),
+      ],
+      auditBindings: [auditEvidence],
+    });
+    const result = await validateCoordinationSharedStateSnapshotV1(snap, current, [
+      { progressionDecisionRef: "progression://decision/1", decision },
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.value.auditBindings[0].ref).toBe("audit://1");
+    expect(result.value.taskStates[0].evidenceBindings[0].ref).toBe("evidence://task");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **MAC-IMPL-SLICE-C** — pure shared-state / evidence binding contracts and deterministic validation per scope-c + correction-2.

## Changed files (locked scope)

- `src/domain/multiAgentCoordination.ts`
- `test/multiAgentCoordination.test.ts`

## Implementation Correction @ c0289e5

Addresses all six non-outdated review findings from comment #5519025716:

| # | Severity | Correction |
|---|---|---|
| 1 | P1 | `READY` auth-stage: `READY_FOR_AUTHORIZATION` allows `executionAuthorizationRef=null`; `AUTHORIZED_NOT_INVOKED` requires it |
| 2 | P1 | Every `CoordinationEvidenceBindingV1` carries `coordinationPlanFingerprint`; validated against snapshot/plan |
| 3 | P1 | Terminal `FAILED`/`SUCCEEDED` bind required refs to actual task evidence records (not merely non-empty array) |
| 4 | P2 | Task `evidenceBindings` reject `COORDINATION`-owned records |
| 5 | P2 | Snapshot digest explicitly constructs six covered fields (excludes any pre-existing `snapshotDigest`) |
| 6 | P2 | Duplicate `progressionDecisionRef` inputs fail closed before lookup |

Regression tests: **C37–C42**.

## Verification

```
npm run verify @ c0289e5c42f9b379e5bde22c970a80b578931917
```

- typecheck: PASS
- tests: **994 passed** (prior 988 + 6 correction regressions)
- build: PASS

## Gate sequence

| Gate | Status |
|---|---|
| Human Implementation Start GO | CONSUMED |
| Implementation Correction GO | CONSUMED |
| `npm run verify` | PASS @ c0289e5 |
| Independent Implementation Review | **PENDING** (fresh review on corrected HEAD) |
| Human Ready GO re-bind | **PENDING** for corrected HEAD |
| Merge GO / HOLD | **HOLD** (no merge authority) |

## Authority boundary

No persistence, dispatch, execution, GitHub mutation, Ready, Merge, or Deploy. Slice A/B behavior unchanged.

Docs-only PR #118 rebase remains **HOLD** (separate track).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05cee-70f4-7408-a182-4db1ff6e412b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05cee-70f4-7408-a182-4db1ff6e412b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

