### PR TITLE
docs: READ-ONLY isolation of /api/status GitHub observation failure

### DIFF
--- a/docs/control-center/github-observation-credential-v1.md
+++ b/docs/control-center/github-observation-credential-v1.md
@@ -1,0 +1,142 @@
+# GITHUB-OBSERVATION-CREDENTIAL-V1
+
+## Phase
+
+Human Secret Provision
+
+## Status
+
+DEFINED · Human Secret Provision GO **NOT CONSUMED**
+
+Prerequisite (closed):
+
+```text
+docs/control-center/github-observation-failure-readonly-v1.md
+READ-ONLY diagnosis = COMPLETE
+H1                  = CONFIRMED
+GITHUB_TOKEN        = NOT CONFIGURED on production Worker
+```
+
+This gate is **credential provisioning**, not further investigation.
+
+```text
+Code mutation              = NOT REQUIRED
+Worker redeploy            = NOT REQUIRED
+TARGET_REPOSITORY mutation = FORBIDDEN
+CLOUDFLARE_API_TOKEN use   = FORBIDDEN as GitHub credential
+Secret value in chat       = FORBIDDEN
+```
+
+Existing `observeRepository()` already sends `Authorization: Bearer` when
+`env.GITHUB_TOKEN` is set. Adding the production secret is sufficient.
+
+## Objective
+
+Restore authenticated, read-only GitHub observation of
+
+```text
+yasutakesougo/severe-behavior-support-spfx
+```
+
+so production `GET /api/status` can leave `evidenceState=ERROR`.
+
+## Bound permission (README, unchanged)
+
+Fine-grained PAT. Repository access = that repository **only**.
+
+Required:
+
+```text
+Contents          Read-only
+Pull requests     Read-only
+Commit statuses   Read-only
+Metadata          Read-only
+```
+
+Forbidden / unused:
+
+```text
+Checks                 不要
+Issues                 不要
+Contents Write         禁止
+Pull requests Write    禁止
+classic repo scope     不要
+GitHub write / merge   禁止
+```
+
+Do not reuse or overwrite `CLOUDFLARE_API_TOKEN`. That token is Cloudflare
+deploy auth only.
+
+## After Human Secret Provision GO (minimal change)
+
+Human-authenticated terminal / GitHub + Cloudflare Dashboard only. Do not
+paste the PAT into chat, commits, or screenshots.
+
+1. Create a fine-grained PAT with the bound permissions above.
+2. Register it on production Worker `ai-development-control-center` as secret
+   name `GITHUB_TOKEN` only:
+
+   ```bash
+   npx wrangler secret put GITHUB_TOKEN
+   ```
+
+   or Dashboard → Workers → `ai-development-control-center` → Secrets →
+   add `GITHUB_TOKEN`.
+
+3. Do not change application code. Do not `wrangler deploy` unless a later
+   Human separately authorizes it. Secret put updates the running Worker
+   binding without a new Version for this purpose.
+
+4. Do not grant the PAT to overview/public repos. Do not add it to staging
+   unless a later gate says so.
+
+## Closeout readback (after put)
+
+Public `GET /api/status` only. Do not print the PAT.
+
+```text
+GET https://ai-development-control-center.momosantanuki.workers.dev/api/status
+```
+
+Pass:
+
+```text
+HTTP                  = 200
+evidenceState         = CONFIRMED
+developmentStatus.main ≠ Unknown
+  (SHA observed; payload field is "Observed" when currentMain is set)
+openPrCount           = number (including 0)
+```
+
+HumanAction may still be `UNKNOWN` for PR-level evidence reasons. That is a
+**different** class and does **not** reopen H1.
+
+Fail (stay on this gate; do not widen scopes blindly):
+
+```text
+still evidenceState=ERROR
+→ H2/H3/H4 become applicable
+→ inspect PAT expiry and Repository access
+→ do not mint a second token until that check
+```
+
+## Non-effects
+
+```text
+severe-behavior-support-spfx mutation = 0
+GitHub write                          = 0
+application source change             = 0
+production Version ID change          = not required
+overview / overlay authority          = unchanged
+CLOUDFLARE_API_TOKEN                  = unchanged
+```
+
+## Current gate
+
+```text
+GITHUB-OBSERVATION-CREDENTIAL-V1
+Human Secret Provision GO = NOT CONSUMED
+
+NEXT
+= Human GO, then PAT create + production secret put + /api/status readback
+```

--- a/docs/control-center/github-observation-credential-v1.md
+++ b/docs/control-center/github-observation-credential-v1.md
@@ -6,7 +6,11 @@ Human Secret Provision
 
 ## Status
 
-DEFINED · Human Secret Provision GO **NOT CONSUMED**
+Human Secret Provision GO **CONSUMED**
+
+Execution in the Cloud Agent environment **BLOCKED** (cannot mint the bound
+PAT; cannot write production Worker secrets; agent GitHub token must not be
+reused). Remaining put is Human-terminal / Dashboard.
 
 Prerequisite (closed):
 
@@ -69,10 +73,14 @@ deploy auth only.
 
 ## After Human Secret Provision GO (minimal change)
 
-Human-authenticated terminal / GitHub + Cloudflare Dashboard only. Do not
-paste the PAT into chat, commits, or screenshots.
+GO is consumed. The following remains a **Human** action on a Human-authenticated
+GitHub + Cloudflare session. Do not paste the PAT into chat, commits, or
+screenshots.
 
-1. Create a fine-grained PAT with the bound permissions above.
+1. GitHub → Settings → Developer settings → Fine-grained personal access
+   tokens → Generate. Repository access =
+   `yasutakesougo/severe-behavior-support-spfx` only. Permissions = bound
+   set above.
 2. Register it on production Worker `ai-development-control-center` as secret
    name `GITHUB_TOKEN` only:
 
