### PR TITLE
feat: add HARNESS-MINIMALITY-V1 shadow evaluator

### DIFF
--- a/src/domain/harnessMinimality.ts
+++ b/src/domain/harnessMinimality.ts
@@ -1,0 +1,266 @@
+export type HarnessRiskClass = "LOW" | "MEDIUM" | "HIGH" | "UNKNOWN";
+export type HarnessEvidenceState = "SUFFICIENT" | "INSUFFICIENT" | "CONTRADICTORY";
+export type HarnessRecommendation = "KEEP_FULL" | "MINIMALITY_CANDIDATE";
+
+export type HarnessReasonCode =
+  | "HIGH_RISK"
+  | "INSUFFICIENT_EVIDENCE"
+  | "CONTRADICTORY_EVIDENCE"
+  | "RECORDED_RISK_MISMATCH"
+  | "GATE_NOT_EXECUTED"
+  | "OUTCOME_NOT_RECONSTRUCTABLE"
+  | "OUTCOME_NOT_ATTRIBUTABLE"
+  | "NO_VALID_COMPARISON_BASIS"
+  | "GATE_PRODUCED_INFORMATION"
+  | "SUFFICIENT_COMPARABLE_EVIDENCE";
+
+export type HarnessChangeCharacteristic =
+  | "PRESENTATION_FORMATTING_ONLY"
+  | "PRESENTATION_WORKFLOW_MEANING"
+  | "CONTRACT_OR_STATE_TRANSITION"
+  | "PERSISTENCE_OR_SCHEMA"
+  | "PERMISSION_OR_CREDENTIAL_OR_SECURITY"
+  | "LIVE_DATA_MUTATION"
+  | "AMBIGUOUS_OR_MIXED";
+
+export interface RawHarnessObservation {
+  workUnitRef: string;
+  changeCharacteristics: HarnessChangeCharacteristic[];
+  gatesActuallyExecuted: string[];
+  materialFindings: string[];
+  corrections: string[];
+  regressions: string[];
+  noNewInformationGates: string[];
+  evidenceRefs: string[];
+  evidenceState: HarnessEvidenceState;
+  /** Historical/source label only. Never authoritative classifier input. */
+  recordedRiskLabel?: HarnessRiskClass;
+}
+
+export interface ComparableGateEvidence {
+  observation: RawHarnessObservation;
+  gate: string;
+  outcomeReconstructable: boolean;
+  attributionExplicit: boolean;
+  validComparisonBasis: boolean;
+}
+
+export interface HarnessEvidenceSufficiency {
+  state: HarnessEvidenceState;
+  reasonCodes: HarnessReasonCode[];
+}
+
+export interface HarnessShadowDecision {
+  riskClass: HarnessRiskClass;
+  recommendation: HarnessRecommendation;
+  reasonCodes: HarnessReasonCode[];
+  advisoryOnly: true;
+}
+
+export interface HarnessEvidencePacket extends HarnessShadowDecision {
+  workUnitRef: string;
+  evidenceState: HarnessEvidenceState;
+  gatesActuallyExecuted: string[];
+  materialFindings: string[];
+  corrections: string[];
+  regressions: string[];
+  noNewInformationGates: string[];
+  evidenceRefs: string[];
+  recordedRiskLabel?: HarnessRiskClass;
+  actualGatePolicy: "UNCHANGED";
+}
+
+const HIGH_CHARACTERISTICS = new Set<HarnessChangeCharacteristic>([
+  "PERSISTENCE_OR_SCHEMA",
+  "PERMISSION_OR_CREDENTIAL_OR_SECURITY",
+  "LIVE_DATA_MUTATION",
+]);
+
+const MEDIUM_CHARACTERISTICS = new Set<HarnessChangeCharacteristic>([
+  "PRESENTATION_WORKFLOW_MEANING",
+  "CONTRACT_OR_STATE_TRANSITION",
+]);
+
+/**
+ * Pure fail-closed classifier. riskClass is derived here and nowhere else.
+ */
+export function classifyHarnessRisk(observation: RawHarnessObservation): HarnessRiskClass {
+  if (
+    observation.evidenceState !== "SUFFICIENT" ||
+    observation.evidenceRefs.length === 0 ||
+    observation.changeCharacteristics.length === 0 ||
+    observation.changeCharacteristics.includes("AMBIGUOUS_OR_MIXED")
+  ) {
+    return "UNKNOWN";
+  }
+
+  let derived: HarnessRiskClass;
+  if (observation.changeCharacteristics.some((item) => HIGH_CHARACTERISTICS.has(item))) {
+    derived = "HIGH";
+  } else if (observation.changeCharacteristics.some((item) => MEDIUM_CHARACTERISTICS.has(item))) {
+    derived = "MEDIUM";
+  } else if (observation.changeCharacteristics.every((item) => item === "PRESENTATION_FORMATTING_ONLY")) {
+    derived = "LOW";
+  } else {
+    derived = "UNKNOWN";
+  }
+
+  if (observation.recordedRiskLabel && observation.recordedRiskLabel !== derived) {
+    return "UNKNOWN";
+  }
+
+  return derived;
+}
+
+/**
+ * Historical evidence may support a candidate only when the evaluated gate was
+ * actually executed and its recorded outcome is reconstructable and attributable.
+ * Unexecuted gates are never treated as no-new-information.
+ */
+export function evaluateComparableGateEvidence(
+  comparable: ComparableGateEvidence[],
+  gate: string,
+): HarnessEvidenceSufficiency {
+  if (comparable.length === 0) {
+    return { state: "INSUFFICIENT", reasonCodes: ["INSUFFICIENT_EVIDENCE"] };
+  }
+
+  const reasons = new Set<HarnessReasonCode>();
+
+  for (const item of comparable) {
+    if (item.gate !== gate || !item.observation.gatesActuallyExecuted.includes(gate)) {
+      reasons.add("GATE_NOT_EXECUTED");
+      continue;
+    }
+
+    if (item.observation.evidenceState === "CONTRADICTORY") {
+      reasons.add("CONTRADICTORY_EVIDENCE");
+      continue;
+    }
+
+    const risk = classifyHarnessRisk(item.observation);
+    if (risk === "HIGH" || risk === "UNKNOWN") {
+      reasons.add("INSUFFICIENT_EVIDENCE");
+    }
+
+    if (!item.outcomeReconstructable) reasons.add("OUTCOME_NOT_RECONSTRUCTABLE");
+    if (!item.attributionExplicit) reasons.add("OUTCOME_NOT_ATTRIBUTABLE");
+    if (!item.validComparisonBasis) reasons.add("NO_VALID_COMPARISON_BASIS");
+    if (item.observation.evidenceRefs.length === 0) reasons.add("INSUFFICIENT_EVIDENCE");
+
+    const gateProducedInformation =
+      !item.observation.noNewInformationGates.includes(gate) ||
+      item.observation.materialFindings.length > 0 ||
+      item.observation.corrections.length > 0 ||
+      item.observation.regressions.length > 0;
+
+    if (gateProducedInformation) reasons.add("GATE_PRODUCED_INFORMATION");
+  }
+
+  if (reasons.has("CONTRADICTORY_EVIDENCE")) {
+    return { state: "CONTRADICTORY", reasonCodes: [...reasons] };
+  }
+
+  if (reasons.size > 0) {
+    return { state: "INSUFFICIENT", reasonCodes: [...reasons] };
+  }
+
+  return { state: "SUFFICIENT", reasonCodes: ["SUFFICIENT_COMPARABLE_EVIDENCE"] };
+}
+
+/**
+ * Advisory-only resolver. It never changes real gate execution or eligibility.
+ */
+export function resolveHarnessShadowDecision(
+  observation: RawHarnessObservation,
+  comparableEvidence: HarnessEvidenceSufficiency,
+): HarnessShadowDecision {
+  const riskClass = classifyHarnessRisk(observation);
+
+  if (observation.evidenceState === "CONTRADICTORY" || comparableEvidence.state === "CONTRADICTORY") {
+    return {
+      riskClass: riskClass === "UNKNOWN" ? "UNKNOWN" : riskClass,
+      recommendation: "KEEP_FULL",
+      reasonCodes: unique(["CONTRADICTORY_EVIDENCE", ...comparableEvidence.reasonCodes]),
+      advisoryOnly: true,
+    };
+  }
+
+  if (riskClass === "HIGH") {
+    return {
+      riskClass,
+      recommendation: "KEEP_FULL",
+      reasonCodes: ["HIGH_RISK"],
+      advisoryOnly: true,
+    };
+  }
+
+  if (riskClass === "UNKNOWN") {
+    const recordedMismatch = Boolean(
+      observation.recordedRiskLabel &&
+        deriveRiskIgnoringRecordedLabel(observation) !== observation.recordedRiskLabel,
+    );
+    return {
+      riskClass,
+      recommendation: "KEEP_FULL",
+      reasonCodes: unique([
+        recordedMismatch ? "RECORDED_RISK_MISMATCH" : "INSUFFICIENT_EVIDENCE",
+        ...comparableEvidence.reasonCodes,
+      ]),
+      advisoryOnly: true,
+    };
+  }
+
+  if (comparableEvidence.state !== "SUFFICIENT") {
+    return {
+      riskClass,
+      recommendation: "KEEP_FULL",
+      reasonCodes: unique(["INSUFFICIENT_EVIDENCE", ...comparableEvidence.reasonCodes]),
+      advisoryOnly: true,
+    };
+  }
+
+  return {
+    riskClass,
+    recommendation: "MINIMALITY_CANDIDATE",
+    reasonCodes: ["SUFFICIENT_COMPARABLE_EVIDENCE"],
+    advisoryOnly: true,
+  };
+}
+
+export function buildHarnessEvidencePacket(
+  observation: RawHarnessObservation,
+  comparableEvidence: HarnessEvidenceSufficiency,
+): HarnessEvidencePacket {
+  const decision = resolveHarnessShadowDecision(observation, comparableEvidence);
+  return {
+    workUnitRef: observation.workUnitRef,
+    ...decision,
+    evidenceState: observation.evidenceState,
+    gatesActuallyExecuted: [...observation.gatesActuallyExecuted],
+    materialFindings: [...observation.materialFindings],
+    corrections: [...observation.corrections],
+    regressions: [...observation.regressions],
+    noNewInformationGates: [...observation.noNewInformationGates],
+    evidenceRefs: [...observation.evidenceRefs],
+    ...(observation.recordedRiskLabel ? { recordedRiskLabel: observation.recordedRiskLabel } : {}),
+    actualGatePolicy: "UNCHANGED",
+  };
+}
+
+export function replayHarnessObservation(
+  observation: RawHarnessObservation,
+  comparable: ComparableGateEvidence[],
+  gate: string,
+): HarnessEvidencePacket {
+  return buildHarnessEvidencePacket(observation, evaluateComparableGateEvidence(comparable, gate));
+}
+
+function deriveRiskIgnoringRecordedLabel(observation: RawHarnessObservation): HarnessRiskClass {
+  const { recordedRiskLabel: _recordedRiskLabel, ...withoutRecorded } = observation;
+  return classifyHarnessRisk(withoutRecorded);
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}

