### PR TITLE
CHAT-READBACK-V1: add read-only Human Gate MCP transport

### DIFF
--- a/src/domain/chatReadback.ts
+++ b/src/domain/chatReadback.ts
@@ -1,0 +1,145 @@
+export const CHAT_READBACK_SOURCE_ENDPOINT = "/api/status" as const;
+export const CHAT_READBACK_BOUNDARY = "READ_ONLY_NO_EXECUTION_AUTHORITY" as const;
+
+export type ChatReadbackHumanActionStatus =
+  | "ACTION_REQUIRED"
+  | "WAIT"
+  | "NO_ACTION"
+  | "UNKNOWN";
+
+export type ChatReadbackEvidenceState =
+  | "CONFIRMED"
+  | "MISSING"
+  | "CONTRADICTORY"
+  | "ERROR";
+
+export type ChatReadbackDecisionCandidate = "PRESENT" | "NOT_PRESENT" | "UNKNOWN";
+
+export interface ChatReadbackSuccess {
+  ok: true;
+  repository: string;
+  humanAction: {
+    status: ChatReadbackHumanActionStatus;
+    title: string;
+    instruction: string;
+    reason: string;
+    sourceRefs: string[];
+  };
+  evidenceState: ChatReadbackEvidenceState;
+  decisionCandidate: Exclude<ChatReadbackDecisionCandidate, "UNKNOWN">;
+  observedAt: string;
+  sourceEndpoint: typeof CHAT_READBACK_SOURCE_ENDPOINT;
+  boundary: typeof CHAT_READBACK_BOUNDARY;
+}
+
+export interface ChatReadbackFailure {
+  ok: false;
+  state: "SOURCE_UNAVAILABLE" | "INVALID_PAYLOAD";
+  decisionCandidate: "UNKNOWN";
+  sourceEndpoint: typeof CHAT_READBACK_SOURCE_ENDPOINT;
+  boundary: typeof CHAT_READBACK_BOUNDARY;
+}
+
+export type ChatReadbackResult = ChatReadbackSuccess | ChatReadbackFailure;
+
+const HUMAN_ACTION_STATUSES = new Set<ChatReadbackHumanActionStatus>([
+  "ACTION_REQUIRED",
+  "WAIT",
+  "NO_ACTION",
+  "UNKNOWN",
+]);
+
+const EVIDENCE_STATES = new Set<ChatReadbackEvidenceState>([
+  "CONFIRMED",
+  "MISSING",
+  "CONTRADICTORY",
+  "ERROR",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+export function invalidChatReadbackPayload(): ChatReadbackFailure {
+  return {
+    ok: false,
+    state: "INVALID_PAYLOAD",
+    decisionCandidate: "UNKNOWN",
+    sourceEndpoint: CHAT_READBACK_SOURCE_ENDPOINT,
+    boundary: CHAT_READBACK_BOUNDARY,
+  };
+}
+
+export function unavailableChatReadbackSource(): ChatReadbackFailure {
+  return {
+    ok: false,
+    state: "SOURCE_UNAVAILABLE",
+    decisionCandidate: "UNKNOWN",
+    sourceEndpoint: CHAT_READBACK_SOURCE_ENDPOINT,
+    boundary: CHAT_READBACK_BOUNDARY,
+  };
+}
+
+export function projectChatReadbackPayload(payload: unknown): ChatReadbackResult {
+  if (!isRecord(payload)) return invalidChatReadbackPayload();
+
+  const action = payload.action;
+  const developmentStatus = payload.developmentStatus;
+  const observedAt = payload.observedAt;
+
+  if (!isRecord(action) || !isRecord(developmentStatus)) return invalidChatReadbackPayload();
+
+  const actionStatus = action.status;
+  const title = action.title;
+  const instruction = action.instruction;
+  const reason = action.reason;
+  const sourceRefs = action.sourceRefs;
+  const repository = developmentStatus.repository;
+  const evidenceState = developmentStatus.evidenceState;
+
+  if (
+    typeof actionStatus !== "string" ||
+    !HUMAN_ACTION_STATUSES.has(actionStatus as ChatReadbackHumanActionStatus) ||
+    typeof title !== "string" ||
+    typeof instruction !== "string" ||
+    typeof reason !== "string" ||
+    !isStringArray(sourceRefs) ||
+    typeof repository !== "string" ||
+    repository.trim().length === 0 ||
+    typeof evidenceState !== "string" ||
+    !EVIDENCE_STATES.has(evidenceState as ChatReadbackEvidenceState) ||
+    typeof observedAt !== "string" ||
+    observedAt.trim().length === 0
+  ) {
+    return invalidChatReadbackPayload();
+  }
+
+  const hasDecisionFingerprint = Object.prototype.hasOwnProperty.call(payload, "decisionFingerprint");
+  if (
+    hasDecisionFingerprint &&
+    (typeof payload.decisionFingerprint !== "string" || payload.decisionFingerprint.trim().length === 0)
+  ) {
+    return invalidChatReadbackPayload();
+  }
+
+  return {
+    ok: true,
+    repository,
+    humanAction: {
+      status: actionStatus as ChatReadbackHumanActionStatus,
+      title,
+      instruction,
+      reason,
+      sourceRefs: [...sourceRefs],
+    },
+    evidenceState: evidenceState as ChatReadbackEvidenceState,
+    decisionCandidate: hasDecisionFingerprint ? "PRESENT" : "NOT_PRESENT",
+    observedAt,
+    sourceEndpoint: CHAT_READBACK_SOURCE_ENDPOINT,
+    boundary: CHAT_READBACK_BOUNDARY,
+  };
+}

--- a/src/worker/chatReadbackMcp.ts
+++ b/src/worker/chatReadbackMcp.ts
@@ -67,6 +67,16 @@ function negotiatedProtocolVersion(params: unknown): string {
   return LATEST_PROTOCOL_VERSION;
 }
 
+function isOriginAllowed(request: Request): boolean {
+  const origin = request.headers.get("Origin");
+  if (origin === null) return true;
+  try {
+    return new URL(origin).origin === new URL(request.url).origin;
+  } catch {
+    return false;
+  }
+}
+
 function toolDefinition() {
   return {
     name: TOOL_NAME,
@@ -144,6 +154,10 @@ export async function handleChatReadbackMcp(
   request: Request,
   dependencies: ChatReadbackMcpDependencies,
 ): Promise<Response> {
+  if (!isOriginAllowed(request)) {
+    return new Response("Forbidden", { status: 403, headers: { "Cache-Control": "no-store" } });
+  }
+
   if (request.method !== "POST") {
     return new Response("Method Not Allowed", {
       status: 405,
@@ -169,9 +183,6 @@ export async function handleChatReadbackMcp(
   if (!isJsonRpcRequest(message)) return jsonRpcError(null, -32600, "Invalid Request");
 
   if (!("id" in message)) {
-    if (message.method === "notifications/initialized" || message.method.startsWith("notifications/")) {
-      return new Response(null, { status: 202, headers: { "Cache-Control": "no-store" } });
-    }
     return new Response(null, { status: 202, headers: { "Cache-Control": "no-store" } });
   }
 

--- a/src/worker/chatReadbackMcp.ts
+++ b/src/worker/chatReadbackMcp.ts
@@ -1,0 +1,226 @@
+import {
+  projectChatReadbackPayload,
+  unavailableChatReadbackSource,
+  type ChatReadbackResult,
+} from "../domain/chatReadback";
+
+const SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26"] as const;
+const LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+const TOOL_NAME = "read_human_gate" as const;
+
+type JsonRpcId = string | number | null;
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: unknown;
+};
+
+export interface ChatReadbackMcpDependencies {
+  loadStatusPayload(): Promise<unknown>;
+}
+
+function responseHeaders(): HeadersInit {
+  return {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: responseHeaders() });
+}
+
+function jsonRpcResult(id: JsonRpcId, result: unknown): Response {
+  return jsonResponse({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id: JsonRpcId, code: number, message: string): Response {
+  return jsonResponse({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.jsonrpc !== "2.0" || typeof candidate.method !== "string") return false;
+  if (
+    "id" in candidate &&
+    candidate.id !== null &&
+    typeof candidate.id !== "string" &&
+    typeof candidate.id !== "number"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function negotiatedProtocolVersion(params: unknown): string {
+  if (typeof params === "object" && params !== null && !Array.isArray(params)) {
+    const requested = (params as Record<string, unknown>).protocolVersion;
+    if (
+      typeof requested === "string" &&
+      (SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(requested)
+    ) {
+      return requested;
+    }
+  }
+  return LATEST_PROTOCOL_VERSION;
+}
+
+function toolDefinition() {
+  return {
+    name: TOOL_NAME,
+    title: "Read Human Gate",
+    description:
+      "Use this when the user asks for the current Human Action, evidence state, decision-candidate presence, instruction, reason, or provenance for the single repository fixed by the Control Center. Read-only; never authorizes or performs Human GO, merge, deploy, or execution.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["ok", "decisionCandidate", "sourceEndpoint", "boundary"],
+      properties: {
+        ok: { type: "boolean" },
+        repository: { type: "string" },
+        humanAction: {
+          type: "object",
+          additionalProperties: false,
+          required: ["status", "title", "instruction", "reason", "sourceRefs"],
+          properties: {
+            status: { enum: ["ACTION_REQUIRED", "WAIT", "NO_ACTION", "UNKNOWN"] },
+            title: { type: "string" },
+            instruction: { type: "string" },
+            reason: { type: "string" },
+            sourceRefs: { type: "array", items: { type: "string" } },
+          },
+        },
+        evidenceState: { enum: ["CONFIRMED", "MISSING", "CONTRADICTORY", "ERROR"] },
+        decisionCandidate: { enum: ["PRESENT", "NOT_PRESENT", "UNKNOWN"] },
+        observedAt: { type: "string" },
+        state: { enum: ["SOURCE_UNAVAILABLE", "INVALID_PAYLOAD"] },
+        sourceEndpoint: { const: "/api/status" },
+        boundary: { const: "READ_ONLY_NO_EXECUTION_AUTHORITY" },
+      },
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  };
+}
+
+function toolContent(result: ChatReadbackResult) {
+  if (!result.ok) {
+    return `Human Gate readback unavailable: ${result.state}. Decision Candidate=UNKNOWN. Boundary=READ-ONLY / NO EXECUTION AUTHORITY.`;
+  }
+  return [
+    `Repository: ${result.repository}`,
+    `Human Action: ${result.humanAction.status}`,
+    `Evidence: ${result.evidenceState}`,
+    `Decision Candidate: ${result.decisionCandidate}`,
+    `Instruction: ${result.humanAction.instruction}`,
+    `Reason: ${result.humanAction.reason}`,
+    `Observed At: ${result.observedAt}`,
+    `Source Refs: ${result.humanAction.sourceRefs.join(", ") || "(none)"}`,
+    "Boundary: READ-ONLY / NO EXECUTION AUTHORITY",
+  ].join("\n");
+}
+
+async function callReadHumanGate(dependencies: ChatReadbackMcpDependencies): Promise<ChatReadbackResult> {
+  try {
+    const payload = await dependencies.loadStatusPayload();
+    return projectChatReadbackPayload(payload);
+  } catch {
+    return unavailableChatReadbackSource();
+  }
+}
+
+export async function handleChatReadbackMcp(
+  request: Request,
+  dependencies: ChatReadbackMcpDependencies,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "POST", "Cache-Control": "no-store" },
+    });
+  }
+
+  const protocolHeader = request.headers.get("MCP-Protocol-Version");
+  if (
+    protocolHeader !== null &&
+    !(SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(protocolHeader)
+  ) {
+    return jsonResponse({ error: "Unsupported MCP protocol version" }, 400);
+  }
+
+  let message: unknown;
+  try {
+    message = await request.json();
+  } catch {
+    return jsonRpcError(null, -32700, "Parse error");
+  }
+
+  if (!isJsonRpcRequest(message)) return jsonRpcError(null, -32600, "Invalid Request");
+
+  if (!("id" in message)) {
+    if (message.method === "notifications/initialized" || message.method.startsWith("notifications/")) {
+      return new Response(null, { status: 202, headers: { "Cache-Control": "no-store" } });
+    }
+    return new Response(null, { status: 202, headers: { "Cache-Control": "no-store" } });
+  }
+
+  const id = message.id ?? null;
+
+  if (message.method === "initialize") {
+    return jsonRpcResult(id, {
+      protocolVersion: negotiatedProtocolVersion(message.params),
+      capabilities: { tools: {} },
+      serverInfo: {
+        name: "ai-development-control-center-chat-readback",
+        title: "AI Development Control Center Chat Readback",
+        version: "1.0.0",
+      },
+      instructions:
+        "Read-only Human Gate readback for one server-fixed repository. Preserve source HumanAction vocabulary. Never infer or perform Human GO, merge, deploy, or execution authority.",
+    });
+  }
+
+  if (message.method === "ping") return jsonRpcResult(id, {});
+
+  if (message.method === "tools/list") {
+    return jsonRpcResult(id, { tools: [toolDefinition()] });
+  }
+
+  if (message.method === "tools/call") {
+    const params = message.params;
+    if (typeof params !== "object" || params === null || Array.isArray(params)) {
+      return jsonRpcError(id, -32602, "Invalid params");
+    }
+    const call = params as Record<string, unknown>;
+    if (call.name !== TOOL_NAME) return jsonRpcError(id, -32602, "Unknown tool");
+    if (
+      call.arguments !== undefined &&
+      (typeof call.arguments !== "object" ||
+        call.arguments === null ||
+        Array.isArray(call.arguments) ||
+        Object.keys(call.arguments as Record<string, unknown>).length > 0)
+    ) {
+      return jsonRpcError(id, -32602, "read_human_gate accepts no arguments");
+    }
+
+    const result = await callReadHumanGate(dependencies);
+    return jsonRpcResult(id, {
+      structuredContent: result,
+      content: [{ type: "text", text: toolContent(result) }],
+      ...(result.ok ? {} : { isError: true }),
+    });
+  }
+
+  return jsonRpcError(id, -32601, "Method not found");
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,5 +1,6 @@
 import { resolveHumanAction } from "../domain/humanActionResolver";
 import { handleAuthStatus } from "./auth/authStatus";
+import { handleChatReadbackMcp } from "./chatReadbackMcp";
 import { observeRepository } from "./github/readOnlyAdapter";
 import { handleLedgerRecordPost, handleLedgerRecordsGet, type LedgerApiEnv } from "./ledger/recordsApi";
 import { handleRepositoryDetailGet, handleRepositoryOverviewGet } from "./repositoryOverviewApi";
@@ -19,6 +20,12 @@ interface Env extends LedgerApiEnv {
 
 const TARGET_REPOSITORY = "yasutakesougo/severe-behavior-support-spfx";
 
+async function loadStatusPayload(env: Env): Promise<Record<string, unknown>> {
+  const facts = await observeRepository(TARGET_REPOSITORY, env);
+  const action = resolveHumanAction(facts);
+  return buildStatusPayload(facts, action);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -36,10 +43,14 @@ export default {
     }
 
     if (request.method === "GET" && url.pathname === "/api/status") {
-      const facts = await observeRepository(TARGET_REPOSITORY, env);
-      const action = resolveHumanAction(facts);
-      const payload = await buildStatusPayload(facts, action);
+      const payload = await loadStatusPayload(env);
       return Response.json(payload, { headers: { "Cache-Control": "no-store" } });
+    }
+
+    if (url.pathname === "/mcp") {
+      return handleChatReadbackMcp(request, {
+        loadStatusPayload: () => loadStatusPayload(env),
+      });
     }
 
     if (request.method === "GET" && url.pathname === "/api/status-overlay") {

--- a/test/chatReadback.test.ts
+++ b/test/chatReadback.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectChatReadbackPayload,
+  unavailableChatReadbackSource,
+} from "../src/domain/chatReadback";
+
+function validPayload() {
+  return {
+    action: {
+      status: "ACTION_REQUIRED",
+      title: "Review current scope",
+      instruction: "Read the independent scope review.",
+      reason: "Human decision required.",
+      sourceRefs: ["github:pr:138"],
+    },
+    developmentStatus: {
+      repository: "yasutakesougo/severe-behavior-support-spfx",
+      evidenceState: "CONFIRMED",
+    },
+    observedAt: "2026-09-02T03:00:00.000Z",
+    decisionFingerprint: "server-only-fingerprint",
+    evidence: [{ privateFutureField: "must-not-leak" }],
+  };
+}
+
+describe("CHAT-READBACK-V1 projection", () => {
+  it("projects only the exact allowlisted operational fields", () => {
+    const result = projectChatReadbackPayload(validPayload());
+
+    expect(result).toEqual({
+      ok: true,
+      repository: "yasutakesougo/severe-behavior-support-spfx",
+      humanAction: {
+        status: "ACTION_REQUIRED",
+        title: "Review current scope",
+        instruction: "Read the independent scope review.",
+        reason: "Human decision required.",
+        sourceRefs: ["github:pr:138"],
+      },
+      evidenceState: "CONFIRMED",
+      decisionCandidate: "PRESENT",
+      observedAt: "2026-09-02T03:00:00.000Z",
+      sourceEndpoint: "/api/status",
+      boundary: "READ_ONLY_NO_EXECUTION_AUTHORITY",
+    });
+    expect(result).not.toHaveProperty("evidence");
+    expect(result).not.toHaveProperty("decisionFingerprint");
+  });
+
+  it("emits NOT_PRESENT only after a valid payload without decisionFingerprint", () => {
+    const payload = validPayload();
+    delete (payload as Partial<typeof payload>).decisionFingerprint;
+
+    expect(projectChatReadbackPayload(payload)).toMatchObject({
+      ok: true,
+      decisionCandidate: "NOT_PRESENT",
+    });
+  });
+
+  it("fails closed for an unknown HumanAction vocabulary value", () => {
+    const payload = validPayload();
+    payload.action.status = "GO";
+
+    expect(projectChatReadbackPayload(payload)).toEqual({
+      ok: false,
+      state: "INVALID_PAYLOAD",
+      decisionCandidate: "UNKNOWN",
+      sourceEndpoint: "/api/status",
+      boundary: "READ_ONLY_NO_EXECUTION_AUTHORITY",
+    });
+  });
+
+  it("fails closed for an unknown EvidenceState value", () => {
+    const payload = validPayload();
+    payload.developmentStatus.evidenceState = "HEALTHY";
+
+    expect(projectChatReadbackPayload(payload)).toMatchObject({
+      ok: false,
+      state: "INVALID_PAYLOAD",
+      decisionCandidate: "UNKNOWN",
+    });
+  });
+
+  it("does not confuse a malformed fingerprint with NOT_PRESENT", () => {
+    const payload = validPayload();
+    payload.decisionFingerprint = "";
+
+    expect(projectChatReadbackPayload(payload)).toMatchObject({
+      ok: false,
+      state: "INVALID_PAYLOAD",
+      decisionCandidate: "UNKNOWN",
+    });
+  });
+
+  it("requires provenance fields before emitting a normal state", () => {
+    const payload = validPayload();
+    payload.developmentStatus.repository = "";
+
+    expect(projectChatReadbackPayload(payload)).toMatchObject({
+      ok: false,
+      state: "INVALID_PAYLOAD",
+      decisionCandidate: "UNKNOWN",
+    });
+  });
+
+  it("represents transport/source failure separately from invalid payload", () => {
+    expect(unavailableChatReadbackSource()).toEqual({
+      ok: false,
+      state: "SOURCE_UNAVAILABLE",
+      decisionCandidate: "UNKNOWN",
+      sourceEndpoint: "/api/status",
+      boundary: "READ_ONLY_NO_EXECUTION_AUTHORITY",
+    });
+  });
+});

--- a/test/chatReadbackMcp.test.ts
+++ b/test/chatReadbackMcp.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { handleChatReadbackMcp } from "../src/worker/chatReadbackMcp";
+
+function statusPayload() {
+  return {
+    action: {
+      status: "ACTION_REQUIRED",
+      title: "Review current scope",
+      instruction: "Read the independent scope review.",
+      reason: "Human decision required.",
+      sourceRefs: ["github:pr:138"],
+    },
+    developmentStatus: {
+      repository: "yasutakesougo/severe-behavior-support-spfx",
+      evidenceState: "CONFIRMED",
+    },
+    observedAt: "2026-09-02T03:00:00.000Z",
+    decisionFingerprint: "server-only-fingerprint",
+    evidence: [{ privateFutureField: "must-not-leak" }],
+  };
+}
+
+function request(body: unknown, headers: Record<string, string> = {}) {
+  return new Request("https://control.example/mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+async function body(response: Response) {
+  return response.json() as Promise<Record<string, any>>;
+}
+
+describe("CHAT-READBACK-V1 MCP contract", () => {
+  it("negotiates current stable MCP and advertises tools capability", async () => {
+    const response = await handleChatReadbackMcp(
+      request({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+      }),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await body(response)).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion: "2025-11-25",
+        capabilities: { tools: {} },
+        serverInfo: { name: "ai-development-control-center-chat-readback" },
+      },
+    });
+  });
+
+  it("lists exactly one zero-input read-only tool with exact safety annotations", async () => {
+    const response = await handleChatReadbackMcp(
+      request({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+    const json = await body(response);
+
+    expect(json.result.tools).toHaveLength(1);
+    expect(json.result.tools[0]).toMatchObject({
+      name: "read_human_gate",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    });
+  });
+
+  it("returns allowlisted structured content without raw evidence or fingerprint", async () => {
+    const response = await handleChatReadbackMcp(
+      request({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "read_human_gate", arguments: {} },
+      }),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+    const json = await body(response);
+
+    expect(json.result.structuredContent).toMatchObject({
+      ok: true,
+      repository: "yasutakesougo/severe-behavior-support-spfx",
+      evidenceState: "CONFIRMED",
+      decisionCandidate: "PRESENT",
+      sourceEndpoint: "/api/status",
+      boundary: "READ_ONLY_NO_EXECUTION_AUTHORITY",
+    });
+    expect(JSON.stringify(json)).not.toContain("privateFutureField");
+    expect(JSON.stringify(json)).not.toContain("server-only-fingerprint");
+  });
+
+  it("maps source exceptions to SOURCE_UNAVAILABLE and UNKNOWN", async () => {
+    const response = await handleChatReadbackMcp(
+      request({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "read_human_gate", arguments: {} },
+      }),
+      {
+        loadStatusPayload: async () => {
+          throw new Error("source unavailable");
+        },
+      },
+    );
+    const json = await body(response);
+
+    expect(json.result.isError).toBe(true);
+    expect(json.result.structuredContent).toEqual({
+      ok: false,
+      state: "SOURCE_UNAVAILABLE",
+      decisionCandidate: "UNKNOWN",
+      sourceEndpoint: "/api/status",
+      boundary: "READ_ONLY_NO_EXECUTION_AUTHORITY",
+    });
+  });
+
+  it("rejects arguments so the tool cannot become a repository selector", async () => {
+    const response = await handleChatReadbackMcp(
+      request({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "read_human_gate", arguments: { repository: "other/repo" } },
+      }),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+
+    expect(await body(response)).toMatchObject({
+      error: { code: -32602 },
+    });
+  });
+
+  it("rejects unsupported MCP protocol headers", async () => {
+    const response = await handleChatReadbackMcp(
+      request(
+        { jsonrpc: "2.0", id: 6, method: "ping" },
+        { "MCP-Protocol-Version": "2099-01-01" },
+      ),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("accepts initialized notifications without creating state", async () => {
+    const response = await handleChatReadbackMcp(
+      request({ jsonrpc: "2.0", method: "notifications/initialized" }),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+
+    expect(response.status).toBe(202);
+    expect(await response.text()).toBe("");
+  });
+
+  it("rejects non-POST requests with no mutation fallback", async () => {
+    const response = await handleChatReadbackMcp(
+      new Request("https://control.example/mcp", { method: "GET" }),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("POST");
+  });
+});

--- a/test/chatReadbackMcp.test.ts
+++ b/test/chatReadbackMcp.test.ts
@@ -158,6 +158,18 @@ describe("CHAT-READBACK-V1 MCP contract", () => {
     expect(response.status).toBe(400);
   });
 
+  it("fails closed for a cross-origin browser request", async () => {
+    const response = await handleChatReadbackMcp(
+      request(
+        { jsonrpc: "2.0", id: 7, method: "ping" },
+        { Origin: "https://unexpected.example" },
+      ),
+      { loadStatusPayload: async () => statusPayload() },
+    );
+
+    expect(response.status).toBe(403);
+  });
+
   it("accepts initialized notifications without creating state", async () => {
     const response = await handleChatReadbackMcp(
       request({ jsonrpc: "2.0", method: "notifications/initialized" }),


### PR DESCRIPTION
## CHAT-READBACK-V1

Implements the authorized single-repository, read-only ChatGPT/MCP transport from #138.

### Surface
- deterministic CHAT-READBACK-V1 payload validator/projector
- one zero-input `read_human_gate` MCP tool
- `/mcp` routing on the existing Control Center Worker
- exact allowlisted output only
- no raw `evidence[]` / no decision fingerprint value exposure
- no repository selector / aggregation
- no mutation tools

### Safety annotations

```text
readOnlyHint = true
destructiveHint = false
idempotentHint = true
openWorldHint = false
```

`openWorldHint=false` follows the current OpenAI Plugins guidance: the tool does not affect public or external systems; it only performs a read-only observation.

### Verification status
- isolated TypeScript compile: PASS
- isolated CHAT-READBACK smoke: PASS
- MCP initialize/tools-list/tools-call contract smoke: PASS
- repository-wide `npm run verify`: pending / no pull_request workflow exists

### Authority

```text
Human Implementation Start GO = CONSUMED
Preview Deploy = NOT YET EXECUTED
Production Deploy = NOT AUTHORIZED
Merge = NOT AUTHORIZED
```

Closes no issue automatically; #138 remains gated through preview/E2E acceptance.