@@ -89,6 +97,32 @@ paste the PAT into chat, commits, or screenshots.
 
 4. Do not grant the PAT to overview/public repos. Do not add it to staging
    unless a later gate says so.
+
+5. Do **not** put the Cloud Agent / `gh` installation token as
+   `GITHUB_TOKEN`. That identity cannot see the private target (GET repo =
+   404) and is out of the bound permission set.
+
+### Agent execution record (GO consumed, 2026-09-02)
+
+```text
+Human Secret Provision GO     = CONSUMED
+PAT mint from this environment = BLOCKED
+  (no user fine-grained PAT API; agent gh cannot see target repo)
+production secret put         = BLOCKED
+  (CLOUDFLARE_API_TOKEN GET .../secrets = 403 code 10000)
+agent token reused as Worker GITHUB_TOKEN = NO
+code mutation                 = NO
+redeploy                      = NO
+
+GET /api/status (unchanged)
+  evidenceState = ERROR
+  main          = Unknown
+  openPrCount   = null
+```
+
+`CLOUDFLARE_API_TOKEN` is still deploy-only. Do not widen it unless a later
+Human gate says the agent must put the secret. Dashboard / Human wrangler
+put is the minimum path.
 
 ## Closeout readback (after put)
 
@@ -135,8 +169,13 @@ CLOUDFLARE_API_TOKEN                  = unchanged
 
 ```text
 GITHUB-OBSERVATION-CREDENTIAL-V1
-Human Secret Provision GO = NOT CONSUMED
+Human Secret Provision GO = CONSUMED
+
+PAT create + GITHUB_TOKEN put
+= HUMAN EXECUTION REMAINING
 
 NEXT
-= Human GO, then PAT create + production secret put + /api/status readback
+= Human mints bound fine-grained PAT
+  + production secret put GITHUB_TOKEN
+  + GET /api/status readback
 ```

--- a/docs/control-center/github-observation-failure-readonly-v1.md
+++ b/docs/control-center/github-observation-failure-readonly-v1.md
@@ -1,6 +1,6 @@
 # `/api/status` GitHub observation failure — READ-ONLY isolation
 
-**Status: READ-ONLY TRIAGE LOCKED · NO IMPLEMENTATION AUTHORIZED**
+**Status: READ-ONLY TRIAGE LOCKED · NEXT HUMAN ACTION LOCKED · NO IMPLEMENTATION AUTHORIZED**
 
 This note isolates the remaining HumanAction copy:
 
@@ -29,12 +29,44 @@ IN SCOPE
 = read-only isolation of GET /api/status GitHub observation fail-closed
 
 OUT OF SCOPE / NOT AUTHORIZED
-= GITHUB_TOKEN inspect, rotate, or put
+= GITHUB_TOKEN value read, display, rotate, or put
+= substituting CLOUDFLARE_API_TOKEN for GITHUB_TOKEN
 = TARGET_REPOSITORY change
 = observeRepository / resolver / payload-shape change
 = exposing GitHub HTTP status or token presence on the public API
 = mutating yasutakesougo/severe-behavior-support-spfx
 = treating overview / overlay CONFIRMED as /api/status CONFIRMED
+```
+
+Canonical lock after isolation:
+
+```text
+READ-ONLY ISOLATION
+= PASS
+
+Production deployment
+= HEALTHY
+
+/api/status transport
+= HTTP 200
+
+HumanAction UNKNOWN
+= resolver の fail-closed 結果
+
+Failure boundary
+= first authenticated GitHub repository observation
+
+Target
+= yasutakesougo/severe-behavior-support-spfx
+
+Implementation
+= NOT AUTHORIZED
+
+Secret mutation
+= NOT AUTHORIZED
+
+TARGET_REPOSITORY mutation
+= NOT AUTHORIZED
 ```
 
 ## 2. Live production observation (2026-09-01)
@@ -178,37 +210,103 @@ Public GitHub / Worker egress    = ruled out (overview + overlay CONFIRMED)
 Action-card scope misread        = already corrected; not this failure
 ```
 
-## 8. Next authorized step (Human)
-
-Read-only, no chat paste of secrets:
+## 8. Locked next gate (Human)
 
 ```text
-1. Confirm whether production Worker secret GITHUB_TOKEN exists
-   (Dashboard or `wrangler secret list` — name only).
+CURRENT
+= READ-ONLY diagnosis complete
 
-2. From a Human-authenticated terminal, GET
-   https://api.github.com/repos/yasutakesougo/severe-behavior-support-spfx
-   with that token. Record only the HTTP status (200 / 401 / 403 / 404).
+NEXT HUMAN ACTION
+= production GITHUB_TOKEN presence check
+  + authenticated GET status check
 
-3. Map:
-   missing secret     → H1
-   401 / 403          → H2 (or insufficient fine-grained permissions)
-   404                → H3 or H4
-   200                → reopen H5; do not guess
+Code mutation
+= HOLD
 
-4. Do not rotate, broaden, or put a token unless separately authorized.
-5. Do not change /api/status semantics to paper over ERROR.
+GitHub token replacement
+= HOLD until H1/H2/H3 classification
 ```
