### PR TITLE
feat: add ANALOG-CONTROL-SURFACE-V2 Human Gate panel

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -103,8 +103,9 @@ export function App({
       const response = await fetch("/api/status", { cache: "no-store" });
       if (!response.ok) throw new Error("status request failed");
       const payload = (await response.json()) as unknown;
+      if (!isHumanGateStatusSource(payload)) throw new Error("invalid status response");
       setData(payload as StatusResponse);
-      setHumanGateSourceAvailability(isHumanGateStatusSource(payload) ? "AVAILABLE" : "UNAVAILABLE");
+      setHumanGateSourceAvailability("AVAILABLE");
     } catch {
       setData({
         action: fallback,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -18,6 +18,11 @@ import {
 import type { StatusOverlayDocument } from "../domain/statusOverlayContract";
 import type { StatusOverlayRuntimePhase } from "../runtime/statusOverlayRuntime";
 import { ApprovalIntentPanel } from "./ApprovalIntentPanel";
+import { HumanGatePanel } from "./HumanGatePanel";
+import {
+  isHumanGateStatusSource,
+  type HumanGateSourceAvailability,
+} from "./humanGateViewModel";
 import { fetchLedgerHistory, postLedgerRecord, type LedgerHistoryResult } from "./ledgerApi";
 import { LedgerHistoryPanel } from "./LedgerHistoryPanel";
 import { LedgerRecordControls } from "./LedgerRecordControls";
@@ -79,6 +84,8 @@ export function App({
   statusOverlayUnavailableReason = null,
 }: AppProps = {}) {
   const [data, setData] = useState<StatusResponse | null>(null);
+  const [humanGateSourceAvailability, setHumanGateSourceAvailability] =
+    useState<HumanGateSourceAvailability>("LOADING");
   const [repositoryOverview, setRepositoryOverview] = useState<RepositoryOverviewData | null>(null);
   const [selectedRepository, setSelectedRepository] = useState<string | null>(null);
   const [repositoryDetail, setRepositoryDetail] = useState<RepositoryOverviewDetailData | null>(null);
@@ -91,10 +98,13 @@ export function App({
   const [history, setHistory] = useState<LedgerHistoryResult | null>(null);
 
   const loadStatus = useCallback(async () => {
+    setHumanGateSourceAvailability("LOADING");
     try {
       const response = await fetch("/api/status", { cache: "no-store" });
       if (!response.ok) throw new Error("status request failed");
-      setData((await response.json()) as StatusResponse);
+      const payload = (await response.json()) as unknown;
+      setData(payload as StatusResponse);
+      setHumanGateSourceAvailability(isHumanGateStatusSource(payload) ? "AVAILABLE" : "UNAVAILABLE");
     } catch {
       setData({
         action: fallback,
@@ -107,6 +117,7 @@ export function App({
         evidence: null,
         observedAt: new Date().toISOString(),
       });
+      setHumanGateSourceAvailability("UNAVAILABLE");
     }
   }, []);
 
@@ -197,6 +208,11 @@ export function App({
         <p className="instruction">{loading ? "GitHubの状態を確認しています。" : action.instruction}</p>
         {!loading && <p className="reason">{action.reason}</p>}
       </section>
+
+      <HumanGatePanel
+        availability={humanGateSourceAvailability}
+        source={humanGateSourceAvailability === "AVAILABLE" && data ? data : null}
+      />
 
       <RepositoryOverviewPanel
         loading={overviewLoading}

--- a/src/ui/HumanGatePanel.tsx
+++ b/src/ui/HumanGatePanel.tsx
@@ -1,0 +1,55 @@
+import {
+  buildHumanGateViewModel,
+  type HumanGateSourceAvailability,
+  type HumanGateStatusSource,
+} from "./humanGateViewModel";
+
+export interface HumanGatePanelProps {
+  availability: HumanGateSourceAvailability;
+  source: HumanGateStatusSource | null;
+}
+
+export function HumanGatePanel({ availability, source }: HumanGatePanelProps) {
+  const view = buildHumanGateViewModel(availability, source);
+
+  return (
+    <section className="human-gate-crt" data-testid="human-gate-crt">
+      <div className="human-gate-crt-header">
+        <div>
+          <p className="human-gate-crt-kicker">[ HUMAN GATE ]</p>
+          <h2>{view.title}</h2>
+        </div>
+        <p className="human-gate-crt-boundary">DISPLAY ONLY / NO EXECUTION AUTHORITY</p>
+      </div>
+
+      <dl className="human-gate-crt-axes">
+        <div><dt>ACTION</dt><dd>{view.status}</dd></div>
+        <div><dt>EVIDENCE</dt><dd>{view.evidenceState}</dd></div>
+        <div><dt>DECISION</dt><dd>{view.decisionCandidate}</dd></div>
+        <div><dt>SOURCE</dt><dd>{view.sourceAvailability}</dd></div>
+        <div><dt>OBSERVED</dt><dd>{view.observedAt ?? "—"}</dd></div>
+      </dl>
+
+      <div className="human-gate-crt-block">
+        <h3>NEXT HUMAN ACTION</h3>
+        <p>{view.instruction}</p>
+      </div>
+
+      <div className="human-gate-crt-block">
+        <h3>REASON</h3>
+        <p>{view.reason}</p>
+      </div>
+
+      <div className="human-gate-crt-block">
+        <h3>SOURCE REFS</h3>
+        {view.sourceRefs.length > 0 ? (
+          <ul>
+            {view.sourceRefs.map((ref) => <li key={ref}>{ref}</li>)}
+          </ul>
+        ) : (
+          <p>—</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/ui/HumanGatePanel.tsx
+++ b/src/ui/HumanGatePanel.tsx
@@ -3,6 +3,7 @@ import {
   type HumanGateSourceAvailability,
   type HumanGateStatusSource,
 } from "./humanGateViewModel";
+import "./humanGateCrt.css";
 
 export interface HumanGatePanelProps {
   availability: HumanGateSourceAvailability;

--- a/src/ui/humanGateCrt.css
+++ b/src/ui/humanGateCrt.css
@@ -1,0 +1,114 @@
+.human-gate-crt {
+  margin-top: 16px;
+  padding: 20px;
+  background: #101510;
+  border: 1px solid #566456;
+  border-radius: 18px;
+  color: #dce8dc;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  box-shadow: inset 0 0 0 1px rgba(220, 232, 220, 0.04);
+}
+
+.human-gate-crt-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.human-gate-crt h2,
+.human-gate-crt h3,
+.human-gate-crt p {
+  color: inherit;
+}
+
+.human-gate-crt h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.human-gate-crt-kicker {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.human-gate-crt-boundary {
+  margin: 0;
+  max-width: 250px;
+  text-align: right;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  opacity: 0.82;
+}
+
+.human-gate-crt-axes {
+  margin-top: 16px;
+  border-top: 1px solid #455245;
+  border-bottom: 1px solid #455245;
+}
+
+.human-gate-crt-axes div {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 12px;
+  padding: 9px 0;
+  border-top: 1px solid #2c362c;
+}
+
+.human-gate-crt-axes div:first-child {
+  border-top: 0;
+}
+
+.human-gate-crt-axes dt {
+  color: #a9b8a9;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+}
+
+.human-gate-crt-axes dd {
+  margin: 0;
+  color: #edf6ed;
+  font-weight: 750;
+  overflow-wrap: anywhere;
+}
+
+.human-gate-crt-block {
+  margin-top: 16px;
+}
+
+.human-gate-crt-block h3 {
+  margin: 0 0 6px;
+  color: #a9b8a9;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+}
+
+.human-gate-crt-block p,
+.human-gate-crt-block ul {
+  margin: 0;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.human-gate-crt-block ul {
+  padding-left: 20px;
+}
+
+@media (max-width: 520px) {
+  .human-gate-crt-header {
+    display: block;
+  }
+
+  .human-gate-crt-boundary {
+    margin-top: 10px;
+    max-width: none;
+    text-align: left;
+  }
+
+  .human-gate-crt-axes div {
+    grid-template-columns: 88px minmax(0, 1fr);
+  }
+}

--- a/src/ui/humanGateViewModel.ts
+++ b/src/ui/humanGateViewModel.ts
@@ -1,0 +1,81 @@
+import type { HumanAction } from "../domain/humanAction";
+
+export type HumanGateSourceAvailability = "LOADING" | "AVAILABLE" | "UNAVAILABLE";
+export type DecisionCandidatePresence = "PRESENT" | "NOT PRESENT" | "UNKNOWN";
+
+export interface HumanGateStatusSource {
+  action: HumanAction;
+  developmentStatus: {
+    evidenceState: string;
+  };
+  observedAt: string;
+  decisionFingerprint?: string;
+}
+
+export interface HumanGateViewModel {
+  sourceAvailability: HumanGateSourceAvailability;
+  status: HumanAction["status"];
+  title: string;
+  instruction: string;
+  reason: string;
+  sourceRefs: string[];
+  evidenceState: string;
+  decisionCandidate: DecisionCandidatePresence;
+  observedAt: string | null;
+}
+
+const unavailableAction: HumanAction = {
+  status: "UNKNOWN",
+  title: "判定できません",
+  instruction: "安全のため判断を保留しています。",
+  reason: "SOURCE UNAVAILABLE",
+  sourceRefs: [],
+};
+
+export function isHumanGateStatusSource(value: unknown): value is HumanGateStatusSource {
+  if (!value || typeof value !== "object") return false;
+  const source = value as Partial<HumanGateStatusSource>;
+  const action = source.action;
+  const developmentStatus = source.developmentStatus;
+
+  return Boolean(
+    action &&
+      typeof action.status === "string" &&
+      ["ACTION_REQUIRED", "WAIT", "NO_ACTION", "UNKNOWN"].includes(action.status) &&
+      typeof action.title === "string" &&
+      typeof action.instruction === "string" &&
+      typeof action.reason === "string" &&
+      Array.isArray(action.sourceRefs) &&
+      action.sourceRefs.every((ref) => typeof ref === "string") &&
+      developmentStatus &&
+      typeof developmentStatus.evidenceState === "string" &&
+      typeof source.observedAt === "string",
+  );
+}
+
+export function buildHumanGateViewModel(
+  availability: HumanGateSourceAvailability,
+  source: HumanGateStatusSource | null,
+): HumanGateViewModel {
+  if (availability !== "AVAILABLE" || !source) {
+    return {
+      sourceAvailability: availability,
+      ...unavailableAction,
+      evidenceState: availability === "LOADING" ? "確認中" : "SOURCE UNAVAILABLE",
+      decisionCandidate: "UNKNOWN",
+      observedAt: null,
+    };
+  }
+
+  return {
+    sourceAvailability: "AVAILABLE",
+    status: source.action.status,
+    title: source.action.title,
+    instruction: source.action.instruction,
+    reason: source.action.reason,
+    sourceRefs: source.action.sourceRefs,
+    evidenceState: source.developmentStatus.evidenceState,
+    decisionCandidate: source.decisionFingerprint ? "PRESENT" : "NOT PRESENT",
+    observedAt: source.observedAt,
+  };
+}

--- a/test/humanGateViewModel.test.ts
+++ b/test/humanGateViewModel.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHumanGateViewModel,
+  isHumanGateStatusSource,
+  type HumanGateStatusSource,
+} from "../src/ui/humanGateViewModel";
+
+const source: HumanGateStatusSource = {
+  action: {
+    status: "ACTION_REQUIRED",
+    title: "Review PR #140",
+    instruction: "Review the current Human Gate.",
+    reason: "Evidence is confirmed.",
+    sourceRefs: ["github:issue/140"],
+  },
+  developmentStatus: { evidenceState: "CONFIRMED" },
+  observedAt: "2026-09-02T11:00:00Z",
+  decisionFingerprint: "fingerprint",
+};
+
+describe("humanGateViewModel", () => {
+  it("projects authoritative fields from an available status payload", () => {
+    const view = buildHumanGateViewModel("AVAILABLE", source);
+    expect(view.status).toBe("ACTION_REQUIRED");
+    expect(view.instruction).toBe(source.action.instruction);
+    expect(view.evidenceState).toBe("CONFIRMED");
+    expect(view.decisionCandidate).toBe("PRESENT");
+    expect(view.observedAt).toBe(source.observedAt);
+  });
+
+  it("uses NOT PRESENT only for a valid available payload without a fingerprint", () => {
+    const view = buildHumanGateViewModel("AVAILABLE", {
+      ...source,
+      decisionFingerprint: undefined,
+    });
+    expect(view.decisionCandidate).toBe("NOT PRESENT");
+  });
+
+  it("fails closed when the source is unavailable", () => {
+    const view = buildHumanGateViewModel("UNAVAILABLE", null);
+    expect(view.status).toBe("UNKNOWN");
+    expect(view.evidenceState).toBe("SOURCE UNAVAILABLE");
+    expect(view.decisionCandidate).toBe("UNKNOWN");
+    expect(view.observedAt).toBeNull();
+  });
+
+  it("does not invent an observedAt while loading", () => {
+    const view = buildHumanGateViewModel("LOADING", null);
+    expect(view.decisionCandidate).toBe("UNKNOWN");
+    expect(view.observedAt).toBeNull();
+  });
+
+  it("rejects an invalid status-shaped payload for the Human Gate projection", () => {
+    expect(isHumanGateStatusSource({ observedAt: "2026-09-02" })).toBe(false);
+    expect(isHumanGateStatusSource(source)).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements #137 within the locked ANALOG-CONTROL-SURFACE-V2 presentation scope.

## Scope
- add one read-only Human Gate CRT projection from the existing `/api/status` response
- preserve exact HumanAction status/title/instruction/reason/sourceRefs
- show Evidence, Decision Candidate, Source Availability, and source `observedAt` as independent axes
- add presentation-local `LOADING | AVAILABLE | UNAVAILABLE`
- valid payload only: `PRESENT | NOT PRESENT`
- source unavailable: `Decision Candidate = UNKNOWN`, no client-generated observedAt displayed in the Human Gate panel
- static `DISPLAY ONLY / NO EXECUTION AUTHORITY` boundary
- focused pure view-model tests and mobile-readable CRT styling

## Explicitly unchanged
- `/api/status` contract
- HumanAction resolver
- ApprovalIntent behavior
- Ledger behavior
- Authority / Execution Policy semantics
- repository aggregation/selector
- Production

Human Implementation Start GO for #137 is already consumed. This PR remains DRAFT. Human Ready / Merge / Deploy are separate gates and are NOT authorized by this implementation.