--- a/test/harnessMinimality.historicalReplay.test.ts
+++ b/test/harnessMinimality.historicalReplay.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateComparableGateEvidence,
+  replayHarnessObservation,
+  resolveHarnessShadowDecision,
+  type ComparableGateEvidence,
+  type RawHarnessObservation,
+} from "../src/domain/harnessMinimality";
+
+const independentImplementationReview = "Independent Implementation Review";
+
+/**
+ * Historical fixtures below are evidence-bound summaries of recorded ADCC work.
+ * They are intentionally read-only and do not assert that a gate is unnecessary.
+ */
+describe("HARNESS-MINIMALITY-V1 historical replay / shadow evidence", () => {
+  it("#137 / PR #142: a MEDIUM presentation-meaning change keeps full process when review found P1", () => {
+    const observation: RawHarnessObservation = {
+      workUnitRef: "github:issue:137/pr:142",
+      changeCharacteristics: ["PRESENTATION_WORKFLOW_MEANING"],
+      gatesActuallyExecuted: [independentImplementationReview],
+      materialFindings: [
+        "P1: schema-invalid /api/status payload could poison App data before fail-closed rendering",
+      ],
+      corrections: ["Implementation Correction-1 at 3b206e842a6829fb544815c1ffb3c0f4293f4db2"],
+      regressions: [],
+      noNewInformationGates: [],
+      evidenceRefs: [
+        "github:issue:137",
+        "github:pr:142#pullrequestreview-5089396556",
+        "github:pr:142@3b206e842a6829fb544815c1ffb3c0f4293f4db2",
+      ],
+      evidenceState: "SUFFICIENT",
+    };
+
+    const comparable: ComparableGateEvidence = {
+      observation,
+      gate: independentImplementationReview,
+      outcomeReconstructable: true,
+      attributionExplicit: true,
+      validComparisonBasis: true,
+    };
+
+    const packet = replayHarnessObservation(
+      observation,
+      [comparable],
+      independentImplementationReview,
+    );
+
+    expect(packet.riskClass).toBe("MEDIUM");
+    expect(packet.recommendation).toBe("KEEP_FULL");
+    expect(packet.reasonCodes).toContain("GATE_PRODUCED_INFORMATION");
+    expect(packet.actualGatePolicy).toBe("UNCHANGED");
+  });
+
+  it("#140: credential/security work is HIGH and remains KEEP_FULL regardless of candidate evidence", () => {
+    const observation: RawHarnessObservation = {
+      workUnitRef: "github:issue:140",
+      changeCharacteristics: ["PERMISSION_OR_CREDENTIAL_OR_SECURITY"],
+      gatesActuallyExecuted: ["Definition Review", "Scope Review"],
+      materialFindings: [
+        "credential type, exact permissions, expiry/revocation and exact staging worker identity required correction",
+      ],
+      corrections: ["Definition Correction-1", "Scope Correction-1"],
+      regressions: [],
+      noNewInformationGates: [],
+      evidenceRefs: ["github:issue:140"],
+      evidenceState: "SUFFICIENT",
+    };
+
+    const decision = resolveHarnessShadowDecision(observation, {
+      state: "SUFFICIENT",
+      reasonCodes: ["SUFFICIENT_COMPARABLE_EVIDENCE"],
+    });
+
+    expect(decision.riskClass).toBe("HIGH");
+    expect(decision.recommendation).toBe("KEEP_FULL");
+    expect(decision.reasonCodes).toEqual(["HIGH_RISK"]);
+    expect(decision.advisoryOnly).toBe(true);
+  });
+
+  it("#141: mixed docs + runtime-script change is UNKNOWN without narrower provenance and stays KEEP_FULL", () => {
+    const observation: RawHarnessObservation = {
+      workUnitRef: "github:pr:141",
+      changeCharacteristics: ["AMBIGUOUS_OR_MIXED"],
+      gatesActuallyExecuted: [],
+      materialFindings: [],
+      corrections: [],
+      regressions: [],
+      noNewInformationGates: [],
+      evidenceRefs: [
+        "github:pr:141",
+        "github:commit:263a29e41a4fe886e689db2a4050df3e26334dcf",
+      ],
+      evidenceState: "SUFFICIENT",
+    };
+
+    const decision = resolveHarnessShadowDecision(
+      observation,
+      evaluateComparableGateEvidence([], independentImplementationReview),
+    );
+
+    expect(decision.riskClass).toBe("UNKNOWN");
+    expect(decision.recommendation).toBe("KEEP_FULL");
+    expect(decision.reasonCodes).toContain("INSUFFICIENT_EVIDENCE");
+    expect(decision.advisoryOnly).toBe(true);
+  });
+});