+
+Do not read or display token values. Confirm only the secret **name** and the
+authenticated GET **HTTP status**.
+
+`CLOUDFLARE_API_TOKEN` is Cloudflare deploy authentication for the agent
+environment. It is **not** `GITHUB_TOKEN`. Do not replace or overwrite one
+with the other.
+
+### PHASE 1 — Worker secret name presence
+
+```text
+production Worker = ai-development-control-center
+secret name       = GITHUB_TOKEN
+record            = exists / absent
+do not            = print, copy, or rotate the value
+```
+
+Dashboard → Workers → `ai-development-control-center` → Settings → Variables
+and Secrets, or a Human `wrangler secret list` that can actually read that
+script's secrets.
+
+### PHASE 2 — Authenticated repository probe
+
+Only after PHASE 1 = exists. Use the Worker GitHub credential (or the same
+fine-grained PAT it was minted from). Record HTTP status only.
+
+```text
+GET /repos/yasutakesougo/severe-behavior-support-spfx
+```
+
+```text
+HTTP classification
+├─ 200       → credential works → reopen H5
+├─ 401 / 403 → H2
+├─ 404       → H3 or H4
+└─ no token  → H1
+```
+
+If PHASE 2 returns **404**, do **not** mint a replacement token first. Confirm
+whether the existing fine-grained PAT includes
+`yasutakesougo/severe-behavior-support-spfx` in Repository access. Only after
+that grant check is H3 vs H4 separable. Recreate a token only if separately
+authorized after that classification.
+
+### This environment's PHASE 1 attempt (2026-09-02)
+
+Presence-only. Token values were not read or printed.
+
+```text
+shell GITHUB_TOKEN / GH_TOKEN     = absent
+CLOUDFLARE_API_TOKEN              = present (deploy auth)
+CLOUDFLARE_ACCOUNT_ID             = present
+GET /user/tokens/verify           = 200, success, status=active
+
+GET .../workers/scripts/ai-development-control-center
+                                  = 403 Authentication error [10000]
+GET .../workers/scripts/.../secrets
+                                  = 403 Authentication error [10000]
+wrangler secret list --name ai-development-control-center
+                                  = same 403
+
+PHASE 1 GITHUB_TOKEN presence     = UNCONFIRMED
+H1                                = NOT classified
+PHASE 2 authenticated GitHub GET  = NOT RUN
+  (no GITHUB_TOKEN available; Worker secret value must not be fetched)
+```
+
+The deploy token can authenticate to Cloudflare and cannot list production
+Worker secrets. That is a Cloudflare permission boundary, not a GitHub
+observation result.
 
 ## 9. Suggested follow-up slices (not started)
 
 Only if separately defined and authorized:
 
 ```text
-SLICE-DIAG-AUTH   Human records token presence + authenticated GET status
+SLICE-DIAG-AUTH   Human completes PHASE 1 + PHASE 2 (name + HTTP status)
 SLICE-OBSERVE-ERR optional: persist GitHub HTTP class (404/401/403/5xx) in
                   internal errors without leaking token or widening authority
 SLICE-TOKEN-FIX   Human secret put / rotation, same README permission boundary
+                  — only after H1/H2/H3 classification
 ```
 
 No implementation slice is opened by this document.
@@ -232,8 +330,15 @@ NOT
 
 OPEN
 = which of H1–H4 (token absence / invalid / no-grant / missing repo)
+= PHASE 1 presence UNCONFIRMED from this environment
 = requires Human secret-presence + authenticated GET
 
 IMPLEMENTATION
+= NOT AUTHORIZED
+
+Secret mutation
+= NOT AUTHORIZED
+
+TARGET_REPOSITORY mutation
 = NOT AUTHORIZED
 ```

--- a/docs/control-center/github-observation-failure-readonly-v1.md
+++ b/docs/control-center/github-observation-failure-readonly-v1.md
@@ -31,6 +31,8 @@ IN SCOPE
 OUT OF SCOPE / NOT AUTHORIZED
 = GITHUB_TOKEN value read, display, rotate, or put
 = substituting CLOUDFLARE_API_TOKEN for GITHUB_TOKEN
+= widening CLOUDFLARE_API_TOKEN just to list Worker secret names
+= curling with a Worker secret that cannot be re-displayed
 = TARGET_REPOSITORY change
 = observeRepository / resolver / payload-shape change
 = exposing GitHub HTTP status or token presence on the public API
@@ -38,35 +40,23 @@ OUT OF SCOPE / NOT AUTHORIZED
 = treating overview / overlay CONFIRMED as /api/status CONFIRMED
 ```
 
-Canonical lock after isolation:
+Canonical lock:
 
 ```text
-READ-ONLY ISOLATION
-= PASS
+PRODUCTION-DRIFT-CORRECTION = CLOSED / PASS
+READ-ONLY ISOLATION         = PASS
+Failure boundary            = private GitHub credential observation
 
-Production deployment
-= HEALTHY
+GITHUB_TOKEN presence       = UNCONFIRMED
+H1                          = UNCLASSIFIED
+Authenticated target GET    = NOT RUN
 
-/api/status transport
-= HTTP 200
+Code mutation               = HOLD
+Secret replacement          = HOLD
+TARGET_REPOSITORY mutation  = HOLD
 
-HumanAction UNKNOWN
-= resolver の fail-closed 結果
-
-Failure boundary
-= first authenticated GitHub repository observation
-
-Target
-= yasutakesougo/severe-behavior-support-spfx
-
-Implementation
-= NOT AUTHORIZED
-
-Secret mutation
-= NOT AUTHORIZED
-
-TARGET_REPOSITORY mutation
-= NOT AUTHORIZED
+NEXT
+= Human Dashboard check of production GITHUB_TOKEN name
 ```
 
 ## 2. Live production observation (2026-09-01)
@@ -215,60 +205,102 @@ Action-card scope misread        = already corrected; not this failure
 ```text
 CURRENT
 = READ-ONLY diagnosis complete
+= cause region = production GitHub credential boundary
+  (not code, not deploy)
 
-NEXT HUMAN ACTION
-= production GITHUB_TOKEN presence check
-  + authenticated GET status check
+NEXT
+= Human Dashboard check of production GITHUB_TOKEN name
 
 Code mutation
 = HOLD
 
-GitHub token replacement
-= HOLD until H1/H2/H3 classification
+Secret replacement
+= HOLD
+
+TARGET_REPOSITORY mutation
+= HOLD
+
+CLOUDFLARE_API_TOKEN scope expansion
+= NOT REQUIRED
 ```
 
-Do not read or display token values. Confirm only the secret **name** and the
-authenticated GET **HTTP status**.
+Cloudflare Worker secrets cannot be re-displayed. Dashboard confirmation that
+the name `GITHUB_TOKEN` exists does **not** yield a value that can be passed
+to an external `curl`. Do not screenshot values or paste token bodies.
 
-`CLOUDFLARE_API_TOKEN` is Cloudflare deploy authentication for the agent
-environment. It is **not** `GITHUB_TOKEN`. Do not replace or overwrite one
-with the other.
+`CLOUDFLARE_API_TOKEN` is Cloudflare deploy authentication. It is **not**
+`GITHUB_TOKEN`. Do not substitute. Do not widen it merely to list secret
+names. Dashboard PHASE 1 is the minimum change.
 
-### PHASE 1 — Worker secret name presence
+### PHASE 1 — Worker secret-name presence
 
 ```text
-production Worker = ai-development-control-center
-secret name       = GITHUB_TOKEN
-record            = exists / absent
-do not            = print, copy, or rotate the value
+Worker     = ai-development-control-center (production)
+surface    = Dashboard → Settings → Variables and Secrets
+record     = GITHUB_TOKEN exists / absent
+do not     = open the value, copy it, or rotate it
 ```
 
-Dashboard → Workers → `ai-development-control-center` → Settings → Variables
-and Secrets, or a Human `wrangler secret list` that can actually read that
-script's secrets.
+```text
+PHASE 1
+Production Worker secret-name presence
 
-### PHASE 2 — Authenticated repository probe
+GITHUB_TOKEN absent
+→ H1 CONFIRMED
 
-Only after PHASE 1 = exists. Use the Worker GitHub credential (or the same
-fine-grained PAT it was minted from). Record HTTP status only.
+GITHUB_TOKEN present
+→ H1 REJECTED
+→ H2 / H3 / H4 remain
+```
+
+### PHASE 1B — provenance / metadata, no credential mutation
+
+Only after PHASE 1 = present. Prefer GitHub token settings / PAT metadata
+over any new secret. Do not mint or put a token here.
+
+```text
+PHASE 1B
+Original GitHub credential provenance / metadata
+
+- token expired / revoked
+  → H2
+
+- fine-grained PAT で
+  severe-behavior-support-spfx が Repository access 外
+  → H3
+
+- token active
+  + repository access includes target
+  → H2/H3 を低下
+  → H4/H5 の切り分けへ
+```
+
+If PHASE 1B cannot identify the original PAT (no safe store, no GitHub token
+list match), stop. Do not invent a curl.
+
+```text
+H1 = REJECTED
+H2/H3/H4 = UNRESOLVED
+READ-ONLY limit reached
+token replacement = separate Human Gate (not opened here)
+```
+
+### PHASE 2 — authenticated GET (optional, only with recovered PAT value)
+
+Only if the original PAT value is available from a **safe store** that is not
+the Worker secret store. Never reconstruct the value from Cloudflare.
 
 ```text
 GET /repos/yasutakesougo/severe-behavior-support-spfx
 ```
 
 ```text
-HTTP classification
-├─ 200       → credential works → reopen H5
-├─ 401 / 403 → H2
-├─ 404       → H3 or H4
-└─ no token  → H1
+200       → first hop works → H5
+401 / 403 → H2
+404       → H3 or H4
+            (do not replace the token yet;
+             finish PHASE 1B repository-access check first)
 ```
-
-If PHASE 2 returns **404**, do **not** mint a replacement token first. Confirm
-whether the existing fine-grained PAT includes
-`yasutakesougo/severe-behavior-support-spfx` in Repository access. Only after
-that grant check is H3 vs H4 separable. Recreate a token only if separately
-authorized after that classification.
 
 ### This environment's PHASE 1 attempt (2026-09-02)
 
@@ -288,25 +320,22 @@ wrangler secret list --name ai-development-control-center
                                   = same 403
 
 PHASE 1 GITHUB_TOKEN presence     = UNCONFIRMED
-H1                                = NOT classified
-PHASE 2 authenticated GitHub GET  = NOT RUN
-  (no GITHUB_TOKEN available; Worker secret value must not be fetched)
+H1                                = UNCLASSIFIED
+Authenticated target GET          = NOT RUN
 ```
 
-The deploy token can authenticate to Cloudflare and cannot list production
-Worker secrets. That is a Cloudflare permission boundary, not a GitHub
-observation result.
+Leave `CLOUDFLARE_API_TOKEN` as deploy-only. Human Dashboard name check is
+enough for PHASE 1.
 
 ## 9. Suggested follow-up slices (not started)
 
 Only if separately defined and authorized:
 
 ```text
-SLICE-DIAG-AUTH   Human completes PHASE 1 + PHASE 2 (name + HTTP status)
-SLICE-OBSERVE-ERR optional: persist GitHub HTTP class (404/401/403/5xx) in
-                  internal errors without leaking token or widening authority
-SLICE-TOKEN-FIX   Human secret put / rotation, same README permission boundary
-                  — only after H1/H2/H3 classification
+SLICE-DIAG-AUTH   Human PHASE 1 (name) → PHASE 1B (metadata)
+                  → optional PHASE 2 if PAT value is in a safe store
+SLICE-OBSERVE-ERR optional: persist GitHub HTTP class without leaking token
+SLICE-TOKEN-FIX   separate Human Gate after H1/H2/H3 classification
 ```
 
 No implementation slice is opened by this document.
@@ -314,31 +343,19 @@ No implementation slice is opened by this document.
 ## 10. Result
 
 ```text