--- a/test/harnessMinimality.test.ts
+++ b/test/harnessMinimality.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHarnessEvidencePacket,
+  classifyHarnessRisk,
+  evaluateComparableGateEvidence,
+  replayHarnessObservation,
+  resolveHarnessShadowDecision,
+  type ComparableGateEvidence,
+  type RawHarnessObservation,
+} from "../src/domain/harnessMinimality";
+
+function observation(overrides: Partial<RawHarnessObservation> = {}): RawHarnessObservation {
+  return {
+    workUnitRef: "issue:example",
+    changeCharacteristics: ["PRESENTATION_FORMATTING_ONLY"],
+    gatesActuallyExecuted: ["Independent Implementation Review"],
+    materialFindings: [],
+    corrections: [],
+    regressions: [],
+    noNewInformationGates: ["Independent Implementation Review"],
+    evidenceRefs: ["github:issue:example"],
+    evidenceState: "SUFFICIENT",
+    ...overrides,
+  };
+}
+
+function comparable(
+  source = observation(),
+  overrides: Partial<Omit<ComparableGateEvidence, "observation">> = {},
+): ComparableGateEvidence {
+  return {
+    observation: source,
+    gate: "Independent Implementation Review",
+    outcomeReconstructable: true,
+    attributionExplicit: true,
+    validComparisonBasis: true,
+    ...overrides,
+  };
+}
+
+describe("HARNESS-MINIMALITY-V1 risk classifier", () => {
+  it("classifies pure formatting-only presentation as LOW", () => {
+    expect(classifyHarnessRisk(observation())).toBe("LOW");
+  });
+
+  it("classifies workflow/gate meaning presentation as MEDIUM", () => {
+    expect(
+      classifyHarnessRisk(
+        observation({ changeCharacteristics: ["PRESENTATION_WORKFLOW_MEANING"] }),
+      ),
+    ).toBe("MEDIUM");
+  });
+
+  it("classifies contract/state-transition semantics as MEDIUM", () => {
+    expect(
+      classifyHarnessRisk(
+        observation({ changeCharacteristics: ["CONTRACT_OR_STATE_TRANSITION"] }),
+      ),
+    ).toBe("MEDIUM");
+  });
+
+  it("classifies credential/security/live-data boundaries as HIGH", () => {
+    expect(
+      classifyHarnessRisk(
+        observation({ changeCharacteristics: ["PERMISSION_OR_CREDENTIAL_OR_SECURITY"] }),
+      ),
+    ).toBe("HIGH");
+    expect(
+      classifyHarnessRisk(observation({ changeCharacteristics: ["LIVE_DATA_MUTATION"] })),
+    ).toBe("HIGH");
+  });
+
+  it("fails closed to UNKNOWN for ambiguous or insufficient classification evidence", () => {
+    expect(
+      classifyHarnessRisk(observation({ changeCharacteristics: ["AMBIGUOUS_OR_MIXED"] })),
+    ).toBe("UNKNOWN");
+    expect(classifyHarnessRisk(observation({ evidenceState: "INSUFFICIENT" }))).toBe("UNKNOWN");
+    expect(classifyHarnessRisk(observation({ evidenceRefs: [] }))).toBe("UNKNOWN");
+  });
+
+  it("does not let a recorded historical risk label override derived risk", () => {
+    expect(classifyHarnessRisk(observation({ recordedRiskLabel: "MEDIUM" }))).toBe("UNKNOWN");
+    expect(classifyHarnessRisk(observation({ recordedRiskLabel: "LOW" }))).toBe("LOW");
+  });
+});
+
+describe("HARNESS-MINIMALITY-V1 evidence sufficiency", () => {
+  it("requires the evaluated gate to have actually executed", () => {
+    const source = observation({ gatesActuallyExecuted: [], noNewInformationGates: [] });
+    const result = evaluateComparableGateEvidence([comparable(source)], "Independent Implementation Review");
+    expect(result.state).toBe("INSUFFICIENT");
+    expect(result.reasonCodes).toContain("GATE_NOT_EXECUTED");
+  });
+
+  it("requires reconstructable, attributable, valid comparison evidence", () => {
+    const result = evaluateComparableGateEvidence(
+      [
+        comparable(observation(), {
+          outcomeReconstructable: false,
+          attributionExplicit: false,
+          validComparisonBasis: false,
+        }),
+      ],
+      "Independent Implementation Review",
+    );
+    expect(result.state).toBe("INSUFFICIENT");
+    expect(result.reasonCodes).toContain("OUTCOME_NOT_RECONSTRUCTABLE");
+    expect(result.reasonCodes).toContain("OUTCOME_NOT_ATTRIBUTABLE");
+    expect(result.reasonCodes).toContain("NO_VALID_COMPARISON_BASIS");
+  });
+
+  it("does not treat a gate that produced findings/corrections as no-new-information", () => {
+    const source = observation({
+      materialFindings: ["P1 finding"],
+      corrections: ["Correction-1"],
+    });
+    const result = evaluateComparableGateEvidence([comparable(source)], "Independent Implementation Review");
+    expect(result.state).toBe("INSUFFICIENT");
+    expect(result.reasonCodes).toContain("GATE_PRODUCED_INFORMATION");
+  });
+
+  it("accepts positive comparable no-new-information evidence", () => {
+    const result = evaluateComparableGateEvidence([comparable()], "Independent Implementation Review");
+    expect(result).toEqual({
+      state: "SUFFICIENT",
+      reasonCodes: ["SUFFICIENT_COMPARABLE_EVIDENCE"],
+    });
+  });
+});
+
+describe("HARNESS-MINIMALITY-V1 shadow resolver", () => {
+  it("keeps the full process for HIGH and UNKNOWN risk", () => {
+    const sufficient = evaluateComparableGateEvidence([comparable()], "Independent Implementation Review");
+
+    expect(
+      resolveHarnessShadowDecision(
+        observation({ changeCharacteristics: ["PERMISSION_OR_CREDENTIAL_OR_SECURITY"] }),
+        sufficient,
+      ).recommendation,
+    ).toBe("KEEP_FULL");
+
+    const unknown = resolveHarnessShadowDecision(
+      observation({ evidenceState: "INSUFFICIENT" }),
+      sufficient,
+    );
+    expect(unknown.recommendation).toBe("KEEP_FULL");
+    expect(unknown.reasonCodes).toContain("INSUFFICIENT_EVIDENCE");
+  });
+
+  it("keeps the full process when comparable evidence is insufficient", () => {
+    const insufficient = evaluateComparableGateEvidence([], "Independent Implementation Review");
+    const decision = resolveHarnessShadowDecision(observation(), insufficient);
+    expect(decision.recommendation).toBe("KEEP_FULL");
+    expect(decision.reasonCodes).toContain("INSUFFICIENT_EVIDENCE");
+  });
+
+  it("emits MINIMALITY_CANDIDATE only with LOW/MEDIUM risk and sufficient comparable evidence", () => {
+    const sufficient = evaluateComparableGateEvidence([comparable()], "Independent Implementation Review");
+    const low = resolveHarnessShadowDecision(observation(), sufficient);
+    const medium = resolveHarnessShadowDecision(
+      observation({ changeCharacteristics: ["PRESENTATION_WORKFLOW_MEANING"] }),
+      sufficient,
+    );
+
+    expect(low.recommendation).toBe("MINIMALITY_CANDIDATE");
+    expect(medium.recommendation).toBe("MINIMALITY_CANDIDATE");
+    expect(low.advisoryOnly).toBe(true);
+  });
+
+  it("keeps contradictory evidence fail-closed", () => {
+    const contradictory = resolveHarnessShadowDecision(
+      observation({ evidenceState: "CONTRADICTORY" }),
+      { state: "CONTRADICTORY", reasonCodes: ["CONTRADICTORY_EVIDENCE"] },
+    );
+    expect(contradictory.recommendation).toBe("KEEP_FULL");
+    expect(contradictory.reasonCodes).toContain("CONTRADICTORY_EVIDENCE");
+  });
+});
+
+describe("HARNESS-MINIMALITY-V1 evidence packet / replay", () => {
+  it("uses only the derived riskClass and preserves recorded label as provenance", () => {
+    const source = observation({ recordedRiskLabel: "LOW" });
+    const sufficient = evaluateComparableGateEvidence([comparable(source)], "Independent Implementation Review");
+    const packet = buildHarnessEvidencePacket(source, sufficient);
+
+    expect(packet.riskClass).toBe("LOW");
+    expect(packet.recordedRiskLabel).toBe("LOW");
+    expect(packet.actualGatePolicy).toBe("UNCHANGED");
+    expect(packet.advisoryOnly).toBe(true);
+  });
+
+  it("replays deterministically without changing actual gate policy", () => {
+    const source = observation();
+    const first = replayHarnessObservation(source, [comparable(source)], "Independent Implementation Review");
+    const second = replayHarnessObservation(source, [comparable(source)], "Independent Implementation Review");
+    expect(second).toEqual(first);
+    expect(first.actualGatePolicy).toBe("UNCHANGED");
+  });
+});


### PR DESCRIPTION
Implements #132 within the locked HARNESS-MINIMALITY-V1 scope.

## Implementation
- pure RawHarnessObservation contract with provenance-only recordedRiskLabel
- derived-only LOW / MEDIUM / HIGH / UNKNOWN classifier
- fail-closed comparable gate evidence evaluator
- advisory-only KEEP_FULL / MINIMALITY_CANDIDATE resolver
- deterministic Harness Evidence Packet and historical replay helper
- focused tests for risk, contradiction, unexecuted-gate, no-new-information, provenance mismatch, and deterministic replay

## Boundaries
- Existing gate policy remains UNCHANGED
- Shadow output has no execution authority
- No automatic gate removal / skipping
- No Human GO synthesis
- No Ready / Merge / Deploy automation
- No credential, Production, SharePoint, M365, or Entra mutation

Human Implementation Start GO for #132 is consumed. This PR remains DRAFT. Ready / Merge / Deploy remain separate Human Gates.