-READ-ONLY ISOLATION
-= PASS
+PRODUCTION-DRIFT-CORRECTION = CLOSED / PASS
+READ-ONLY ISOLATION         = PASS
+Failure boundary            = private GitHub credential observation
 
-FAILURE SITE
-= observeRepository(yasutakesougo/severe-behavior-support-spfx)
-= GitHub GET fail-closed
-= evidenceState=ERROR
-= HumanAction=UNKNOWN
+GITHUB_TOKEN presence       = UNCONFIRMED
+H1                          = UNCLASSIFIED
+Authenticated target GET    = NOT RUN
 
-NOT
-= production drift
-= /api/status HTTP failure
-= overview / overlay observation failure
+Code mutation               = HOLD
+Secret replacement          = HOLD
+TARGET_REPOSITORY mutation  = HOLD
 
-OPEN
-= which of H1–H4 (token absence / invalid / no-grant / missing repo)
-= PHASE 1 presence UNCONFIRMED from this environment
-= requires Human secret-presence + authenticated GET
-
-IMPLEMENTATION
-= NOT AUTHORIZED
-
-Secret mutation
-= NOT AUTHORIZED
-
-TARGET_REPOSITORY mutation
-= NOT AUTHORIZED
+NEXT
+= Human Dashboard check of production GITHUB_TOKEN name
 ```
+

--- a/docs/control-center/github-observation-failure-readonly-v1.md
+++ b/docs/control-center/github-observation-failure-readonly-v1.md
@@ -1,6 +1,6 @@
 # `/api/status` GitHub observation failure — READ-ONLY isolation
 
-**Status: READ-ONLY TRIAGE LOCKED · NEXT HUMAN ACTION LOCKED · NO IMPLEMENTATION AUTHORIZED**
+**Status: READ-ONLY DIAGNOSIS COMPLETE · H1 CONFIRMED · CREDENTIAL PROVISION NOT AUTHORIZED**
 
 This note isolates the remaining HumanAction copy:
 
@@ -40,24 +40,53 @@ OUT OF SCOPE / NOT AUTHORIZED
 = treating overview / overlay CONFIRMED as /api/status CONFIRMED
 ```
 
-Canonical lock:
+Canonical lock (Human Dashboard PHASE 1):
 
 ```text
 PRODUCTION-DRIFT-CORRECTION = CLOSED / PASS
 READ-ONLY ISOLATION         = PASS
-Failure boundary            = private GitHub credential observation
 
-GITHUB_TOKEN presence       = UNCONFIRMED
-H1                          = UNCLASSIFIED
+GITHUB_TOKEN presence       = ABSENT
+H1                          = CONFIRMED
+
+H2/H3/H4                    = NOT APPLICABLE YET
 Authenticated target GET    = NOT RUN
 
 Code mutation               = HOLD
-Secret replacement          = HOLD
 TARGET_REPOSITORY mutation  = HOLD
+READ-ONLY diagnosis         = COMPLETE
 
 NEXT
-= Human Dashboard check of production GITHUB_TOKEN name
+= separate Human Gate
+  GITHUB-OBSERVATION-CREDENTIAL-V1
+  Human Secret Provision GO
+  (not consumed)
 ```
+
+Causal chain (now closed as diagnosis):
+
+```text
+production Worker
+ai-development-control-center
+
+GITHUB_TOKEN
+= NOT CONFIGURED
+
+↓
+private severe-behavior-support-spfx を認証付きでGETできない
+
+↓
+GitHub 404
+
+↓
+evidenceState = ERROR
+
+↓
+HumanAction = UNKNOWN
+```
+
+Credential put, PAT mint, code change, and redeploy are **out of this document**.
+See `docs/control-center/github-observation-credential-v1.md`.
 
 ## 2. Live production observation (2026-09-01)
 
@@ -200,162 +229,52 @@ Public GitHub / Worker egress    = ruled out (overview + overlay CONFIRMED)
 Action-card scope misread        = already corrected; not this failure
 ```
 
-## 8. Locked next gate (Human)
+## 8. PHASE 1 result (Human Dashboard)
+
+Human confirmed production Worker secret-name presence:
 
 ```text
-CURRENT
-= READ-ONLY diagnosis complete
-= cause region = production GitHub credential boundary
-  (not code, not deploy)
-
-NEXT
-= Human Dashboard check of production GITHUB_TOKEN name
-
-Code mutation
-= HOLD
-
-Secret replacement
-= HOLD
-
-TARGET_REPOSITORY mutation
-= HOLD
-
-CLOUDFLARE_API_TOKEN scope expansion
-= NOT REQUIRED
+Worker     = ai-development-control-center
+surface    = Dashboard Secrets
+GITHUB_TOKEN
+           = NOT CONFIGURED / ABSENT
+H1         = CONFIRMED
 ```
 
-Cloudflare Worker secrets cannot be re-displayed. Dashboard confirmation that
-the name `GITHUB_TOKEN` exists does **not** yield a value that can be passed
-to an external `curl`. Do not screenshot values or paste token bodies.
+PHASE 1B and PHASE 2 are **not applicable**. There is no stored Worker
+credential whose metadata or recovered PAT value could be inspected.
 
-`CLOUDFLARE_API_TOKEN` is Cloudflare deploy authentication. It is **not**
-`GITHUB_TOKEN`. Do not substitute. Do not widen it merely to list secret
-names. Dashboard PHASE 1 is the minimum change.
+H2 / H3 / H4 remain unused until a credential exists and still fails.
 
-### PHASE 1 — Worker secret-name presence
+Agent-side Cloudflare secrets-list 403 is historical only. It is not needed
+once Dashboard PHASE 1 is recorded.
+
+## 9. Hand-off (out of READ-ONLY)
+
+This document does not authorize secret put.
 
 ```text
-Worker     = ai-development-control-center (production)
-surface    = Dashboard → Settings → Variables and Secrets
-record     = GITHUB_TOKEN exists / absent
-do not     = open the value, copy it, or rotate it
+NEXT GATE
+= GITHUB-OBSERVATION-CREDENTIAL-V1
+= Human Secret Provision GO
+= docs/control-center/github-observation-credential-v1.md
 ```
-
-```text
-PHASE 1
-Production Worker secret-name presence
-
-GITHUB_TOKEN absent
-→ H1 CONFIRMED
-
-GITHUB_TOKEN present
-→ H1 REJECTED
-→ H2 / H3 / H4 remain
-```
-
-### PHASE 1B — provenance / metadata, no credential mutation
-
-Only after PHASE 1 = present. Prefer GitHub token settings / PAT metadata
-over any new secret. Do not mint or put a token here.
-
-```text
-PHASE 1B
-Original GitHub credential provenance / metadata
-
-- token expired / revoked
-  → H2
-
-- fine-grained PAT で
-  severe-behavior-support-spfx が Repository access 外
-  → H3
-
-- token active
-  + repository access includes target
-  → H2/H3 を低下
-  → H4/H5 の切り分けへ
-```
-
-If PHASE 1B cannot identify the original PAT (no safe store, no GitHub token
-list match), stop. Do not invent a curl.
-
-```text
-H1 = REJECTED
-H2/H3/H4 = UNRESOLVED
-READ-ONLY limit reached
-token replacement = separate Human Gate (not opened here)
-```
-
-### PHASE 2 — authenticated GET (optional, only with recovered PAT value)
-
-Only if the original PAT value is available from a **safe store** that is not
-the Worker secret store. Never reconstruct the value from Cloudflare.
-
-```text
-GET /repos/yasutakesougo/severe-behavior-support-spfx
-```
-
-```text
-200       → first hop works → H5
-401 / 403 → H2
-404       → H3 or H4
-            (do not replace the token yet;
-             finish PHASE 1B repository-access check first)
-```
-
-### This environment's PHASE 1 attempt (2026-09-02)
-
-Presence-only. Token values were not read or printed.
-
-```text
-shell GITHUB_TOKEN / GH_TOKEN     = absent
-CLOUDFLARE_API_TOKEN              = present (deploy auth)
-CLOUDFLARE_ACCOUNT_ID             = present
-GET /user/tokens/verify           = 200, success, status=active
-
-GET .../workers/scripts/ai-development-control-center
-                                  = 403 Authentication error [10000]
-GET .../workers/scripts/.../secrets
-                                  = 403 Authentication error [10000]
-wrangler secret list --name ai-development-control-center
-                                  = same 403
-
-PHASE 1 GITHUB_TOKEN presence     = UNCONFIRMED
-H1                                = UNCLASSIFIED
-Authenticated target GET          = NOT RUN
-```
-
-Leave `CLOUDFLARE_API_TOKEN` as deploy-only. Human Dashboard name check is
-enough for PHASE 1.
-
-## 9. Suggested follow-up slices (not started)
-
-Only if separately defined and authorized:
-
-```text
-SLICE-DIAG-AUTH   Human PHASE 1 (name) → PHASE 1B (metadata)
-                  → optional PHASE 2 if PAT value is in a safe store
-SLICE-OBSERVE-ERR optional: persist GitHub HTTP class without leaking token
-SLICE-TOKEN-FIX   separate Human Gate after H1/H2/H3 classification
-```
-
-No implementation slice is opened by this document.
 
 ## 10. Result
 
 ```text
 PRODUCTION-DRIFT-CORRECTION = CLOSED / PASS
 READ-ONLY ISOLATION         = PASS
-Failure boundary            = private GitHub credential observation
 
-GITHUB_TOKEN presence       = UNCONFIRMED
-H1                          = UNCLASSIFIED
+GITHUB_TOKEN presence       = ABSENT
+H1                          = CONFIRMED
+
+H2/H3/H4                    = NOT APPLICABLE YET
 Authenticated target GET    = NOT RUN
 
 Code mutation               = HOLD
-Secret replacement          = HOLD
 TARGET_REPOSITORY mutation  = HOLD
-
-NEXT
-= Human Dashboard check of production GITHUB_TOKEN name
+READ-ONLY diagnosis         = COMPLETE
 ```
+
 

--- a/docs/control-center/github-observation-failure-readonly-v1.md
+++ b/docs/control-center/github-observation-failure-readonly-v1.md
@@ -57,10 +57,9 @@ TARGET_REPOSITORY mutation  = HOLD
 READ-ONLY diagnosis         = COMPLETE
 
 NEXT
-= separate Human Gate
-  GITHUB-OBSERVATION-CREDENTIAL-V1
-  Human Secret Provision GO
-  (not consumed)
+= GITHUB-OBSERVATION-CREDENTIAL-V1
+  Human Secret Provision GO = CONSUMED
+  PAT create + production secret put = HUMAN EXECUTION REMAINING
 ```
 
 Causal chain (now closed as diagnosis):

--- a/docs/control-center/github-observation-failure-readonly-v1.md
+++ b/docs/control-center/github-observation-failure-readonly-v1.md
@@ -1,0 +1,239 @@
+# `/api/status` GitHub observation failure — READ-ONLY isolation
+
+**Status: READ-ONLY TRIAGE LOCKED · NO IMPLEMENTATION AUTHORIZED**
+
+This note isolates the remaining HumanAction copy:
+
+```text
+判定できません
+GitHubの状態取得に失敗しました。
+```
+
+It is **not** a production-deploy diagnosis. Production drift correction remains closed.
+
+```text
+PRODUCTION-DRIFT-CORRECTION
+Exact deploy HEAD     = abac2ff1b3f704bf4cdb59e1bfaf3c148a8a19a0
+verify                = PASS / 952 tests
+Cloudflare Version ID = 4f8d9bac-4c23-4bb6-a21d-d41b056d1221
+/api/repositories/overview = 200
+Action-card repository scope = PASS
+Rendered Browser Acceptance = PASS
+RESULT                = CLOSED / PASS
+```
+
+## 1. What this slice is / is not
+
+```text
+IN SCOPE
+= read-only isolation of GET /api/status GitHub observation fail-closed
+
+OUT OF SCOPE / NOT AUTHORIZED
+= GITHUB_TOKEN inspect, rotate, or put
+= TARGET_REPOSITORY change
+= observeRepository / resolver / payload-shape change
+= exposing GitHub HTTP status or token presence on the public API
+= mutating yasutakesougo/severe-behavior-support-spfx
+= treating overview / overlay CONFIRMED as /api/status CONFIRMED
+```
+
+## 2. Live production observation (2026-09-01)
+
+`GET https://ai-development-control-center.momosantanuki.workers.dev/api/status`
+
+```text
+HTTP                = 200
+Cache-Control       = no-store
+action.status       = UNKNOWN
+action.title        = 判定できません
+action.reason       = GitHubの状態取得に失敗しました。
+action.sourceRefs   = github:repo:yasutakesougo/severe-behavior-support-spfx
+developmentStatus.repository   = yasutakesougo/severe-behavior-support-spfx
+developmentStatus.main         = Unknown
+developmentStatus.openPrCount  = null
+developmentStatus.evidenceState = ERROR
+evidence            = null
+decisionFingerprint = ABSENT
+```
+
+The UI copy is the resolver mapping for `evidenceState === "ERROR"`. The Worker
+route itself is healthy. This is **not** an `/api/status` HTTP failure and
+**not** the client fallback (`状態をまだ取得できていません。`).
+
+## 3. Exact fail-closed path
+
+```text
+GET /api/status
+→ TARGET_REPOSITORY = yasutakesougo/severe-behavior-support-spfx   (src/worker/index.ts)
+→ observeRepository(TARGET_REPOSITORY, env)                       (src/worker/github/readOnlyAdapter.ts)
+→ githubGet GET /repos/{TARGET_REPOSITORY}
+   optional Authorization: Bearer env.GITHUB_TOKEN
+→ any non-OK or thrown fetch
+   → evidenceState = ERROR
+   → errors        = ["GitHub API request failed"]   (internal only)
+   → currentMain   = null
+   → openPullRequests = null
+→ resolveHumanAction
+   → UNKNOWN / 判定できません / GitHubの状態取得に失敗しました。
+→ buildStatusPayload
+   → public JSON above (errors[] is not exposed)
+```
+
+The adapter's first required hop is `GET /repos/{repository}`. Later hops
+(default-branch commit, open pulls, per-PR detail) never run if that hop fails.
+
+`errors[]` and the GitHub HTTP status are intentionally not part of the public
+`/api/status` body. Public evidence therefore proves **fail-closed ERROR**, not
+**which GitHub status** caused it.
+
+## 4. Adjacent surfaces (different authority)
+
+Same production Worker, same window:
+
+| Surface | Repository | Auth mode | Result |
+|---|---|---|---|
+| `GET /api/status` | `yasutakesougo/severe-behavior-support-spfx` | Worker `GITHUB_TOKEN` if present | `evidenceState=ERROR` |
+| `GET /api/repositories/overview` | 3 public repos | `PUBLIC_UNAUTHENTICATED` | all `CONFIRMED` |
+| `GET /api/status-overlay` | `yasutakesougo/ai-development-control-center` | overlay observer | `200`, `main.sha=abac2ff1…` |
+
+Overview allow-list (`PUBLIC_OVERVIEW_REPOSITORIES`) does **not** include
+`severe-behavior-support-spfx`. `isPublicOverviewRepository(...)` is false for
+that name. Overview CONFIRMED cannot rescue `/api/status`.
+
+This matches CONTROL-CENTER-ACTION-SCOPE-CLARITY-V1: the action-card judges
+one private target; the fleet card judges three public repos.
+
+## 5. Unauthenticated GitHub probes (this environment)
+
+No Worker secret was read. Probes used the public GitHub REST API only.
+
+```text
+GET /repos/yasutakesougo/severe-behavior-support-spfx
+  → 404 {"message":"Not Found"}
+
+GET /repos/yasutakesougo/severe-behavior-support-spfx/commits/main
+  → 404
+
+GET /repos/yasutakesougo/severe-behavior-support-spfx/pulls?state=open&per_page=1
+  → 404
+
+GET /repos/yasutakesougo/ai-development-control-center
+  → 200  private=false  visibility=public  default_branch=main
+```
+
+GitHub returns **404** for both missing and private-without-access repositories.
+Unauthenticated 404 is therefore consistent with:
+
+```text
+A. repository is private and this caller has no grant
+B. repository does not exist / was renamed
+```
+
+It is **not** consistent with “GitHub.com is down” or “the Worker cannot reach
+api.github.com at all”: the same network successfully observed the public
+Control Center repository and served overview + overlay CONFIRMED.
+
+README already states that private-repo observation requires a Worker
+`GITHUB_TOKEN` (fine-grained PAT, GET-only, Contents / Pull requests /
+Commit statuses / Metadata read). Without a valid grant, `observeRepository`
+must fail closed.
+
+Staging historically showed the same public shape when no staging token was
+configured (`docs/mvp-3-approval-ledger-staging-pilot-v1.md`). That is the
+same fail-closed class, not proof of current production secret state.
+
+## 6. Remaining hypotheses (cannot distinguish from public evidence)
+
+These are ordered by how far public evidence can go. None is confirmed.
+
+| ID | Hypothesis | Public evidence | What would confirm it (Human-only) |
+|---|---|---|---|
+| H1 | Production `GITHUB_TOKEN` absent | Compatible with unauth 404 + ERROR | Cloudflare / `wrangler secret` **presence** check. Do not paste the value. |
+| H2 | Token present but expired / revoked / malformed | Compatible | Authenticated `GET /repos/yasutakesougo/severe-behavior-support-spfx` → 401 |
+| H3 | Token valid but no access to this private repo | Compatible | Same authenticated GET → 404 |
+| H4 | Repo renamed or deleted | Compatible with 404 | Same authenticated GET → 404 **and** Human confirms the repo identity |
+| H5 | First hop succeeds; later required hop fails | **Not** favored: public payload has `main=Unknown` and `openPrCount=null`, which is the catch-all before any PR loop | Authenticated GET repo = 200, then check commits/pulls |
+| H6 | Transient GitHub / Worker egress | **Not** favored: repeated `/api/status` ERROR plus stable unauth 404 | Would need a later CONFIRMED sample without secret change |
+
+H1–H4 collapse to one operational class until a Human inspects token **presence**
+and one authenticated GET against the target repository:
+
+```text
+CLASS
+= authenticated observation of a non-public TARGET_REPOSITORY is not succeeding
+```
+
+This environment must not perform that authenticated GET. Doing so would
+require reading or supplying `GITHUB_TOKEN`.
+
+## 7. What is already ruled out
+
+```text
+Cloudflare deploy drift          = ruled out (HEAD abac2ff1 locked, Version 4f8d9bac…)
+/api/status route broken         = ruled out (HTTP 200 JSON)
+UI mis-binding of overlay/overview into HumanAction
+                                 = ruled out (sourceRefs + repository = TARGET_REPOSITORY)
+Resolver defect for ERROR        = ruled out (explicit mapping, unit-covered)
+Public GitHub / Worker egress    = ruled out (overview + overlay CONFIRMED)
+Action-card scope misread        = already corrected; not this failure
+```
+
+## 8. Next authorized step (Human)
+
+Read-only, no chat paste of secrets:
+
+```text
+1. Confirm whether production Worker secret GITHUB_TOKEN exists
+   (Dashboard or `wrangler secret list` — name only).
+
+2. From a Human-authenticated terminal, GET
+   https://api.github.com/repos/yasutakesougo/severe-behavior-support-spfx
+   with that token. Record only the HTTP status (200 / 401 / 403 / 404).
+
+3. Map:
+   missing secret     → H1
+   401 / 403          → H2 (or insufficient fine-grained permissions)
+   404                → H3 or H4
+   200                → reopen H5; do not guess
+
+4. Do not rotate, broaden, or put a token unless separately authorized.
+5. Do not change /api/status semantics to paper over ERROR.
+```
+
+## 9. Suggested follow-up slices (not started)
+
+Only if separately defined and authorized:
+
+```text
+SLICE-DIAG-AUTH   Human records token presence + authenticated GET status
+SLICE-OBSERVE-ERR optional: persist GitHub HTTP class (404/401/403/5xx) in
+                  internal errors without leaking token or widening authority
+SLICE-TOKEN-FIX   Human secret put / rotation, same README permission boundary
+```
+
+No implementation slice is opened by this document.
+
+## 10. Result
+
+```text
+READ-ONLY ISOLATION
+= PASS
+
+FAILURE SITE
+= observeRepository(yasutakesougo/severe-behavior-support-spfx)
+= GitHub GET fail-closed
+= evidenceState=ERROR
+= HumanAction=UNKNOWN
+
+NOT
+= production drift
+= /api/status HTTP failure
+= overview / overlay observation failure
+
+OPEN
+= which of H1–H4 (token absence / invalid / no-grant / missing repo)
+= requires Human secret-presence + authenticated GET
+
+IMPLEMENTATION
+= NOT AUTHORIZED
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GITHUB-OBSERVATION-CREDENTIAL-V1` **Human Secret Provision GO = CONSUMED**.

This environment **did not** mint a PAT or put `GITHUB_TOKEN`. The Cloud Agent GitHub identity cannot see `severe-behavior-support-spfx` (404) and must not be reused as the Worker secret. `CLOUDFLARE_API_TOKEN` still gets **403** on production Worker secrets.

`GET /api/status` is unchanged: `evidenceState=ERROR`.

## Remaining Human execution

1. Mint a fine-grained PAT: repo `yasutakesougo/severe-behavior-support-spfx` only; Contents / Pull requests / Commit statuses / Metadata read-only.
2. Production Worker `ai-development-control-center`: secret name `GITHUB_TOKEN` via Dashboard or `npx wrangler secret put GITHUB_TOKEN`.
3. No code change, no redeploy. Do not paste the PAT into chat.
4. Close on `GET /api/status` → `evidenceState=CONFIRMED`, `main=Observed`, `openPrCount` numeric.

[credential_go_consumed.txt](https://cursor.com/agents/bc-06eb0bc8-c650-4de8-af25-0d0b6f1aa967/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcredential_go_consumed.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06eb0bc8-c650-4de8-af25-0d0b6f1aa967?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06eb0bc8-c650-4de8-af25-0d0b6f1aa967&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

